### PR TITLE
Use a consistent args style in all yaml files.

### DIFF
--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -28,8 +28,8 @@ spec:
           region={{ .Values.region }},\
           use_tv_k8s_backend={{ .Values.use_tv_k8s_backend }},\
           use_tv_verbose={{ .Values.use_tv_verbose }}"
-        - "--webhook-port=9876"
-        - "--cert-dir=/tls"
+        - --webhook-port=9876
+        - --cert-dir=/tls
         env:
         - name: GOOGLE_CLOUD_PROJECT
           value: {{ .Values.project }}

--- a/src/app_charts/base/robot/app-management.yaml
+++ b/src/app_charts/base/robot/app-management.yaml
@@ -17,11 +17,11 @@ spec:
       - name: chart-assignment-controller
         image: {{ .Values.registry }}{{ .Values.images.chart_assignment_controller }}
         args:
-        - "--cloud-cluster=false"
-        - "--webhook-enabled={{ .Values.webhook.enabled }}"
-        - "--webhook-port=9876"
-        - "--cert-dir=/tls"
-        - "--trace-stackdriver-project-id={{ .Values.project }}"
+        - --cloud-cluster=false
+        - --webhook-enabled={{ .Values.webhook.enabled }}
+        - --webhook-port=9876
+        - --cert-dir=/tls
+        - --trace-stackdriver-project-id={{ .Values.project }}
         env:
         - name: GOOGLE_CLOUD_PROJECT
           value: {{ .Values.project }}

--- a/src/app_charts/base/robot/cr-syncer.yaml
+++ b/src/app_charts/base/robot/cr-syncer.yaml
@@ -15,15 +15,12 @@ spec:
     spec:
       containers:
       - name: cr-syncer
-        args:
-        - -remote-server
-        - {{ .Values.domain }}
-        - --robot-name
-        - "{{ .Values.robot.name }}"
-        - -alsologtostderr
-        - --verbose=false
-        - --listen-address=:8080
         image: {{ .Values.registry }}{{ .Values.images.cr_syncer }}
+        args:
+        - --listen-address=:8080
+        - --remote-server={{ .Values.domain }}
+        - --robot-name={{ .Values.robot.name }}
+        - --verbose=false
         ports:
         - name: http
           containerPort: 8080

--- a/src/app_charts/base/robot/gcr-credential-refresher.yaml
+++ b/src/app_charts/base/robot/gcr-credential-refresher.yaml
@@ -16,8 +16,7 @@ spec:
       containers:
       - image: {{ .Values.registry }}{{ .Values.images.gcr_credential_refresher }}
         args:
-        - --robot_id_file
-        - /credentials/robot-id.json
+        - --robot_id_file=/credentials/robot-id.json
         name: gcr-credential-refresher
         resources:
           requests:

--- a/src/app_charts/base/robot/metadata-server.yaml
+++ b/src/app_charts/base/robot/metadata-server.yaml
@@ -28,12 +28,9 @@ spec:
       - name: metadata-server
         image: {{ .Values.registry }}{{ .Values.images.metadata_server }}
         args:
-        - --port
-        - "8965"
-        - --robot_id_file
-        - /credentials/robot-id.json
-        - --source_cidr
-        - "{{ .Values.pod_cidr }}"
+        - --port=8965
+        - --robot_id_file=/credentials/robot-id.json
+        - --source_cidr={{ .Values.pod_cidr }}
         env:
         - name: BIND_IP
           value: "127.0.0.1"

--- a/src/app_charts/token-vendor/cloud/token-vendor.yaml
+++ b/src/app_charts/token-vendor/cloud/token-vendor.yaml
@@ -15,34 +15,33 @@ spec:
       containers:
       - name: token-vendor
         image: {{ .Values.registry }}{{ .Values.images.token_vendor_go }}
+        args:
+        - --project={{ .Values.project }}
+        - --accepted_audience=https://{{ .Values.domain }}/apis/core.token-vendor/v1/token.oauth2
+        - --service_account=robot-service
+        # This scope is for token vendor and for access to GCS/GCR.
+        - --scope=https://www.googleapis.com/auth/cloud-platform
+        # This scope allows GKE RBAC policy bindings to refer to service accounts by email.
+        # https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#forbidden_error_for_service_accounts_on_vm_instances
+        - --scope=https://www.googleapis.com/auth/userinfo.email
+{{- if .Values.use_tv_verbose }}
+        - --verbose,
+{{- end }}
+{{- if eq .Values.deploy_environment "GCP-testing" }}
+        - --key-store=IN_MEMORY,
+{{- else }}
+  {{- if .Values.use_tv_k8s_backend }}
+        - --key-store=KUBERNETES
+        - --namespace=app-token-vendor
+  {{- else }}
+        - --key-store=CLOUD_IOT
+        - --region={{ .Values.region }}
+        - --registry=cloud-robotics
+  {{- end }}
+{{- end }}
         ports:
         - name: token-vendor
           containerPort: 9090
-        args: [
-          "--project", "{{ .Values.project }}",
-          "--accepted_audience", "https://{{ .Values.domain }}/apis/core.token-vendor/v1/token.oauth2",
-          "--service_account", "robot-service",
-          # This scope is for token vendor and for access to GCS/GCR.
-          "--scope", "https://www.googleapis.com/auth/cloud-platform",
-          # This scope allows GKE RBAC policy bindings to refer to service accounts by email.
-          # https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#forbidden_error_for_service_accounts_on_vm_instances
-          "--scope", "https://www.googleapis.com/auth/userinfo.email",
-{{- if .Values.use_tv_verbose }}
-        "--verbose",
-{{- end }}
-{{- if eq .Values.deploy_environment "GCP-testing" }}
-        "--key-store", "IN_MEMORY",
-{{- else }}
-  {{- if .Values.use_tv_k8s_backend }}
-          "--key-store", "KUBERNETES",
-          "--namespace", "app-token-vendor",
-  {{- else }}
-          "--key-store", "CLOUD_IOT",
-          "--region", "{{ .Values.region }}",
-          "--registry", "cloud-robotics",
-  {{- end }}
-{{- end }}
-        ]
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Use a compact and readable one line per flag form. Drop unnecesary quoting before it gets copied even more.

Also drop "-alsologtostderr" for crsyncer which was never defined.