### PR TITLE
Avoid Reconcile loops in AppRollout and ChartAssignment controllers because of status updates in Reconciler

### DIFF
--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -147,6 +147,8 @@ func Add(mgr manager.Manager, baseValues chartutil.Values) error {
 				r.enqueueAll(q)
 			},
 			UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+				// Robots don't have the status subresource enabled. Filter updates that didn't
+				// change robot name or labels.
 				change := !reflect.DeepEqual(e.MetaOld.GetLabels(), e.MetaNew.GetLabels())
 				change = change || e.MetaOld.GetName() != e.MetaNew.GetName()
 				if change {

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -393,7 +393,9 @@ func setCondition(ar *apps.AppRollout, t apps.AppRolloutConditionType, s core.Co
 			continue
 		}
 		// Update existing condition.
-		c.LastUpdateTime = now
+		if c.Status != s || c.Message != msg {
+			c.LastUpdateTime = now
+		}
 		if c.Status != s {
 			c.LastTransitionTime = now
 		}

--- a/src/go/pkg/controller/chartassignment/BUILD.bazel
+++ b/src/go/pkg/controller/chartassignment/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/serializer:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/yaml:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",

--- a/src/go/pkg/controller/chartassignment/controller.go
+++ b/src/go/pkg/controller/chartassignment/controller.go
@@ -486,7 +486,9 @@ func setCondition(as *apps.ChartAssignment, t apps.ChartAssignmentConditionType,
 			continue
 		}
 		// Update existing condition.
-		c.LastUpdateTime = now
+		if c.Status != v || c.Message != msg {
+			c.LastUpdateTime = now
+		}
 		if c.Status != v {
 			c.LastTransitionTime = now
 		}

--- a/src/go/pkg/controller/chartassignment/controller.go
+++ b/src/go/pkg/controller/chartassignment/controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +85,36 @@ func Add(mgr manager.Manager, cluster string) error {
 	}
 	err = c.Watch(
 		&source.Kind{Type: &apps.ChartAssignment{}},
-		&handler.EnqueueRequestForObject{},
+		&handler.Funcs{
+			CreateFunc: func(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+				log.Printf("ChartAssignment controller received create event for ChartAssignment %q", e.Meta.GetName())
+				q.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: e.Meta.GetName()},
+				})
+			},
+			UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+				// Compare spec of old and new ChartAssignment to avoid Reconcile loop because of status updates of ChartAssignment
+				change := !reflect.DeepEqual(e.ObjectNew.(*apps.ChartAssignment).Spec, e.ObjectOld.(*apps.ChartAssignment).Spec)
+				change = change || e.MetaOld.GetName() != e.MetaNew.GetName()
+				if change {
+					log.Printf("ChartAssignment controller received update event for ChartAssignment %q", e.MetaNew.GetName())
+					q.Add(reconcile.Request{
+						NamespacedName: types.NamespacedName{Name: e.MetaNew.GetName()},
+					})
+					if e.MetaOld.GetName() != e.MetaNew.GetName() {
+						q.Add(reconcile.Request{
+							NamespacedName: types.NamespacedName{Name: e.MetaOld.GetName()},
+						})
+					}
+				}
+			},
+			DeleteFunc: func(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+				log.Printf("ChartAssignment controller received delete event for ChartAssignment %q", e.Meta.GetName())
+				q.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: e.Meta.GetName()},
+				})
+			},
+		},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Compare `spec` of AppRollout and ChartAssigment CRs in corresponding controllers to identify update events.
`Reconcile` methods update the `status` of their own CRs which could lead to a Reconcile loop if any CR change triggers an update event.