### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,7 @@ jobs:
           # From https://cloud.google.com/sdk/docs/install#deb
           echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
             | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
-          sudo wget -q https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-            -O /usr/share/keyrings/cloud.google.gpg
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
           sudo apt-get update -y
           sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 


### PR DESCRIPTION
# Description
The release workflow is broken.
[See failing job ❌](https://github.com/googlecloudrobotics/core/actions/runs/5076304373/jobs/9118356457)

```
Err:6 https://packages.cloud.google.com/apt cloud-sdk InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
Reading package lists...
W: GPG error: https://packages.cloud.google.com/apt cloud-sdk InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B[53](https://github.com/googlecloudrobotics/core/actions/runs/5076304373/jobs/9118356457#step:5:54)DC80D13EDEF05
E: The repository 'https://packages.cloud.google.com/apt cloud-sdk InRelease' is not signed.
Error: Process completed with exit code 100.
```

This is a potential fix.
I will be running the release workflow with this branch to validate.

---

**Update 1:** This fix got us further than before, but the release workflow is still broken.
[See failing run ❌](https://github.com/googlecloudrobotics/core/actions/runs/5084736376/jobs/9137398879)

```
Error: Provider produced inconsistent result after apply

When applying changes to
google_project_iam_member.robot-service-roles["roles/cloudtrace.agent"],
provider "registry.terraform.io/-/google" produced an unexpected new value for
was present, but now absent.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.

+2023-05-25 21:27:30+00:00:./deploy.sh:240: die 'terraform apply failed'
+2023-05-25 21:27:30+00:00:/tmp/tmp.ZO8MouQCCG/cloud-robotics-core/scripts/common.sh:18: echo 'terraform apply failed'
terraform apply failed
+2023-05-
```

**Update 2**: Rerunning the workflow got it to work without me changing anything, so I'm just going to take the win 😬 
[See passing run ✅](https://github.com/googlecloudrobotics/core/actions/runs/5084736376)

# tl;dr

**tl;dr**: Release workflow broke starting from a week ago, I fixed it.
But for some reason the release workflow needs to be run twice (if there is a change) before it succeeds.

![image](https://github.com/googlecloudrobotics/core/assets/20265670/e9061bb0-87b1-44d2-b72d-2194448249ac)
