### PR TITLE
Update cloud-robotics CRDs to v1

### DIFF
--- a/docs/how-to/creating-declarative-api.md
+++ b/docs/how-to/creating-declarative-api.md
@@ -234,7 +234,7 @@ Create a file called `charge-crd.yaml` with the following contents:
 
 [embedmd]:# (examples/charge-service/charge-crd.yaml yaml)
 ```yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: chargeactions.example.com
@@ -242,14 +242,17 @@ metadata:
     cr-syncer.cloudrobotics.com/spec-source: cloud
 spec:
   group: example.com
-  version: v1
   names:
     kind: ChargeAction
     plural: chargeactions
     singular: chargeaction
   scope: Namespaced
-  subresources:
-    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/docs/how-to/examples/charge-service/charge-crd.yaml
+++ b/docs/how-to/examples/charge-service/charge-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: chargeactions.example.com
@@ -6,14 +6,17 @@ metadata:
     cr-syncer.cloudrobotics.com/spec-source: cloud
 spec:
   group: example.com
-  version: v1
   names:
     kind: ChargeAction
     plural: chargeactions
     singular: chargeaction
   scope: Namespaced
-  subresources:
-    status: {}
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/src/app_charts/base/cloud/apps-crd.yaml
+++ b/src/app_charts/base/cloud/apps-crd.yaml
@@ -17,6 +17,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          type: object
           properties:
             spec:
               type: object
@@ -83,6 +84,7 @@ spec:
         type: date
       schema:
         openAPIV3Schema:
+          type: object
           properties:
             spec:
               type: object
@@ -113,12 +115,14 @@ spec:
                           matchExpressions:
                             type: array
                             items:
+                              type: object
                               properties:
                                 key:
                                   type: string
                                 operator:
                                   type: string
                                 values:
+                                  type: array
                                   items:
                                     type: string
             status:
@@ -136,10 +140,10 @@ spec:
                     type: object
                     properties:
                       lastUpdateTime:
-                        type: date
+                        type: string
                         format: date-time
                       lastTransitionTime:
-                        type: date
+                        type: string
                         format: date-time
                       status:
                         type: string
@@ -179,6 +183,7 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          type: object
           properties:
             spec:
               type: object
@@ -211,10 +216,10 @@ spec:
                     type: object
                     properties:
                       lastUpdateTime:
-                        type: date
+                        type: string
                         format: date-time
                       lastTransitionTime:
-                        type: date
+                        type: string
                         format: date-time
                       status:
                         type: string

--- a/src/app_charts/base/cloud/apps-crd.yaml
+++ b/src/app_charts/base/cloud/apps-crd.yaml
@@ -32,23 +32,17 @@ spec:
                     cloud:
                       type: object
                       properties:
-                        chart:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                            inline:
-                              type: string
+                        name:
+                          type: string
+                        inline:
+                          type: string
                     robots:
                       type: object
                       properties:
-                        chart:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                            inline:
-                              type: string
+                        name:
+                          type: string
+                        inline:
+                          type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -96,6 +90,7 @@ spec:
                   properties:
                     values:
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                 robots:
                   type: array
                   items:
@@ -103,6 +98,7 @@ spec:
                     properties:
                       values:
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       version:
                         type: string
                       selector:
@@ -112,6 +108,7 @@ spec:
                             type: boolean
                           matchLabels:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           matchExpressions:
                             type: array
                             items:
@@ -132,7 +129,11 @@ spec:
                   type: integer
                 assignments:
                   type: integer
-                updatedAssignment:
+                readyAssignments:
+                  type: integer
+                settledAssignments:
+                  type: integer
+                failedAssignments:
                   type: integer
                 conditions:
                   type: array
@@ -148,6 +149,8 @@ spec:
                       status:
                         type: string
                       type:
+                        type: string
+                      message:
                         type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -205,6 +208,7 @@ spec:
                       type: string
                     values:
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
             status:
               type: object
               properties:
@@ -229,9 +233,3 @@ spec:
                         type: string
                 phase:
                   type: string
-                desiredRevision:
-                  type: integer
-                deployedRevision:
-                  type: integer
-                rollbackRevision:
-                  type: integer

--- a/src/app_charts/base/cloud/apps-crd.yaml
+++ b/src/app_charts/base/cloud/apps-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apps.apps.cloudrobotics.com
@@ -6,47 +6,50 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   group: apps.cloudrobotics.com
-  version: v1alpha1
   names:
     kind: App
     plural: apps
     singular: app
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           properties:
-            repository:
-              type: string
-            version:
-              type: string
-            components:
+            spec:
               type: object
               properties:
-                cloud:
+                repository:
+                  type: string
+                version:
+                  type: string
+                components:
                   type: object
                   properties:
-                    chart:
+                    cloud:
                       type: object
                       properties:
-                        name:
-                          type: string
-                        inline:
-                          type: string
-                robots:
-                  type: object
-                  properties:
-                    chart:
+                        chart:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            inline:
+                              type: string
+                    robots:
                       type: object
                       properties:
-                        name:
-                          type: string
-                        inline:
-                          type: string
+                        chart:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            inline:
+                              type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: approllouts.apps.cloudrobotics.com
@@ -54,93 +57,96 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   group: apps.cloudrobotics.com
-  version: v1alpha1
   names:
     kind: AppRollout
     plural: approllouts
     singular: approllout
   scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - JSONPath: .status.assignments
-    name: Assignments
-    type: integer
-  - JSONPath: .status.readyAssignments
-    name: Ready
-    type: integer
-  - JSONPath: .status.failedAssignments
-    name: Failed
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
+  versions: 
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - jsonPath: .status.assignments
+        name: Assignments
+        type: integer
+      - jsonPath: .status.readyAssignments
+        name: Ready
+        type: integer
+      - jsonPath: .status.failedAssignments
+        name: Failed
+        type: integer
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      schema:
+        openAPIV3Schema:
           properties:
-            appName:
-              type: string
-            cloud:
+            spec:
               type: object
               properties:
-                values:
+                appName:
+                  type: string
+                cloud:
                   type: object
-            robots:
-              type: array
-              items:
-                type: object
-                properties:
-                  values:
-                    type: object
-                  version:
-                    type: string
-                  selector:
+                  properties:
+                    values:
+                      type: object
+                robots:
+                  type: array
+                  items:
                     type: object
                     properties:
-                      any:
-                        type: boolean
-                      matchLabels:
+                      values:
                         type: object
-                      matchExpressions:
-                        type: array
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-        status:
-          type: object
-          properties:
-            observedGeneration:
-              type: integer
-            assignments:
-              type: integer
-            updatedAssignment:
-              type: integer
-            conditions:
-              type: array
-              items:
-                type: object
-                properties:
-                  lastUpdateTime:
-                    type: date
-                    format: date-time
-                  lastTransitionTime:
-                    type: date
-                    format: date-time
-                  status:
-                    type: string
-                  type:
-                    type: string
+                      version:
+                        type: string
+                      selector:
+                        type: object
+                        properties:
+                          any:
+                            type: boolean
+                          matchLabels:
+                            type: object
+                          matchExpressions:
+                            type: array
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                assignments:
+                  type: integer
+                updatedAssignment:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastUpdateTime:
+                        type: date
+                        format: date-time
+                      lastTransitionTime:
+                        type: date
+                        format: date-time
+                      status:
+                        type: string
+                      type:
+                        type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: chartassignments.apps.cloudrobotics.com
@@ -150,74 +156,77 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   group: apps.cloudrobotics.com
-  version: v1alpha1
   names:
     kind: ChartAssignment
     plural: chartassignments
     singular: chartassignment
   scope: Cluster
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    name: Phase
-    type: string
-  - JSONPath: .status.observedGeneration
-    name: Generation
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+      - jsonPath: .status.phase
+        name: Phase
+        type: string
+      - jsonPath: .status.observedGeneration
+        name: Generation
+        type: integer
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           properties:
-            clusterName:
-              type: string
-            namespaceName:
-              type: string
-            chart:
+            spec:
               type: object
               properties:
-                repository:
+                clusterName:
                   type: string
-                name:
+                namespaceName:
                   type: string
-                version:
-                  type: string
-                inline:
-                  type: string
-                values:
+                chart:
                   type: object
-        status:
-          type: object
-          properties:
-            observedGeneration:
-              type: integer
-            conditions:
-              type: array
-              items:
-                type: object
-                properties:
-                  lastUpdateTime:
-                    type: date
-                    format: date-time
-                  lastTransitionTime:
-                    type: date
-                    format: date-time
-                  status:
-                    type: string
-                  type:
-                    type: string
-                  message:
-                    type: string
-            phase:
-              type: string
-            desiredRevision:
-              type: integer
-            deployedRevision:
-              type: integer
-            rollbackRevision:
-              type: integer
+                  properties:
+                    repository:
+                      type: string
+                    name:
+                      type: string
+                    version:
+                      type: string
+                    inline:
+                      type: string
+                    values:
+                      type: object
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastUpdateTime:
+                        type: date
+                        format: date-time
+                      lastTransitionTime:
+                        type: date
+                        format: date-time
+                      status:
+                        type: string
+                      type:
+                        type: string
+                      message:
+                        type: string
+                phase:
+                  type: string
+                desiredRevision:
+                  type: integer
+                deployedRevision:
+                  type: integer
+                rollbackRevision:
+                  type: integer

--- a/src/app_charts/base/cloud/registry-crd.yaml
+++ b/src/app_charts/base/cloud/registry-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: robottypes.registry.cloudrobotics.com
@@ -7,26 +7,29 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   group: registry.cloudrobotics.com
-  version: v1alpha1
   names:
     kind: RobotType
     plural: robottypes
     singular: robottype
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
-          required: ['make', 'model']
-          maxProperties: 2
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           properties:
-            make:
-              type: string
-            model:
-              type: string
+            spec:
+              type: object
+              required: ['make', 'model']
+              maxProperties: 2
+              properties:
+                make:
+                  type: string
+                model:
+                  type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: robots.registry.cloudrobotics.com
@@ -37,51 +40,54 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   group: registry.cloudrobotics.com
-  version: v1alpha1
   names:
     kind: Robot
     plural: robots
     singular: robot
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          type: object
-          maxProperties: 3
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           properties:
-            type:
-              type: string
-            project:
-              type: string
-        status:
-          type: object
-          properties:
-            cloud:
+            spec:
               type: object
-            robot:
+              maxProperties: 3
+              properties:
+                type:
+                  type: string
+                project:
+                  type: string
+            status:
               type: object
               properties:
-                updateTime:
-                  type: string
-                state:
-                  type: string
-                  enum:
-                    - UNDEFINED
-                    - UNAVAILABLE
-                    - AVAILABLE
-                    - EMERGENCY_STOP
-                    - ERROR
-                lastStateChangeTime:
-                  type: string
-                batteryPercentage:
-                  type: number
-                emergencyStopButtonPressed:
-                  type: boolean
-            configuration:
-              type: object
-              properties:
-                trolleyAttached:
-                  type: boolean
+                cloud:
+                  type: object
+                robot:
+                  type: object
+                  properties:
+                    updateTime:
+                      type: string
+                    state:
+                      type: string
+                      enum:
+                        - UNDEFINED
+                        - UNAVAILABLE
+                        - AVAILABLE
+                        - EMERGENCY_STOP
+                        - ERROR
+                    lastStateChangeTime:
+                      type: string
+                    batteryPercentage:
+                      type: number
+                    emergencyStopButtonPressed:
+                      type: boolean
+                configuration:
+                  type: object
+                  properties:
+                    trolleyAttached:
+                      type: boolean

--- a/src/app_charts/base/cloud/registry-crd.yaml
+++ b/src/app_charts/base/cloud/registry-crd.yaml
@@ -69,6 +69,7 @@ spec:
               properties:
                 cloud:
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 robot:
                   type: object
                   properties:

--- a/src/app_charts/base/cloud/registry-crd.yaml
+++ b/src/app_charts/base/cloud/registry-crd.yaml
@@ -18,6 +18,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          type: object
           properties:
             spec:
               type: object
@@ -53,6 +54,7 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          type: object
           properties:
             spec:
               type: object

--- a/src/go/tests/apps/apps_test.go
+++ b/src/go/tests/apps/apps_test.go
@@ -163,9 +163,9 @@ spec:
   clusterName: {{ .cluster }}
   namespaceName: {{ .namespace }}
   chart:
-    repository: https://k8s-at-home.com/charts/
+    repository: https://oauth2-proxy.github.io/manifests
     name: oauth2-proxy
-    version: 4.0.1
+    version: 4.2.1
     values:
       fullnameOverride: test
 `


### PR DESCRIPTION
[The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122)

This PR migrates cloud-robotics.com CRDs to `apiextensions.k8s.io/v1`