### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/bazel/build_rules/rosmsg.bzl
+++ b/bazel/build_rules/rosmsg.bzl
@@ -13,8 +13,8 @@ _COMMON_CMD_CODE = """
 # bindir.
 # TODO(rodrigoq): use providers for the include directories instead of find(1).
 ROS_INCLUDE_DIRS=( $$(find $(GENDIR) bazel-out/host/bin \\
-    \( -name "*.msg" -or -name "*.srv" \) \\
-    -exec dirname {{}} \; | sort -u) )
+    \\( -name "*.msg" -or -name "*.srv" \\) \\
+    -exec dirname {{}} \\; | sort -u) )
 
 # Construct the arguments for the generation scripts.
 ROS_INCLUDE_FLAGS=( )


### PR DESCRIPTION
`\(`, `\)`, and `\;` are invalid escape sequences in Starlark. This used to be silently ignored but now throws an error (see https://github.com/bazelbuild/bazel/commit/73402fa4aa5b9de46c9a4042b75e6fb332ad4a7f).