### PR TITLE
Allow running setup-robot with human-acl@ tokens

### DIFF
--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -139,6 +139,14 @@ resource "google_project_iam_member" "human-acl-object-viewer" {
   member  = "serviceAccount:${google_service_account.human-acl.email}"
 }
 
+# Allow pulling setup-robot container image from a private GCR.
+resource "google_project_iam_member" "human-acl-container-access" {
+  project = var.private_image_repositories[count.index]
+  count   = length(var.private_image_repositories)
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.human-acl.email}"
+}
+
 # Allow robot registration with the token vendor, which checks if the client's
 # token can "act as" the human-acl@ SA. We need this binding even if the
 # client provided a token for the human-acl@ SA itself.


### PR DESCRIPTION
To reduce the privilege of the token you run setup-robot with, it's safer to give it a token for the human-acl@ SA rather than your own account. However, this currently prevents it from pulling setup-robot from a private GCR, which breaks the dev workflow. Adding this ACL fixes it.