### PR TITLE
Check availability of served CRDs only

### DIFF
--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -800,7 +800,9 @@ func (s *Synk) crdAvailable(ucrd *unstructured.Unstructured) (bool, error) {
 	// Get a list of versions to check for.
 	var versions []string
 	for _, v := range crd.Spec.Versions {
-		versions = append(versions, v.Name)
+		if v.Served {
+			versions = append(versions, v.Name)
+		}
 	}
 
 	for _, v := range versions {


### PR DESCRIPTION
This tiny patch excludes versions of CRDs which are not served from availability check in `synk`. Unserved version are never available and they currently block deployments by synk.
I was facing this issue when trying to upgrade cert-manager to v1.6.1 because they stop serving CRD versions v1alpha1, v1alpha2 and v1alpha3.