### PR TITLE
Also patch the default/default SA.

### DIFF
--- a/src/go/cmd/metadata-server/BUILD.bazel
+++ b/src/go/cmd/metadata-server/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     srcs = [
         "coredns.go",
         "main.go",
-        "metadata.go"
+        "metadata.go",
     ],
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/metadata-server",
     visibility = ["//visibility:private"],


### PR DESCRIPTION
A change to the order in which we update the GCR credentials introduced a bug that prevented us from running pods with images from a private GCR in the default namespace, which is triggered when setting up a new cluster pointed at a CRC dev project.

The BUILD.bazel change was required by the pre-commit hook.