### PR TITLE
Fix robot chart in app CRD

### DIFF
--- a/src/app_charts/base/cloud/apps-crd.yaml
+++ b/src/app_charts/base/cloud/apps-crd.yaml
@@ -36,7 +36,7 @@ spec:
                           type: string
                         inline:
                           type: string
-                    robots:
+                    robot:
                       type: object
                       properties:
                         name:


### PR DESCRIPTION
@ensonic there was one more little inconsistency between apps-crd.yaml and the go structure I did not find in the first place. It's just one letter, but in the end it removes all the robot charts from App CRs.