### PR TITLE
Fix Flogger error prone violations

### DIFF
--- a/src/java/com/cloudrobotics/tokenvendor/cloudiot/CloudIotPublicKeyRepository.java
+++ b/src/java/com/cloudrobotics/tokenvendor/cloudiot/CloudIotPublicKeyRepository.java
@@ -70,7 +70,7 @@ class CloudIotPublicKeyRepository implements PublicKeyPublisher, PublicKeyReposi
       String message =
           String.format(
               "Failed to publish public key for device %s to Cloud IoT Registry", deviceId.value());
-      logger.atSevere().withCause(e).log(message);
+      logger.atSevere().withCause(e).log("%s", message);
       throw new CloudIotException(message, e);
     }
   }
@@ -161,7 +161,7 @@ class CloudIotPublicKeyRepository implements PublicKeyPublisher, PublicKeyReposi
         return ImmutableList.of();
       }
       String message = String.format("Failed to list devices from Cloud IoT Registry");
-      logger.atSevere().withCause(e).log(message);
+      logger.atSevere().withCause(e).log("%s", message);
       throw new CloudIotException(message, e);
     }
   }
@@ -187,7 +187,7 @@ class CloudIotPublicKeyRepository implements PublicKeyPublisher, PublicKeyReposi
       }
       String message =
           String.format("Failed to get device %s from Cloud IoT Registry", deviceId.value());
-      logger.atSevere().withCause(e).log(message);
+      logger.atSevere().withCause(e).log("%s", message);
       throw new CloudIotException(message, e);
     }
   }


### PR DESCRIPTION
New error prone checks have been added around FluentLogger, so building with the bazel at head with latest java_tools causes the following errors:

```
core/src/java/com/cloudrobotics/tokenvendor/cloudiot/BUILD.bazel:3:13: Building src/java/com/cloudrobotics/tokenvendor/cloudiot/libcloudiot.jar (3 source files) and running annotation processors (ComponentProcessor) failed: (Exit 1): java failed: error executing command (from target //src/java/com/cloudrobotics/tokenvendor/cloudiot:cloudiot)
--
  | (cd /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/8c32e694a468f8d49666471b7551ce22/execroot/cloud_robotics && \
  | exec env - \
  | LC_CTYPE=en_US.UTF-8 \
  | PATH=/bin:/usr/bin:/usr/local/bin \
  | external/remotejdk11_linux/bin/java -XX:-CompactStrings '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.resources=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED' '--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED' '--add-opens=java.base/java.nio=ALL-UNNAMED' '--add-opens=java.base/java.lang=ALL-UNNAMED' '--patch-module=java.compiler=external/remote_java_tools/java_tools/java_compiler.jar' '--patch-module=jdk.compiler=external/remote_java_tools/java_tools/jdk_compiler.jar' -jar external/remote_java_tools/java_tools/JavaBuilder_deploy.jar @bazel-out/k8-opt/bin/src/java/com/cloudrobotics/tokenvendor/cloudiot/libcloudiot.jar-0.params @bazel-out/k8-opt/bin/src/java/com/cloudrobotics/tokenvendor/cloudiot/libcloudiot.jar-1.params)
  | # Configuration: cdbffe1c6342375d5b3fac01cf67bc8ac55c5eabd9fbbd4f23198902b250e7be
  | # Execution platform: @local_config_platform//:host
  | src/java/com/cloudrobotics/tokenvendor/cloudiot/CloudIotPublicKeyRepository.java:73: error: [FloggerLogString] Arguments to log(String) must be compile-time constants or parameters annotated with @CompileTimeConstant. If possible, use Flogger's formatting log methods instead.
  | logger.atSevere().withCause(e).log(message);
  | ^
  | src/java/com/cloudrobotics/tokenvendor/cloudiot/CloudIotPublicKeyRepository.java:164: error: [FloggerLogString] Arguments to log(String) must be compile-time constants or parameters annotated with @CompileTimeConstant. If possible, use Flogger's formatting log methods instead.
  | logger.atSevere().withCause(e).log(message);
  | ^
  | src/java/com/cloudrobotics/tokenvendor/cloudiot/CloudIotPublicKeyRepository.java:190: error: [FloggerLogString] Arguments to log(String) must be compile-time constants or parameters annotated with @CompileTimeConstant. If possible, use Flogger's formatting log methods instead.
  | logger.atSevere().withCause(e).log(message);
```

Context: https://github.com/bazelbuild/bazel/issues/15219