### PR TITLE
Add clusterroles and dedicated service accounts for app management apps / remove permissive binding

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -333,13 +333,9 @@ function helm_charts {
     ca_key=$(openssl base64 -A < ${certdir}/ca.key)
   fi
 
-  # Create a permissive policy if none exists yet. This allows code running in the
-  # cluster to administer it.
-  if ! kc get clusterrolebinding permissive-binding &>/dev/null; then
-    kc create clusterrolebinding permissive-binding \
-      --clusterrole=cluster-admin \
-      --user=admin \
-      --group=system:serviceaccounts
+  # Delete permissive binding if it exists because from previous deployments
+  if kc get clusterrolebinding permissive-binding &>/dev/null; then
+    kc delete clusterrolebinding permissive-binding
   fi
 
   ${SYNK} init

--- a/src/app_charts/base/cloud/app-management-policy.yaml
+++ b/src/app_charts/base/cloud/app-management-policy.yaml
@@ -1,0 +1,169 @@
+# This policy lets app-rollout and chart-assigment controllers operate on the apps & registry CRDs.
+# For app-rollout-controller
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:app-rollout-controller:base
+  labels:
+    app-rollout-controller.cloudrobotics.com/aggregate-to-app-rollout: "true"
+rules:
+- apiGroups:
+  - registry.cloudrobotics.com
+  resources:
+  - robots
+  - robots/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - apps
+  - approllouts
+  - approllouts/status
+  - chartassignments
+  - chartassignments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - chartassignments
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - approllouts/status
+  verbs:
+  - update
+  - patch
+---
+# Aggregated role for app-rollout-controller
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:app-rollout-controller
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      app-rollout-controller.cloudrobotics.com/aggregate-to-app-rollout: "true"
+rules: []  # The control plane automatically fills in the rules
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-rollout-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-robotics:app-rollout-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-robotics:app-rollout-controller
+subjects:
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: app-rollout-controller
+---
+# For chart-assignment-controller
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:chart-assignment-controller:base
+  labels:
+    chart-assignment-controller.cloudrobotics.com/aggregate-to-chart-assignment: "true"
+rules:
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - chartassignments
+  - chartassignments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - chartassignments/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - apps.cloudrobotics.com
+  resources:
+  - resourcesets
+  - resourcesets/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:chart-assignment-controller:k8s-control
+  labels:
+    chart-assignment-controller.cloudrobotics.com/aggregate-to-chart-assignment: "true"
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+# Aggregated role for chart-assignment-controller
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-robotics:chart-assignment-controller
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      chart-assignment-controller.cloudrobotics.com/aggregate-to-chart-assignment: "true"
+  - matchLabels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules: []  # The control plane automatically fills in the rules
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chart-assignment-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-robotics:chart-assignment-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-robotics:chart-assignment-controller
+subjects:
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: chart-assignment-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-robotics:chart-assignment-controller:cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: chart-assignment-controller

--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: app-rollout-controller
     spec:
+      serviceAccountName: app-rollout-controller
       containers:
       - name: app-rollout-controller
         image: {{ .Values.registry }}{{ .Values.images.app_rollout_controller }}
@@ -113,6 +114,7 @@ spec:
       labels:
         app: chart-assignment-controller
     spec:
+      serviceAccountName: chart-assignment-controller
       containers:
       - name: chart-assignment-controller
         image: {{ .Values.registry }}{{ .Values.images.chart_assignment_controller }}

--- a/src/app_charts/base/cloud/nginx-ingress-controller-policy.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller-policy.yaml
@@ -1,0 +1,175 @@
+# Source: ingress-nginx/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingress-nginx
+automountServiceAccountToken: true
+---
+# Source: ingress-nginx/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ingress-nginx
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: ingress-nginx/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: {{ .Release.Namespace }}
+---
+# Source: ingress-nginx/templates/controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ingress-nginx
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    resourceNames:
+      - ingress-controller-leader-nginx
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# Source: ingress-nginx/templates/controller-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: {{ .Release.Namespace }}

--- a/src/app_charts/base/cloud/nginx-ingress-controller.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         k8s-app: nginx-ingress-controller
     spec:
+      serviceAccountName: ingress-nginx
       dnsPolicy: ClusterFirst
       containers:
         - name: nginx-ingress-controller


### PR DESCRIPTION
This PR adds cluster roles and for app-rollout and chart-assignment-controllers and starts them with dedicated service accounts. **Additionally the permissive-binding is removed during deployment.**

The cluster roles for app-rollout-controller are pretty easy and just include additional permissions for `robots`, `apps`, `approllouts` and `chartassignments` CRDs.

Chart-assignment-controller has now permissions for `chartassignments` and `resourcesets` CRDs and for namespaces. For convenience the `cluster-admin` role is assigned to its service account too, because we do not really have a concept yet, which Kubernetes objects we would like to be managed by chart-assignment-controller.

However, this change allows to investigate roles and permissions of other apps now, which was somehow pointless while a permissive-binding was existing. Thus, this PR might lead to "permission denied" in other apps.