### PR TITLE
Flip the CR_SYNCER_RBAC to be `true` by default

### DIFF
--- a/scripts/include-config.sh
+++ b/scripts/include-config.sh
@@ -57,6 +57,6 @@ function include_config {
   CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT=${CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT:-GCP}
   check_var_is_one_of CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT "GCP" "GCP-testing"
 
-  CR_SYNCER_RBAC=${CR_SYNCER_RBAC:-false}
+  CR_SYNCER_RBAC=${CR_SYNCER_RBAC:-true}
   check_var_is_one_of CR_SYNCER_RBAC "true" "false"
 }


### PR DESCRIPTION
We've used the new setting in many places for a long time. This change is a preparation to drop the option.