### PR TITLE
Get base images for go builds independent of rules_docker version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,10 +151,27 @@ load("@io_bazel_rules_docker//cc:image.bzl", _cc_image_repos = "repositories")
 
 _cc_image_repos()
 
-# Containerization rules for Go must come after go_rules_dependencies().
-load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
+# oci_rules is configured to pull rules_docker go base images
+# The configuration was copied from the release documentation at
+# https://github.com/bazel-contrib/rules_oci/releases/tag/v0.3.9 and then slightly
+# modified to remove duplicate calls already present in this file.
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
-_go_image_repos()
+rules_oci_dependencies()
+
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "LATEST_ZOT_VERSION", "oci_register_toolchains")
+
+oci_register_toolchains(
+    name = "oci",
+    crane_version = LATEST_CRANE_VERSION,
+)
+
+# This section replaces the standard @io_bazel_rules_docker//go:image.bzl `repositories` macro to be able
+# to define base image versions independent of rules_docker version.
+# Containerization rules for Go must come after go_rules_dependencies().
+load("//bazel:base_images.bzl", _go_base_images = "go_base_images")
+
+_go_base_images()
 
 # grafana dashboards for nginx ingress controller
 

--- a/bazel/base_images.bzl
+++ b/bazel/base_images.bzl
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_docker//repositories:go_repositories.bzl", _go_deps = "go_deps")
+load("@rules_oci//oci:pull.bzl", "oci_pull")
+
+def go_base_images():
+    # This call is technically optional but is included here for safety as it is idempotent and required,
+    _go_deps()
+
+    oci_pull(
+        name = "go_image_base",
+        digest = "sha256:e711a716d8b7fe9c4f7bbf1477e8e6b451619fcae0bc94fdf6109d490bf6cea0",
+        image = "gcr.io/distroless/base",
+    )
+    oci_pull(
+        name = "go_debug_image_base",
+        digest = "sha256:357bc96a42d8db2e4710d8ae6257da3a66b1243affc03932438710a53a8d1ac6",
+        image = "gcr.io/distroless/base",
+    )
+    oci_pull(
+        name = "go_image_static",
+        digest = "sha256:e711a716d8b7fe9c4f7bbf1477e8e6b451619fcae0bc94fdf6109d490bf6cea0",
+        image = "gcr.io/distroless/static",
+    )
+    oci_pull(
+        name = "go_debug_image_static",
+        digest = "sha256:357bc96a42d8db2e4710d8ae6257da3a66b1243affc03932438710a53a8d1ac6",
+        image = "gcr.io/distroless/static",
+    )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -84,6 +84,20 @@ def cloud_robotics_repositories():
         urls = ["https://github.com/bazelbuild/buildtools/archive/5.1.0.tar.gz"],
     )
 
+    # Rules to perform OCI operations.
+    # This is currently only used to pulled base images to build images with. rules_docker and rules_go are the ones
+    # that actually do the heavy lifting when building images.
+    _maybe(
+        http_archive,
+        name = "rules_oci",
+        sha256 = "f6125c9a123a2ac58fb6b13b4b8d4631827db9cfac025f434bbbefbd97953f7c",
+        strip_prefix = "rules_oci-0.3.9",
+        urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v0.3.9/rules_oci-v0.3.9.tar.gz"],
+    )
+
 def _maybe(repo_rule, name, **kwargs):
+    """
+    Runs a named rule if a target with the rule name hasn't already been defined.
+    """
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)


### PR DESCRIPTION
Closes issue #130.

This PR alters the bazel build to use `rules_oci` to pull go base images using a version that's decoupled for the `rules_docker` version. This allows for us to update the base image version without having to depend on `rules_docker`.

The latest version of both the `base` and `static` distroless version was used to avoid unexpected breakages. 

Note that `oci_rules` `pull` supports using the `latest` tag. The macro that pulls base images can be configured to always pull the latest images and be up to date if we are okay with assuming the potential upstream breakage risks it introduces.
