### PR TITLE
Replace cr-syncer finalizers with async logic

### DIFF
--- a/docs/concepts/federation.md
+++ b/docs/concepts/federation.md
@@ -18,18 +18,21 @@ author.
 For federating resources, this means that `spec` and `status` of a resource are owned by at most
 one cluster respectively (possibly the same one). The cluster owning the spec is also the main
 owner of the resource overall and controls its lifecycle, i.e. deletion.
-A resource’s spec is always synced from cluster A to B and its status synced back from B to A.
+A resource’s spec is always synced from an upstream cluster to a downstream
+cluster and its status synced back from downstream to upstream.
 
 All resources of a specific type may either be synchronized to all robots or to exactly one robot.
 There is no direct synchronization between robots. However, a robot may create a resource in the
 cloud cluster that will be distributed to other robots.
 
-If a resource owned by cluster A has been synchronized to one or more clusters, it can only be
-permanently deleted in cluster A. It’s full deletion in A will be blocked until it has been
-propagated and completed across all clusters that held a copy of the resource.
+If a resource owned by the upstream cluster has been synchronized to one or more
+downstream clusters, it can only be permanently deleted upstream: if deleted
+downstream, it will be recreated. If deleted in the upstream cluster, it will be
+asynchronously deleted in other clusters that hold a copy of the resource.
+Upstream deletion can complete before the downstream resource is deleted.
 
 ## cr-syncer
-The cr-syncer component (Custom Resource Syncer) is a controller that runs once inside each robot
+The cr-syncer component (Custom Resource Syncer) is a controller that runs inside each robot
 cluster. It is connected to the Kubernetes API servers of the cloud and the robot cluster alike
 and continuously watches for updates on custom resources. The controller contains retry and resync
 logic to address intermittent connectivity.
@@ -47,16 +50,63 @@ annotations on its CRD:
   `cloudrobotics.com/robot-name` to indicate which robot it should be synced to. If the label
   is missing on a resource, it will not be synced at all.
 * `cr-syncer.cloudrobotics.com/status-subtree`: a string key, which defines which sub-section of
-  the resource status is synced from the cluster that’s not the spec source. This allows for
-  example, to split a resource’s status into a `robot` and `cloud` section. Using this annotation
-  is generally discouraged as it likely points to a flaw in the modeling of the respective CRD.
+  the resource status is synced from the downstream cluster. This lets you split
+  a resource’s status into `robot` and `cloud` sections, for example. Using this
+  annotation is generally discouraged as it likely points to a flaw in the
+  modeling of the respective CRD.
 
-## Finalizers
-The cr-syncer uses finalizers to ensure that resource deletions in the spec-source cluster have
-fully propagated and completed across all other clusters. When a resource owned by cluster A is
-synchronized to cluster B for the first time, the cr-syncer adds a [Kubernetes finalizer](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/)
-of the form `B.synced.cr-syncer.cloudrobotics.com` to the resource in cluster A.
+## Deletion
+When the cr-syncer sees a resource in the downstream cluster with no
+corresponding resource in upstream cluster, it deletes it. This handles orphaned
+resources when the upstream resource was deleted while the cr-syncer was
+restarting. It also means that you can't create a resource directly in the
+downstream cluster. The upstream resource is identified using the namespace and
+name, but not the UID, so deletion and recreation upstream may result in an
+update in the downstream cluster.
 
