### PR TITLE
Also make iot-registry conditional.

### DIFF
--- a/src/bootstrap/cloud/terraform/iot_registry.tf
+++ b/src/bootstrap/cloud/terraform/iot_registry.tf
@@ -10,4 +10,5 @@ resource "google_cloudiot_registry" "cloud-robotics" {
     # Registry can be safely created without triggering the bug.
     google_container_cluster.cloud-robotics,
   ]
+  count = var.use_cloudiot ? 1 : 0
 }

--- a/src/bootstrap/cloud/terraform/workload-identity.tf
+++ b/src/bootstrap/cloud/terraform/workload-identity.tf
@@ -32,6 +32,7 @@ resource "google_project_iam_member" "token_vendor_cloudiot_provisioner" {
   project = data.google_project.project.project_id
   role    = "roles/cloudiot.provisioner"
   member  = "serviceAccount:${google_service_account.token_vendor.email}"
+  count = var.use_cloudiot ? 1 : 0
 }
 
 # Note: the policy in service-account.tf allows the token-vendor to create


### PR DESCRIPTION
Otherwise terraform deployment fails if the iot-api is not available.