### PR TITLE
Change stable-repo-url for helm init containers

### DIFF
--- a/src/app_charts/base/cloud/cloud-master.yaml
+++ b/src/app_charts/base/cloud/cloud-master.yaml
@@ -43,7 +43,7 @@ spec:
       # some client library functionality expects to exist.
       - name: helm
         image: {{ .Values.registry }}{{ .Values.images.cloud_master }}
-        command: ['/helm', 'init', '--client-only']
+        command: ['/helm', 'init', '--client-only', '--stable-repo-url', 'https://k8s-at-home.com/charts']
         volumeMounts:
         - mountPath: /home
           name: home

--- a/src/app_charts/base/robot/robot-master.yaml
+++ b/src/app_charts/base/robot/robot-master.yaml
@@ -39,7 +39,7 @@ spec:
       # some client library functionality expects to exist.
       - name: helm
         image: {{ .Values.registry }}{{ .Values.images.robot_master }}
-        command: ['/helm', 'init', '--client-only']
+        command: ['/helm', 'init', '--client-only', '--stable-repo-url', 'https://k8s-at-home.com/charts']
         volumeMounts:
         - mountPath: /home/nonroot
           name: home


### PR DESCRIPTION
Fix for issue https://github.com/googlecloudrobotics/core/issues/60

I changed the stable-repo-url to the one Stefan used in his commit 279ebb3.

Cloud-master is using the same `helm init` command and is still starting. Thus, I assume the repo is longer available for GCP services. I made the same change here, because sooner or later it will become invalid from there too.