-When the resource is deleted in cluster A, it’s deletion will be blocked but the intent will be
-propagated to cluster B by the cr-syncer. Once deletion has completed in cluster B, the
-cr-syncer will remove the finalizer in cluster A and deletion can complete there as well.
+In some cases, downstream deletion may be blocked. For example, if we have
+deleted an upstream ChartAssignment, but the robot-master has failed to remove
+its finalizer from the downstream ChartAssignment. This edge case leads to
+surprising behavior:
+
+- An upstream ChartAssignment can be recreated before the downstream
+  ChartAssignment is deleted.
+- The old status from the downstream cluster will be synced to the new upstream
+  ChartAssignment.
+
+If needed, this can be detected by watching the downstream cluster after
+deleting the resource from the downstream cluster. The situation will clean up
+once downstream deletion is complete.
+
+Note: previously, the cr-syncer used finalizers to block upstream deletion
+until the downstream resource was deleted. This gave the original deleter more
+information: for example, once an AppRollout had been deleted in the cloud, it
+means that all robots have terminated the app's pods. However, this caused
+problems with offline or renamed clusters: an admin would have to manually clean
+up the old finalizers. The new asynchronous behavior is not affected by offline
+clusters.
+
+## Resource generations
+
+Custom resources have a field `.metadata.generation` that starts at 1 and is
+incremented when the resource changes. Specifically, if the CRD enables the
+/status subresource, the generation increases by 1 every time the resource spec
+changes, but not when the status changes. The resource controller can set
+`.status.observedGeneration` to the latest generation it has observed, so the
+user can change the spec, then wait for `observedGeneration` to catch up before
+looking at the status. For example:
+
+* Create a Deployment for one pod (generation=1), and wait for the status to be Ready.
+* Change the Deployment's image reference (generation=2): the status is still
+  Ready, but this refers the old spec (observedGeneration=1).
+* Wait for the status to update (observedGeneration=2): now the status is
+  non-ready, referring to the newer spec.
+* Wait for the status to be Ready. The new image is now running.
+
+`generation` and `observedGeneration` can **only be compared in the downstream
+cluster**. As the generation is managed by the Kubernetes apiserver, the
+cr-syncer cannot guarantee that the upstream generation matches the downstream
+generation. On the other hand, `observedGeneration` will be copied from
+downstream to upstream with the rest of `.status`. This means that `generation`
+is cluster-specific but `observedGeneration` always refers to the downstream
+generation.

--- a/src/go/cmd/cr-syncer/syncer.go
+++ b/src/go/cmd/cr-syncer/syncer.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -44,8 +45,11 @@ const (
 
 	// Annotations and labels attached to CRs.
 	labelRobotName = "cloudrobotics.com/robot-name"
-	// Annotation for remote resource version. Note that for resources in the cloud cluster,
-	// this is a resource version on the robot's cluster (and vice versa).
+	// Annotation for remote resource version. Note that for resources in
+	// the cloud cluster, this is a resource version on the robot's cluster
+	// (and vice versa). This will only be set when the status subresource
+	// is disabled, otherwise the status and annotation cannot be updated
+	// in a single request.
 	annotationResourceVersion = "cr-syncer.cloudrobotics.com/remote-resource-version"
 )
 
@@ -85,27 +89,31 @@ func init() {
 	}
 }
 
