### PR TITLE
Use an uncommon port for metadata-server on the robot (8965)

### DIFF
--- a/src/app_charts/base/robot/metadata-server.yaml
+++ b/src/app_charts/base/robot/metadata-server.yaml
@@ -32,7 +32,7 @@ spec:
         image: {{ .Values.registry }}{{ .Values.images.metadata_server }}
         args:
         - --port
-        - "8080"
+        - "8965"
         - --robot_id_file
         - /credentials/robot-id.json
         - --source_cidr


### PR DESCRIPTION
Current port of metadata-server is 8080 which might be bound to other applications already. Using port 8965 would decrease this risk.
To deploy these changes on existing robot Kubernetes clusters either `setup_robot.sh` could be run again or the port in metadata-server daemonset could be changed manually from 8080 to 8965 using `kubectl edit daemonsets metadata-server` command on the robot cluster.