### PR TITLE
Upgrade version of platforms repository

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -638,10 +638,10 @@ py_library(
     _maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+        sha256 = "e88471aea3a3a4f19ec1310a55ba94772d087e9ce46e41ae38ecebe17935de7b",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz",
         ],
     )
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -634,6 +634,22 @@ py_library(
         urls = ["https://github.com/bazelbuild/rules_docker/archive/faaa10a72fa9abde070e2a20d6046e9f9b849e9a.tar.gz"],
     )
 
+    # Override platforms declared in rules_go with later version, to support new
+    # definitions that bazel toolchains need.
+    # This should be removed when rules_go version is updated.
+    _maybe(
+        http_archive,
+        name = "platforms",
+        strip_prefix = "platforms-681f1ee032566aa2d443cf0335d012925d9c58d4",
+        # master, as of 2020-08-24
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/681f1ee032566aa2d443cf0335d012925d9c58d4.zip",
+            "https://github.com/bazelbuild/platforms/archive/681f1ee032566aa2d443cf0335d012925d9c58d4.zip",
+        ],
+        sha256 = "ae95e4bfcd9f66e9dc73a92cee0107fede74163f788e3deefe00f3aaae75c431",
+    )
+
+
     # Go rules and proto support
     _maybe(
         http_archive,

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -638,10 +638,10 @@ py_library(
     _maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        sha256 = "e88471aea3a3a4f19ec1310a55ba94772d087e9ce46e41ae38ecebe17935de7b",
+        sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.20.3/rules_go-v0.20.3.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Versions of rules_go below 0.24 include platforms repository, which are lacking
definitions of os:macos, cpu:arm64 constraints.

This definitions are needed to properly select toolchains in latest
bazel.

As a workaround platforms repository is added.