### PR TITLE
Update Go base images

### DIFF
--- a/bazel/base_images.bzl
+++ b/bazel/base_images.bzl
@@ -21,7 +21,7 @@ def go_base_images():
     # 2. If you have downloaded the image, you can run
     #    `docker inspect <image> | grep RepoDigests -A2`
     #    and copy the digest.
-    # 3. Go to `gcr.io/distroless/base` in a browser and select the image you want. The digest will be listed along
+    # 3. Go to `<image>` in a browser and select the image you want. The digest will be listed along
     #    some other fields.
     #
     # Note that `oci_pull` supports tags if we ever want to use them.

--- a/bazel/base_images.bzl
+++ b/bazel/base_images.bzl
@@ -28,21 +28,21 @@ def go_base_images():
     # Example: image = "gcr.io/distroless/base:latest"
     oci_pull(
         name = "go_image_base",
-        digest = "sha256:e711a716d8b7fe9c4f7bbf1477e8e6b451619fcae0bc94fdf6109d490bf6cea0",
+        digest = "sha256:df13a91fd415eb192a75e2ef7eacf3bb5877bb05ce93064b91b83feef5431f37",
         image = "gcr.io/distroless/base",
     )
     oci_pull(
         name = "go_debug_image_base",
-        digest = "sha256:357bc96a42d8db2e4710d8ae6257da3a66b1243affc03932438710a53a8d1ac6",
+        digest = "sha256:b57f14dff8aac3e09a24fa55d64fb6d36b95bdadead01a4c0b45e55d656e586b",
         image = "gcr.io/distroless/base",
     )
     oci_pull(
         name = "go_image_static",
-        digest = "sha256:e711a716d8b7fe9c4f7bbf1477e8e6b451619fcae0bc94fdf6109d490bf6cea0",
+        digest = "sha256:7198a357ff3a8ef750b041324873960cf2153c11cc50abb9d8d5f8bb089f6b4e",
         image = "gcr.io/distroless/static",
     )
     oci_pull(
         name = "go_debug_image_static",
-        digest = "sha256:357bc96a42d8db2e4710d8ae6257da3a66b1243affc03932438710a53a8d1ac6",
+        digest = "sha256:18740b995b4eac1b5706392a96ff8c4f30cefac18772058a71449692f1581f0f",
         image = "gcr.io/distroless/static",
     )


### PR DESCRIPTION
Base Go images have been updated to use the latest versions. Images for `gcr.io/distroless/base` and `gcr.io/distroless/static` have been updated.