### PR TITLE
Add early exit if we already cleaned up the iot-registry.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -240,6 +240,7 @@ function cleanup_helm_data {
 function cleanup_iot_devices {
   gcloud services list --project="${GCP_PROJECT_ID}" | grep -q cloudiot.googleapis.com || return
   local iot_registry_name="cloud-robotics"
+  gcloud beta iot registries list --project="${GCP_PROJECT_ID}" --region="${GCP_REGION}" | grep -q "${iot_registry_name}" || return
   local devices
   devices=$(gcloud beta iot devices list \
     --project "${GCP_PROJECT_ID}" \


### PR DESCRIPTION
This hides a noisy error we'd print on subsequent runs.