### PR TITLE
Change scope of chartassignments CRD to Namespaced / Increase kubernetes min_master_version to 1.13

### DIFF
--- a/src/app_charts/base/cloud/apps-crd.yaml
+++ b/src/app_charts/base/cloud/apps-crd.yaml
@@ -155,7 +155,7 @@ spec:
     kind: ChartAssignment
     plural: chartassignments
     singular: chartassignment
-  scope: Cluster
+  scope: Namespaced
   additionalPrinterColumns:
   - JSONPath: .status.phase
     name: Phase

--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -1,7 +1,7 @@
 resource "google_container_cluster" "cloud-robotics" {
   name               = "cloud-robotics"
   location           = "${var.zone}"
-  min_master_version = "1.11"
+  min_master_version = "1.13"
   enable_legacy_abac = true
   depends_on         = ["google_project_service.container"]
 

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -521,6 +521,9 @@ func newRobotChartAssignment(
 func newBaseChartAssignment(app *apps.App, rollout *apps.AppRollout, comp *apps.AppComponent) *apps.ChartAssignment {
 	var ca apps.ChartAssignment
 
+	// Use default namespace
+	ca.ObjectMeta.Namespace = core.NamespaceDefault
+
 	// Clone labels and annotations. Just setting the map reference
 	// would cause the map to be shared across objects.
 	for k, v := range rollout.Labels {


### PR DESCRIPTION
cr-syncer was not able to sync chartassignments CRD to the robot cluster anymore.
This error occurred on each request:
**E0916 11:56:06.361712       1 reflector.go:126] external/io_k8s_client_go/tools/cache/reflector.go:94: Failed to list *unstructured.Unstructured: the server could not find the requested resource**

Potentially this is related to the fix in this [security bulletin](https://cloud.google.com/kubernetes-engine/docs/security-bulletins#august-05-2019).

Changing the scope of chartassignments CRD from Cluster to Namespaced seems to fix the issue.

Since Kubernetes v1.11 is outdated on GCP, min_master_version is pushed to 1.13