### PR TITLE
oauth2-proxy: set --cookie-expire flag to 1h

### DIFF
--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -23,6 +23,7 @@ spec:
         - --pass-access-token
         - --pass-host-header
         - "--scope=https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email"
+        - --cookie-expire=1h
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           value: {{ .Values.oauth2_proxy.client_id }}


### PR DESCRIPTION
Bearer tokens expire after 1h, but default cookie expiration of oauth2-proxy is 168h.
This leads to expired Bearer tokens in _oauth2_proxy cookie which makes token-vendor verifying every HTTP request at IAM API when the cookie is older than 1h.
New cookie expiration is in sync with Bearer token lifetime and avoids expired tokens.
