### PR TITLE
cr-syncer: Preserve observedGeneration semantics

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudrobotics/core/src
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go v0.105.0 // indirect

--- a/src/go/cmd/cr-syncer/BUILD.bazel
+++ b/src/go/cmd/cr-syncer/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     embed = [":go_default_library"],
     visibility = ["//visibility:private"],
     deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/client/clientset/clientset/fake:go_default_library",

--- a/src/go/cmd/token-vendor/BUILD.bazel
+++ b/src/go/cmd/token-vendor/BUILD.bazel
@@ -1,12 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "main.go",
-    ],
+    srcs = ["main.go"],
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/token-vendor",
     visibility = ["//visibility:private"],
     deps = [
@@ -17,13 +15,10 @@ go_library(
         "//src/go/cmd/token-vendor/repository/k8s:go_default_library",
         "//src/go/cmd/token-vendor/repository/memory:go_default_library",
         "//src/go/cmd/token-vendor/tokensource:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//plugin/pkg/client/auth:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
-        "@io_k8s_client_go//tools/clientcmd:go_default_library",
-        "@io_k8s_client_go//util/homedir:go_default_library",
     ],
 )
 


### PR DESCRIPTION
The status's observedGeneration field lets a CR creator identify when a controller has updated the status to reflect a change in the spec. However, because it's tied to the generation field, which is managed by the apiserver, it can't be directly copied between two clusters. Instead, we can preserve the difference between generation and observedGeneration, allowing the CR creator to wait until generation==observedGeneration before looking at the status.

I also needed to bump to Go 1.18 to use `any`.