### PR TITLE
Move master-host to an annotation

### DIFF
--- a/scripts/robot-sim.sh
+++ b/scripts/robot-sim.sh
@@ -72,13 +72,9 @@ function create {
   gcloud container clusters get-credentials "${ROBOT_NAME}" \
     --zone=${GCP_ZONE} --project=${GCP_PROJECT_ID}
 
-  # This ensures the 'cloudrobotics.com/master-host' label will point to the VM
-  local CLUSTER_IP
-  CLUSTER_IP=$(gcloud compute instances list --project="${GCP_PROJECT_ID}" --filter "name~gke-${ROBOT_NAME}-default-pool.*" --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
-
   # shellcheck disable=2097 disable=2098
   KUBE_CONTEXT=${GKE_SIM_CONTEXT} \
-  HOST_HOSTNAME=${CLUSTER_IP} \
+  HOST_HOSTNAME="nic0.${ROBOT_NAME}${GCP_ZONE}.c.${GCP_PROJECT_ID}.internal.gcpnode.com" \
   ACCESS_TOKEN=$(gcloud auth application-default print-access-token) \
     $DIR/../src/bootstrap/robot/setup_robot.sh \
     ${ROBOT_NAME} \

--- a/src/go/cmd/setup-robot/main.go
+++ b/src/go/cmd/setup-robot/main.go
@@ -351,10 +351,11 @@ func installChartOrDie(ctx context.Context, cs *kubernetes.Clientset, domain, re
 }
 
 func createOrUpdateRobot(ctx context.Context, k8sDynamicClient dynamic.Interface, labels map[string]string, annotations map[string]string) error {
+	const masterHost = "cloudrobotics.com/master-host"
 	labels["cloudrobotics.com/robot-name"] = *robotName
 	host := os.Getenv("HOST_HOSTNAME")
-	if host != "" && labels["cloudrobotics.com/master-host"] == "" {
-		labels["cloudrobotics.com/master-host"] = host
+	if host != "" && annotations[masterHost] == "" {
+		annotations[masterHost] = host
 	}
 	crc_version := os.Getenv("CRC_VERSION")
 	if crc_version != "" {


### PR DESCRIPTION
This allows for longer hostnames, in particular those of GCE instances. This doesn't delete the old label, because that's hard with the default "merge labels" behavior of CreateOrUpdateRobot(), so it's easier to manually migrate the labels.

@Ongy 