### PR TITLE
Build the relay url just once.

### DIFF
--- a/src/go/cmd/http-relay-client/main.go
+++ b/src/go/cmd/http-relay-client/main.go
@@ -109,20 +109,12 @@ var (
 	ErrForbidden = errors.New(http.StatusText(http.StatusForbidden))
 )
 
-func getRequest(remote *http.Client) (*pb.HttpRequest, error) {
+func getRequest(remote *http.Client, relayURL string) (*pb.HttpRequest, error) {
 	if debugLogs {
 		log.Printf("Connecting to relay server to get next request for %s", *serverName)
 	}
-	query := url.Values{}
-	query.Add("server", *serverName)
-	relayURL := url.URL{
-		Scheme:   *relayScheme,
-		Host:     *relayAddress,
-		Path:     *relayPrefix + "/server/request",
-		RawQuery: query.Encode(),
-	}
 
-	resp, err := remote.Get(relayURL.String())
+	resp, err := remote.Get(relayURL)
 	if err != nil {
 		return nil, err
 	}
@@ -474,8 +466,8 @@ func handleRequest(remote *http.Client, local *http.Client, req *pb.HttpRequest)
 	}
 }
 
-func localProxy(remote *http.Client, local *http.Client) error {
-	req, err := getRequest(remote)
+func localProxy(remote, local *http.Client, relayURL string) error {
+	req, err := getRequest(remote, relayURL)
 	if err != nil {
 		if errors.Is(err, ErrTimeout) {
 			return err
@@ -491,15 +483,27 @@ func localProxy(remote *http.Client, local *http.Client) error {
 	return nil
 }
 
-func localProxyWorker(remote *http.Client, local *http.Client) {
+func localProxyWorker(remote, local *http.Client, relayURL string) {
 	log.Printf("Starting to relay server request loop for %s", *serverName)
 	for {
-		err := localProxy(remote, local)
+		err := localProxy(remote, local, relayURL)
 		if err != nil && !errors.Is(err, ErrTimeout) {
 			log.Print(err)
 			time.Sleep(1 * time.Second)
 		}
 	}
+}
+
+func buildRelayURL() string {
+	query := url.Values{}
+	query.Add("server", *serverName)
+	relayURL := url.URL{
+		Scheme:   *relayScheme,
+		Host:     *relayAddress,
+		Path:     *relayPrefix + "/server/request",
+		RawQuery: query.Encode(),
+	}
+	return relayURL.String()
 }
 
 func main() {
@@ -586,10 +590,13 @@ func main() {
 		},
 		Transport: transport,
 	}
+
+	relayURL := buildRelayURL()
+
 	wg := new(sync.WaitGroup)
 	wg.Add(*numPendingRequests)
 	for i := 0; i < *numPendingRequests; i++ {
-		go localProxyWorker(remote, local)
+		go localProxyWorker(remote, local, relayURL)
 	}
 	// Waiting for all goroutines to finish (they never do)
 	wg.Wait()

--- a/src/go/cmd/http-relay-client/main_test.go
+++ b/src/go/cmd/http-relay-client/main_test.go
@@ -27,6 +27,8 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
+var defaultRelayURL = buildRelayURL()
+
 func assertMocksDoneWithin(t *testing.T, d time.Duration) {
 	for start := time.Now(); time.Since(start) < d; {
 		if gock.IsDone() {
@@ -98,7 +100,7 @@ func TestLocalProxy(t *testing.T) {
 		Body(bytes.NewReader(resp)).
 		Reply(200)
 
-	err := localProxy(&http.Client{}, &http.Client{})
+	err := localProxy(&http.Client{}, &http.Client{}, defaultRelayURL)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -143,7 +145,7 @@ func TestBackendError(t *testing.T) {
 		Body(bytes.NewReader(resp)).
 		Reply(200)
 
-	err := localProxy(&http.Client{}, &http.Client{})
+	err := localProxy(&http.Client{}, &http.Client{}, defaultRelayURL)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -171,7 +173,7 @@ func TestServerTimeout(t *testing.T) {
 		Reply(408).
 		BodyString(string(req))
 
-	err := localProxy(&http.Client{}, &http.Client{})
+	err := localProxy(&http.Client{}, &http.Client{}, defaultRelayURL)
 	if err != ErrTimeout {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
The relay url is build from commandline flags and cannot change during runtime. Build it just once and reuse.

Besides that it should make the code more readable, it will also help latency and lower GC pressure.