### PR TITLE
Use Kubernetes 1.16 minimum

### DIFF
--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -1,7 +1,7 @@
 resource "google_container_cluster" "cloud-robotics" {
   name               = "cloud-robotics"
   location           = "${var.zone}"
-  min_master_version = "1.14"
+  min_master_version = "1.16"
   enable_legacy_abac = true
   depends_on         = ["google_project_service.container"]
 


### PR DESCRIPTION
Beginning October 6, 2020 GKE starts to migrate Kubernetes control planes to v1.16 automatically.
It seems to be time for an upgrade.

Current cert-manager v0.8.1 is using the deprecated apps/v1beta1 API, which was removed. Thus, I bumped it to v0.10.1 which is the last version supporting certmanager.k8s.io/v1alpha1 API. For later versions we need to migrate to cert-manager.io/v1alpha2. Please see [here](https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/).

These are the changes of this pull request:
- Kubernetes minimum version raised to 1.16
- Migration from cert-manager v0.8.1 to v0.10.1
- Wait for apiservice `v1beta1.metrics.k8s.io` to become available because otherwise synk fails. This happened every time when terraform was performing the control plane update
- Increase the timeout of `kubectl wait` to 600s. Especially the cert-manager-webhook deployment can take longer than the default timeout when upgrading. In this case deploy.sh failed before.

