### PR TITLE
Add CR_SYNCER_RBAC flag for reducing robot permissions

### DIFF
--- a/config.sh.tmpl
+++ b/config.sh.tmpl
@@ -49,3 +49,9 @@ GCP_ZONE=europe-west1-c
 # Enable google cloud robotics layer 2
 APP_MANAGEMENT=true
 
+# Require explicit RBAC policies for the cr-syncer. If false, the
+# robot-service@ service account has broad permissions in the GKE cluster.
+# If true, you will have to create RBAC policies when enabling the cr-syncer
+# for your own CustomResourceDefinitions. As this is more secure, we plan
+# to enable everywhere after migration.
+CR_SYNCER_RBAC=false

--- a/deploy.sh
+++ b/deploy.sh
@@ -157,6 +157,7 @@ region = "${GCP_REGION}"
 shared_owner_group = "${CLOUD_ROBOTICS_SHARED_OWNER_GROUP}"
 robot_image_reference = "${SOURCE_CONTAINER_REGISTRY}/setup-robot@${ROBOT_IMAGE_DIGEST}"
 crc_version = "${CRC_VERSION}"
+cr_syncer_rbac = "${CR_SYNCER_RBAC}"
 EOF
 
   if [[ -n "${PRIVATE_DOCKER_PROJECTS:-}" ]]; then

--- a/docs/how-to/creating-declarative-api.md
+++ b/docs/how-to/creating-declarative-api.md
@@ -230,10 +230,28 @@ spec:
     plural: chargeactions
     singular: chargeaction
   scope: Namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:cr-syncer:chartaction
+  labels:
+    cr-syncer.cloudrobotics.com/aggregate-to-robot-service: "true"
+rules:
+- apiGroups:
+  - example.com
+  resources:
+  - chargeactions
+  verbs:
+  - get
+  - list
+  - watch
+  - update
 ```
 
 This is a [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) definition (CRD) for a resource called ChargeAction.
 This simple example just describes the name and version of the API, but CRDs can also define schemas for the resources.
+The ClusterRole configures [role-based access control](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to let the robot access the ChargeActions.
 Don't worry about the `cr-syncer.cloudrobotics.com/spec-source` annotation for now, as it'll be explained later in the tutorial.
 
 Next, create a file called `charge-controller.yaml` with the following contents, replacing `[PROJECT_ID]` with your GCP project ID:

--- a/docs/how-to/examples/charge-service/charge-crd.yaml
+++ b/docs/how-to/examples/charge-service/charge-crd.yaml
@@ -12,3 +12,20 @@ spec:
     plural: chargeactions
     singular: chargeaction
   scope: Namespaced
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:cr-syncer:chartaction
+  labels:
+    cr-syncer.cloudrobotics.com/aggregate-to-robot-service: "true"
+rules:
+- apiGroups:
+  - example.com
+  resources:
+  - chargeactions
+  verbs:
+  - get
+  - list
+  - watch
+  - update

--- a/scripts/include-config.sh
+++ b/scripts/include-config.sh
@@ -56,4 +56,7 @@ function include_config {
 
   CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT=${CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT:-GCP}
   check_var_is_one_of CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT "GCP" "GCP-testing"
+
+  CR_SYNCER_RBAC=${CR_SYNCER_RBAC:-false}
+  check_var_is_one_of CR_SYNCER_RBAC "true" "false"
 }

--- a/src/app_charts/base/cloud/cr-syncer-policy.yaml
+++ b/src/app_charts/base/cloud/cr-syncer-policy.yaml
@@ -1,0 +1,66 @@
+# This policy lets the cr-syncer operate on the apps & registry CRDs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:cr-syncer:base
+  labels:
+    cr-syncer.cloudrobotics.com/aggregate-to-robot-service: "true"
+rules:
+
+# Robots and RobotTypes. To sync the specs from the cloud to the robot, and the
+# status from the robot to the cloud, the cr-syncer needs to read & update the
+# resources in the cloud cluster.
+- apiGroups:
+  - registry.cloudrobotics.com
+  resources:
+  - robots
+  - robottypes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+
+# ChartAssignments have the status subresource enabled, so it can be treated
+# differently. It's important that the robot can update the status but not the
+# spec, or it could run code on other robots.
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - chartassignments
+  - chartassignments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - chartassignments/status
+  verbs:
+  - update
+---
+# This aggregate role will combine all roles with the given label. This means
+# that policy can easily be added for CRDs beyond those listed above.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:cr-syncer
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cr-syncer.cloudrobotics.com/aggregate-to-robot-service: "true"
+rules: []  # The control plane automatically fills in the rules
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-robotics:cr-syncer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-robotics:cr-syncer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: robot-service@{{ .Values.project }}.iam.gserviceaccount.com

--- a/src/app_charts/base/cloud/token-vendor.yaml
+++ b/src/app_charts/base/cloud/token-vendor.yaml
@@ -26,6 +26,9 @@ spec:
           "--service_account", "robot-service",
           # This scope is for token vendor and for access to GCS/GCR.
           "--scope", "https://www.googleapis.com/auth/cloud-platform",
+          # This scope allows GKE RBAC policy bindings to refer to service accounts by email.
+          # https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#forbidden_error_for_service_accounts_on_vm_instances
+          "--scope", "https://www.googleapis.com/auth/userinfo.email",
 {{- if eq .Values.deploy_environment "GCP-testing" }}
           "--key-store", "IN_MEMORY",
 {{- else }}

--- a/src/bootstrap/cloud/terraform/input.tf
+++ b/src/bootstrap/cloud/terraform/input.tf
@@ -36,3 +36,13 @@ variable "private_image_repositories" {
   type        = list
   default     = []
 }
+
+variable "cr_syncer_rbac" {
+  description = <<-EOD
+    If true, robot-service@ is granted the container.clusterViewer
+    role, and explicit RBAC policies must be created to let the cr-syncer
+    read/write resources in the GKE cluster. If false, robot-service@ is granted
+    the container.developer role, which gives it broad access to the GKE
+    cluster.
+  EOD
+}

--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -80,9 +80,8 @@ resource "google_project_iam_member" "robot-service-logging" {
 resource "google_project_iam_member" "robot-service-kubernetes" {
   project = data.google_project.project.project_id
 
-  # TODO(swolter): This permission is very wide. Use custom IAM roles or RBAC
-  # to restrict it.
-  role = "roles/container.developer"
+  # TODO(rodrigoq): migrate to RBAC and remove roles/container.developer
+  role = var.cr_syncer_rbac == "true" ? "roles/container.clusterViewer" : "roles/container.developer"
 
   member = "serviceAccount:${google_service_account.robot-service.email}"
 }


### PR DESCRIPTION
This allows us to reduce the IAM permissions granted to robot-service@, preventing a compromised robot from running workloads in the GKE cluster or on other robots.

Users will need to create RBAC ClusterRoles for their CRs based on the example, add CR_SYNCER_RBAC=true to config.sh, and redeploy their projects. If they fail to configure appropriate policies, they will can check the auth errors in the cr-syncer logs to debug. Once all projects have migrated, we can remove the legacy CR_SYNCER_RBAC=false support.