### PR TITLE
Bump LLVM toolchain to Ubuntu 20.04

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    distribution = "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz",
+    distribution = "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz",
     llvm_version = "12.0.0",
     sysroot = {
         "linux-x86_64": "@com_googleapis_storage_chrome_linux_amd64_sysroot//:all_files",

--- a/bazel/rbe_config/config/BUILD
+++ b/bazel/rbe_config/config/BUILD
@@ -40,7 +40,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://gcr.io/cloud-robotics-releases/bazel-rbe-executor@sha256:3d35426a6b622ee2b01c62960df2b913829c07bd960604c6ace0c69538897cea",
+        "container-image": "docker://gcr.io/cloud-robotics-releases/bazel-rbe-executor@sha256:4f5e402f2856ae805cc1f13f3b3b362e4bbf368a923e55e3d9743188d8f9c23f",
         "OSFamily": "Linux",
     },
     parents = ["@local_config_platform//:host"],


### PR DESCRIPTION
16.04 is EOL. This modernizes the hermetic toolchain setup.

Thanks to some changes in how we build the corresponding RBE image, this also reduces its size >10x.