-// finalizerFor returns the finalizer for the given cluster name
-func finalizerFor(clusterName string) string {
-	return fmt.Sprintf("%s.synced.cr-syncer.cloudrobotics.com", clusterName)
-}
-
-func stringsContain(strs []string, v string) bool {
-	for _, s := range strs {
-		if s == v {
-			return true
+// removeFinalizers removes all cr-syncer finalizers. For resources synced to
+// more than one cluster, this will also delete the finalizers for
+// other/offline clusters. This doesn't affect resources synced to other
+// clusters with filter-by-robot-name.
+// TODO(rodrigoq): remove after migration
+func removeFinalizers(client dynamic.ResourceInterface, obj *unstructured.Unstructured) {
+	update := false
+	finalizers := []string{}
+	for _, x := range obj.GetFinalizers() {
+		if strings.HasSuffix(x, ".synced.cr-syncer.cloudrobotics.com") {
+			update = true
+		} else {
+			finalizers = append(finalizers, x)
 		}
 	}
-	return false
-}
-
-func stringsDelete(list []string, s string) (res []string) {
-	for _, x := range list {
-		if x != s {
-			res = append(res, x)
-		}
+	if !update {
+		return
 	}
-	return res
+	obj.SetFinalizers(finalizers)
+	if _, err := client.Update(obj, metav1.UpdateOptions{}); err != nil {
+		if isNotFoundError(err) {
+			return
+		}
+		log.Printf("failed to remove finalizers: %v", err)
+	}
 }
 
 // crSyncer synchronizes custom resources from an upstream source cluster to a
@@ -277,7 +285,7 @@ func (s *crSyncer) processNextWorkItem(
 	}
 	// Synchronization failed, retry later.
 	stats.Record(ctx, mSyncErrors.M(1))
-	log.Printf("Syncing key %q from queue %q failed: %s", key, qName, err)
+	log.Printf("Syncing key %q from queue %q failed: %v", key, qName, err)
 	q.AddRateLimited(key)
 
 	return true
@@ -316,41 +324,41 @@ func (s *crSyncer) stop() {
 	close(s.done)
 }
 
-// syncDownstream reconciles state after receiving change events from the downstream cluster.
-// It synchronizes the status from the downstream to the upstream cluster, removes
-// fnializers from upstream and downstream if both resources can be safely deleted, and
-// deletes orphaned downstream resources.
+// syncDownstream reconciles state after receiving change events from the
+// downstream cluster. It synchronizes the status from the downstream to the
+// upstream cluster, and deletes orphaned downstream resources.
 func (s *crSyncer) syncDownstream(key string) error {
 	var (
-		finalizer           = finalizerFor(s.clusterName)
 		statusIsSubresource = s.crd.Spec.Subresources != nil && s.crd.Spec.Subresources.Status != nil
 	)
-	// Get a recent version of the upstream spec.
-	srcObj, exists, err := s.downstreamInf.GetIndexer().GetByKey(key)
+	// Get the downstream status (src) and upstream spec (dst).
+	srcObj, srcExists, err := s.downstreamInf.GetIndexer().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve resource for key %s: %s", key, err)
 	}
-	if !exists {
+	if !srcExists {
+		// The downstream resource has been deleted: possibly because
+		// the upstream resource was deleted and recreated. Add this to
+		// the upstream queue so that syncUpstream() can check if it needs
+		// to recreate the downstream resource.
+		s.upstreamQueue.Add(key)
 		return nil
 	}
 	src := srcObj.(*unstructured.Unstructured).DeepCopy()
+	removeFinalizers(s.downstream, src)
 
-	dstObj, exists, err := s.upstreamInf.GetIndexer().GetByKey(key)
+	dstObj, dstExists, err := s.upstreamInf.GetIndexer().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve resource for key %s: %s", key, err)
 	}
-	// Upstream resource no longer exists. Remove the finalizer from the downstream
-	// resource and delete it.
-	if !exists {
-		src.SetFinalizers(stringsDelete(src.GetFinalizers(), finalizer))
-		if _, err := s.downstream.Update(src, metav1.UpdateOptions{}); err != nil {
-			if isNotFoundError(err) {
-				return nil
-			}
-			return fmt.Errorf("remove finalizer: %s", err)
-		}
+	// If the upstream resource no longer exists, delete the downstream
+	// resource. Normally, this occurs when syncUpstream() handles the
+	// upstream deletion, but if the resource was deleted when the robot
+	// was offline, upstream doesn't know about the old resource and we'll
+	// hit this condition.
+	if !dstExists {
 		if src.GetDeletionTimestamp() != nil {
-			return nil // Already deleted.
+			return nil // Already being deleted.
 		}
 		if err := s.downstream.Delete(src.GetName(), nil); err != nil {
 			if isNotFoundError(err) {
@@ -392,74 +400,54 @@ func (s *crSyncer) syncDownstream(key string) error {
 		if dst.Object["status"] == nil {
 			dst.Object["status"] = struct{}{}
 		}
-		updated, err := s.upstream.UpdateStatus(dst, metav1.UpdateOptions{})
+		dst, err = s.upstream.UpdateStatus(dst, metav1.UpdateOptions{})
 		if err != nil {
 			return newAPIErrorf(dst, "update status failed: %s", err)
 		}
-		dst = updated
 	} else {
-		updated, err := s.upstream.Update(dst, metav1.UpdateOptions{})
+		dst, err = s.upstream.Update(dst, metav1.UpdateOptions{})
 		if err != nil {
 			return newAPIErrorf(dst, "update failed: %s", err)
 		}
-		dst = updated
 	}
 	log.Printf("Copied %s %s status@v%s to upstream@v%s",
-		src.GetKind(), src.GetName(), src.GetResourceVersion(), src.GetResourceVersion())
-
-	if src.GetDeletionTimestamp() == nil {
-		return nil
-	}
-	// Downstream resource is pending for deletion. Once all downstream finalizers but our
-	// own are removed, drop it from upstream and downstream in order. The order
-	// ensures that the upstream resource is not left with a dangling finalizer.
-	if len(src.GetFinalizers()) == 1 && stringsContain(src.GetFinalizers(), finalizer) {
-		dst.SetFinalizers(stringsDelete(src.GetFinalizers(), finalizer))
-		src.SetFinalizers(nil)
-
-		if _, err := s.upstream.Update(dst, metav1.UpdateOptions{}); err != nil {
-			return newAPIErrorf(dst, "upstream update failed: %s", err)
-		}
-		// If we crash before reaching this point, the orphan cleanup above
-		// will ensure the downstream resource is deleted.
-		if _, err := s.downstream.Update(src, metav1.UpdateOptions{}); err != nil {
-			return newAPIErrorf(src, "downstream update failed: %s", err)
-		}
-	}
+		src.GetKind(), src.GetName(), src.GetResourceVersion(), dst.GetResourceVersion())
 	return nil
 }
 
 // syncUpstream reconciles the state after receiving a change event from upstream.
 // It synchronizes the spec changes from upstream to the downstream cluster and propagates
 // deletions.
-// It attaches a finalizer to the upstream and downstream resource in order to
-// ensure that downstream resources are properly cleaned up before the upstream resource
-// can complete deletion.
 func (s *crSyncer) syncUpstream(key string) error {
-	// Create-or-update function.
-	upsert := func(o *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-		return s.downstream.Update(o, metav1.UpdateOptions{})
-	}
-	// Get a recent version of the upstream spec.
-	srcObj, exists, err := s.upstreamInf.GetIndexer().GetByKey(key)
+	// Get the upstream spec (src) and downstream status (dst).
+	src := &unstructured.Unstructured{make(map[string]interface{})}
+	dst := &unstructured.Unstructured{make(map[string]interface{})}
+	srcObj, srcExists, err := s.upstreamInf.GetIndexer().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve resource for key %s: %s", key, err)
 	}
-	if !exists {
-		return nil
+	if srcExists {
+		src = srcObj.(*unstructured.Unstructured).DeepCopy()
+		removeFinalizers(s.upstream, src)
 	}
-	src := srcObj.(*unstructured.Unstructured).DeepCopy()
-
-	dstObj, exists, err := s.downstreamInf.GetIndexer().GetByKey(key)
+	dstObj, dstExists, err := s.downstreamInf.GetIndexer().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve resource for key %s: %s", key, err)
 	}
-	dst := &unstructured.Unstructured{}
-	if exists {
+	if dstExists {
 		dst = dstObj.(*unstructured.Unstructured).DeepCopy()
-	} else {
+	}
+
+	// Check if the downstream resource (dst) should be created, updated,
+	// or deleted. If we don't need to create/update dst, return early.
+	var createOrUpdate func(*unstructured.Unstructured) (*unstructured.Unstructured, error)
+	switch {
+	case !srcExists && !dstExists:
+		// Both deleted, nothing to do.
+		return nil
+	case srcExists && !dstExists:
 		// Create object and set base fields.
-		upsert = func(o *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		createOrUpdate = func(o *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 			o.SetGroupVersionKind(src.GroupVersionKind())
 			o.SetNamespace(src.GetNamespace())
 			o.SetName(src.GetName())
@@ -468,42 +456,49 @@ func (s *crSyncer) syncUpstream(key string) error {
 
 			return s.downstream.Create(o, metav1.CreateOptions{})
 		}
-	}
-
-	finalizer := finalizerFor(s.clusterName)
-
-	if !stringsContain(dst.GetFinalizers(), finalizer) {
-		dst.SetFinalizers(append(dst.GetFinalizers(), finalizer))
-	}
-	dst.SetLabels(src.GetLabels())
-	dst.SetAnnotations(src.GetAnnotations())
-	deleteAnnotation(dst, annotationResourceVersion)
-
-	dst.Object["spec"] = src.Object["spec"]
-
-	// Ensure that our finalizer is set in the upstream resource before the downstream
-	// resource is created.
-	if src.GetDeletionTimestamp() == nil && !stringsContain(src.GetFinalizers(), finalizer) {
-		src.SetFinalizers(append(src.GetFinalizers(), finalizer))
-
-		if _, err := s.upstream.Update(src, metav1.UpdateOptions{}); err != nil {
-			return newAPIErrorf(src, "setting upstream finalizer failed: %s", err)
+	case srcExists && dstExists:
+		// Update dst.
+		createOrUpdate = func(o *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+			return s.downstream.Update(o, metav1.UpdateOptions{})
 		}
-	}
-	// Now we can safely create/update the resource downstream and the upstream
-	// resource will not go away until we've deleted it again.
-	updated, err := upsert(dst)
-	if err != nil {
-		return newAPIErrorf(dst, "failed to upsert downstream: %s", err)
-	}
-	dst = updated
-
-	// Mark downstream resource deleted if upstream resource is being deleted.
-	if src.GetDeletionTimestamp() != nil && dst.GetDeletionTimestamp() == nil {
+	case !srcExists && dstExists:
+		// Delete dst.
 		if err := s.downstream.Delete(dst.GetName(), nil); err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
 			return newAPIErrorf(dst, "downstream delete failed: %s", err)
 		}
 		return nil
+	default:
+		log.Fatalf("unhandled condition: srcExists=%t, dstExists=%t", srcExists, dstExists)
+		return nil
+	}
+
+	// Before creating/updating, check if deletion is in progress. This
+	// is checked separately to src/dstExists for readability (hopefully).
+	if src.GetDeletionTimestamp() != nil {
+		if err := s.downstream.Delete(src.GetName(), nil); err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return newAPIErrorf(dst, "downstream delete failed: %s", err)
+		}
+		return nil
+	}
+
+	// Create/update dst with the labels+annotations+spec of src.
+	dst.SetLabels(src.GetLabels())
+	dst.SetAnnotations(src.GetAnnotations())
+	dst.Object["spec"] = src.Object["spec"]
+
+	// The remote-resource-version annotation is removed from dst to
+	// prevent an infinite loop, because changing the annotation would
+	// change the resource version.
+	deleteAnnotation(dst, annotationResourceVersion)
+
+	if _, err = createOrUpdate(dst); err != nil {
+		return newAPIErrorf(dst, "failed to create or update downstream: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This lets you delete a ChartAssignment from the cloud (upstream) cluster
even when the robot (downstream) cluster is offline and cannot process
the deletion. The downstream resource will be deleted when the robot
comes online.

It also lets you apply RBAC policy to prevent the cr-syncer from
updating specs in the cloud, as it now only needs to update the status.

This will remove finalizers from actively-synced resources, although if
a robot has been taken offline, you will need to manually remove
finalizers and delete its ChartAssignments etc.