### PR TITLE
Update ingress-nginx to 1.8.0

### DIFF
--- a/METADATA
+++ b/METADATA
@@ -4,7 +4,7 @@ third_party {
   # https://nvd.nist.gov/products/cpe/search
   security {
     tag: "NVD-CPE2.3:cpe:/a:grafana:grafana:9.1.17"
-    tag: "NVD-CPE2.3:cpe:/a:kubernetes:ingress-nginx:1.2.1"
+    tag: "NVD-CPE2.3:cpe:/a:kubernetes:ingress-nginx:1.8.0"
     tag: "NVD-CPE2.3:cpe:/a:oauth2_proxy_project:oauth2_proxy:7.3.0"
     tag: "NVD-CPE2.3:cpe:/a:prometheus:prometheus:2.39.1"
   }

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -178,9 +178,9 @@ _go_base_images()
 http_archive(
     name = "ingress-nginx",
     build_file = "//third_party:ingress-nginx.BUILD",
-    sha256 = "719a7a54fe8156a38075eb99f82819b661ff117a2b043b41c1f560aaf71d4a09",
-    strip_prefix = "ingress-nginx-1b1f7d30a39f71cd9fe9f7191258e983dcb159c6",
+    sha256 = "6e571764828b24545eea49582fd56d66d51fc66e52a375d98251c80c57fdb2fc",
+    strip_prefix = "ingress-nginx-controller-v1.8.0",
     urls = [
-        "https://github.com/kubernetes/ingress-nginx/archive/1b1f7d30a39f71cd9fe9f7191258e983dcb159c6.tar.gz",
+        "https://github.com/kubernetes/ingress-nginx/archive/refs/tags/controller-v1.8.0.tar.gz",
     ],
 )

--- a/current_versions.txt
+++ b/current_versions.txt
@@ -1,6 +1,6 @@
 {
   "cert-manager": "1.7.2",
-  "ingress-nginx": "1.2.1",
+  "ingress-nginx": "1.8.0",
   "oauth2-proxy": "7.3.0",
   "stackdriver-logging-agent": "1.9.5"
 }

--- a/new_versions.txt
+++ b/new_versions.txt
@@ -1,6 +1,6 @@
 {
-  "cert-manager": "1.10.0",
-  "ingress-nginx": "1.5.1",
+  "cert-manager": "1.12.1",
+  "ingress-nginx": "1.8.0",
   "oauth2-proxy": "7.4.0",
-  "stackdriver-logging-agent": "1.9.9"
+  "stackdriver-logging-agent": "1.10.0"
 }

--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -7,6 +7,9 @@ newver = "new_versions.txt"
 
 [ingress-nginx]
 source = "container"
+# As of 2023-06-09, nvchecker is not compatible with registry.k8s.io, which
+# doesn't return the WWW-Authenticate header that nvchecker expects, so you get
+# UnsupportedAuthenticationError.
 registry = "k8s.gcr.io"
 container = "ingress-nginx/controller"
 prefix = "v"

--- a/src/app_charts/base/cloud/nginx-ingress-controller-policy.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller-policy.yaml
@@ -37,14 +37,42 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
-      - networking.k8s.io   # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resourceNames:
+      - ingress-controller-leader
+    resources:
+      - leases
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
   - apiGroups:
       - ''
     resources:
@@ -53,20 +81,13 @@ rules:
       - create
       - patch
   - apiGroups:
-      - extensions
-      - networking.k8s.io   # k8s 1.14+
+      - discovery.k8s.io
     resources:
-      - ingresses/status
+      - endpointslices
     verbs:
-      - update
-  - apiGroups:
-      - networking.k8s.io   # k8s 1.14+
-    resources:
-      - ingressclasses
-    verbs:
-      - get
       - list
       - watch
+      - get
 ---
 # Source: ingress-nginx/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,6 +127,13 @@ rules:
       - list
       - watch
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - list
+      - watch
+  - apiGroups:
       - ''
     resources:
       - services
@@ -114,8 +142,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
-      - networking.k8s.io   # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
@@ -123,20 +150,27 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
-      - networking.k8s.io   # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:
       - update
   - apiGroups:
-      - networking.k8s.io   # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingressclasses
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
+      - get
   - apiGroups:
       - ''
     resources:

--- a/src/app_charts/base/cloud/nginx-ingress-controller.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller.yaml
@@ -31,7 +31,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: nginx-ingress-controller
-          image: k8s.gcr.io/ingress-nginx/controller-chroot:v1.2.1
+          image: registry.k8s.io/ingress-nginx/controller-chroot:v1.8.0@sha256:a45e41cd2b7670adf829759878f512d4208d0aec1869dae593a0fecd09a5e49e
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
This pulls in an Alpine update which should fix some CVE warnings. The newer release is incompatible with k8s 1.23 but GKE has auto-updated to 1.24 everywhere now 1.23 is EOL.

I changed the RBAC policy based on the v1.3.0 release notes (needs permission for coordination.k8s.io/leases). Don't ask me why upstream added it to both the Role and the ClusterRole.
https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.3.0

Tested by deploying to robco-rodrigoq and checking the nginx dashboards in Grafana.