### PR TITLE
Update cert-manager letsencrypt issuer

### DIFF
--- a/src/app_charts/base/cloud/cert-manager-issuers.yaml
+++ b/src/app_charts/base/cloud/cert-manager-issuers.yaml
@@ -9,7 +9,10 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-prod
     # We can't use dns01 since we don't control the dns-zone that endpoints uses.
-    http01: {}
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
 ---
 # A self-signing issuer for cluster-internal services.
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
The structure of the letsencrypt issuer has changed and the `orders.acme.cert-manager.io` for letsencrypt were stuck with this message:  
```
Warning  Solver    11m (x2 over 11m)  cert-manager  Failed to determine a valid solver configuration for the set of domains on the Order: no configured challenge solvers can be used for this challenge
```
This PR changes `letsencrypt-prod` issuer according to the [cert-manager docs](https://cert-manager.io/docs/configuration/acme/http01/).