### PR TITLE
apps: allow versioned inline apps

### DIFF
--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -79,6 +79,33 @@ spec:
     name: cluster-authority
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: app-rollout-controller
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/app-rollout-controller
+webhooks:
+- name: apps.apps.cloudrobotics.com
+  admissionReviewVersions: ["v1"]
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: app-rollout-controller
+      path: /app/mutate
+  rules:
+  - apiGroups:
+    - apps.cloudrobotics.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apps
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: app-rollout-controller

--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -104,14 +104,6 @@ webhooks:
     resources:
     - apps
   sideEffects: None
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: app-rollout-controller
-  annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/app-rollout-controller
-webhooks:
 - name: approllouts.apps.cloudrobotics.com
   admissionReviewVersions: ["v1"]
   failurePolicy: Fail

--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -79,7 +79,7 @@ spec:
     name: cluster-authority
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
   name: app-rollout-controller
   annotations:
@@ -92,7 +92,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace }}
       name: app-rollout-controller
-      path: /app/mutate
+      path: /app/validate
   rules:
   - apiGroups:
     - apps.cloudrobotics.com

--- a/src/go/cmd/app-rollout-controller/main.go
+++ b/src/go/cmd/app-rollout-controller/main.go
@@ -92,6 +92,7 @@ func runController(ctx context.Context, cfg *rest.Config, params map[string]inte
 	srv.CertDir = *certDir
 
 	srv.Register("/approllout/validate", approllout.NewValidationWebhook(mgr))
+	srv.Register("/app/mutate", approllout.NewMutatingWebhook(mgr))
 
 	return mgr.Start(signals.SetupSignalHandler())
 }

--- a/src/go/cmd/app-rollout-controller/main.go
+++ b/src/go/cmd/app-rollout-controller/main.go
@@ -91,8 +91,8 @@ func runController(ctx context.Context, cfg *rest.Config, params map[string]inte
 	srv := mgr.GetWebhookServer()
 	srv.CertDir = *certDir
 
-	srv.Register("/approllout/validate", approllout.NewValidationWebhook(mgr))
-	srv.Register("/app/mutate", approllout.NewMutatingWebhook(mgr))
+	srv.Register("/approllout/validate", approllout.NewAppRolloutValidationWebhook(mgr))
+	srv.Register("/app/validate", approllout.NewAppValidationWebhook(mgr))
 
 	return mgr.Start(signals.SetupSignalHandler())
 }

--- a/src/go/pkg/controller/approllout/BUILD.bazel
+++ b/src/go/pkg/controller/approllout/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
         "//src/go/pkg/apis/registry/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_helm//pkg/chartutil:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -756,7 +756,7 @@ func appValidate(cur *apps.App) error {
 	appName, anok := cur.Labels[labelAppName]
 	appVersion, avok := cur.Labels[labelAppVersion]
 	if anok {
-		if avok {
+		if avok && appVersion != "" {
 			// both name and version are defined
 			ename := strings.ToLower(fmt.Sprintf("%s.v%s", appName, appVersion))
 			if ename != name {

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -273,6 +273,16 @@ func (r *Reconciler) reconcile(ctx context.Context, ar *apps.AppRollout) (reconc
 		// if we needed it, it will fail in generateChartAssignments
 		app := apps.App{}
 		if err := r.kube.Get(ctx, kclient.ObjectKey{Name: ar.Spec.AppName}, &app); err == nil {
+			// If we're here, the App is both:
+			// - app.Name == ar.Spec.AppName.
+			// - not found using the app-name label. This object is a copy so
+			// we can just write the label in there, so generateChartAssignments
+			// can safely assume the label is always there.
+			if app.Labels == nil {
+				app.Labels = map[string]string{}
+			}
+			app.Labels[labelAppName] = app.Name
+			app.Labels[labelAppVersion] = ""
 			al.Items = append(al.Items, app)
 		}
 	}

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"encoding/json"
 	"net/http"
 	"reflect"
 	"sort"
@@ -228,7 +227,11 @@ func (r *Reconciler) reconcile(ctx context.Context, ar *apps.AppRollout) (reconc
 	log.Printf("Reconcile AppRollout %q (version: %s)", ar.Name, ar.ResourceVersion)
 
 	// Apply spec.
-	var curCAs apps.ChartAssignmentList
+	var (
+		curCAs apps.ChartAssignmentList
+		al     apps.AppList
+		robots registry.RobotList
+	)
 
 	ar.Status.ObservedGeneration = ar.Generation
 	ar.Status.Assignments = 0
@@ -236,12 +239,45 @@ func (r *Reconciler) reconcile(ctx context.Context, ar *apps.AppRollout) (reconc
 	ar.Status.ReadyAssignments = 0
 	ar.Status.FailedAssignments = 0
 
+	// TODO(coconutruben): consider moving these into a testable function.
+	// Moving them into generateChartAssignments requires rewriting the
+	// existing tests.
 	err := r.kube.List(ctx, &curCAs, kclient.MatchingFields(map[string]string{fieldIndexOwners: string(ar.UID)}))
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "list ChartAssignments for owner UID %s", ar.UID)
 	}
 
-	wantCAs, err := r.generateChartAssignments(ctx, ar, r.baseValues)
+	if err := r.kube.List(ctx, &robots); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "list all Robots")
+	}
+
+	if err := r.kube.List(ctx, &al, kclient.MatchingLabels{labelAppName: ar.Spec.AppName}); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "list all App Versions")
+	}
+
+	// There might be old Apps laying around that do not conform to this
+	// methodology yet. However, those Apps also do not use the version
+	// mechanism. Therefore, we can just look for that App once, and put
+	// it into our map if it's not there yet.
+	appFound := func(name string) bool {
+		for idx := range al.Items {
+			if al.Items[idx].Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !appFound(ar.Spec.AppName) {
+		// We might not need the canonical app at all, if all the rollout
+		// entries are asking for versioned apps. Do not fail here yet,
+		// if we needed it, it will fail in generateChartAssignments
+		app := apps.App{}
+		if err := r.kube.Get(ctx, kclient.ObjectKey{Name: ar.Spec.AppName}, &app); err == nil {
+			al.Items = append(al.Items, app)
+		}
+	}
+
+	wantCAs, err := generateChartAssignments(al.Items, robots.Items, ar, r.baseValues)
 	if err != nil {
 		if _, ok := errors.Cause(err).(errRobotSelectorOverlap); ok {
 			return reconcile.Result{}, r.updateErrorStatus(ctx, ar, err.Error())
@@ -399,57 +435,48 @@ func (r errRobotSelectorOverlap) Error() string {
 
 // generateChartAssignments returns a list of all cloud and robot ChartAssignments
 // for the given app, its rollout, and set of robots.
-func (r *Reconciler) generateChartAssignments(
-	ctx context.Context,
+func generateChartAssignments(
+	al []apps.App,
+	robots []registry.Robot,
 	rollout *apps.AppRollout,
 	baseValues chartutil.Values,
 ) ([]*apps.ChartAssignment, error) {
-
 
 	var (
 		// Different entries might request different app versions. This map
 		// is used to only retrieve them once.
 		appVersions = map[string]*apps.App{}
-		appVersionsList apps.AppList
-		robots registry.RobotList
-		cas   []*apps.ChartAssignment
+		cas         []*apps.ChartAssignment
 		// Robots that matched selectors for the rollout and which will be
 		// passed to the cloud chart.
 		selectedRobots = map[string]*registry.Robot{}
 	)
 
-	if err := r.kube.List(ctx, &robots); err != nil {
-		return nil, errors.Wrap(err, "list all Robots")
-	}
-
-	if err := r.kube.List(ctx, &appVersionsList, kclient.MatchingLabels{labelAppName: rollout.Spec.AppName}); err != nil {
-		return nil, errors.Wrap(err, "list all App Versions")
-	}
-	for _, app := range appVersionsList.Items {
-		appVersions[app.Labels[labelAppVersion]] = &app
-	}
-
-
-	// There might be old Apps laying around that do not conform to this
-	// methodology yet. However, those Apps also do not use the version
-	// mechanism. Therefore, we can just look for that App once, and put
-	// it into our map if it's not there yet.
-	if _, ok := appVersions[""]; !ok {
-		app := apps.App{}
-		if err := r.kube.Get(ctx, kclient.ObjectKey{Name: rollout.Spec.AppName}, &app); err == nil {
-			appVersions[""] = &app
+	for _, app := range al {
+		v, ok := app.Labels[labelAppVersion]
+		if !ok {
+			// If only app-name is defined, it is an unversioned app.
+			v = ""
+		}
+		if _, ok := appVersions[v]; ok {
+			log.Printf("App %q version %q already known. Going to ignore App Object %q for the same app/version", rollout.Spec.AppName, v, app.Name)
+		} else {
+			// only add to map if this is the first time we're adding this
+			// version for the app. The validator should ensure that this
+			// overwrite cannot happen, but apps might be legacy, or have
+			// bypassed validation.
+			appVersions[v] = &app
 		}
 	}
-
 	for _, rcomp := range rollout.Spec.Robots {
-		robots, err := matchingRobots(robots.Items, rcomp.Selector)
+		robots, err := matchingRobots(robots, rcomp.Selector)
 		if err != nil {
 			return nil, errors.Wrap(err, "select robots")
 		}
 		// map is populated by for all the rcomp.Version, no need to check ok
-		app , ok := appVersions[rcomp.Version]
+		app, ok := appVersions[rcomp.Version]
 		if !ok {
-			return nil, errors.Wrap(err, fmt.Sprintf("no App %q (Version: %q) found", rollout.Spec.AppName, rcomp.Version))
+			return nil, fmt.Errorf("no App %q (Version: %q) found", rollout.Spec.AppName, rcomp.Version)
 		}
 		comps := app.Spec.Components
 		for i := range robots {
@@ -666,74 +693,78 @@ func indexAppName(o kclient.Object) []string {
 	return []string{ar.Spec.AppName}
 }
 
-// NewMutatingWebhook returns a new webhook that standardizes Apps.
-//
-// Apps can be a version of a canonical app. This is a naming convention
-// where an App named [App].v[something] is [App] version [something]
-// This hook sets known labels on the object to make indentifying those
-// apps easier in the reconciliation.
-func NewMutatingWebhook(mgr manager.Manager) *admission.Webhook {
-	return &admission.Webhook{Handler: newAppVersionLabelSetter(mgr.GetScheme())}
-}
-
-func newAppVersionLabelSetter(sc *runtime.Scheme) *appVersionLabelSetter {
-	return &appVersionLabelSetter{
-		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
-	}
-}
-
-// appVersionLabelSetter implements a version label setting webhook.
-type appVersionLabelSetter struct {
-	decoder runtime.Decoder
-}
-
-func (v *appVersionLabelSetter) Handle(_ context.Context, req admission.Request) admission.Response {
-	cur := &apps.App{}
-
-	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	if err := v.label(cur); err != nil {
-		return admission.Denied(err.Error())
-	}
-	craw, err := json.Marshal(cur)
-	if err != nil {
-		return admission.Denied(err.Error())
-	}
-	return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, craw)
-}
-
 const (
 	// canonical name of an app
 	labelAppName = "cloudrobotics.com/app-name"
 	// version of that app. Note, the default version of the app has
 	// a version label of ""
-	labelAppVersion    = "cloudrobotics.com/app-version"
+	labelAppVersion = "cloudrobotics.com/app-version"
 )
 
-// label will use the labels above to create version and canonical app
-// labels
-func (v *appVersionLabelSetter) label(cur *apps.App) error {
-	if cur.ObjectMeta.Labels == nil {
-		cur.ObjectMeta.Labels = map[string]string{}
-	}
-	parts := strings.Split(cur.Name, ".v")
-	switch len(parts) {
-	case 1:
-		cur.ObjectMeta.Labels[labelAppName] = parts[0]
-		cur.ObjectMeta.Labels[labelAppVersion] = ""
-	case 2:
-		cur.ObjectMeta.Labels[labelAppName] = parts[0]
-		cur.ObjectMeta.Labels[labelAppVersion] = parts[1]
-	default:
-		return fmt.Errorf("AppName %q invalid", cur.Name)
+// NewAppValidationWebhook returns a new webhook that validates Apps.
+//
+// This pertains to multiple versions of the same app, so that the labels
+// defined above are in sync with the name of the App.
+// The policy is
+// - an unversioned app defines
+//   - cloudrobotics.com/app-name
+//   - (optionally): cloudrobotics.com/app-version with a "" value
+//     this must match the name of the object
+//
+// - a versioned app defines
+//   - cloudrobotics.com/app-name
+//   - cloudrobotics.com/app-version
+//     the name of the App object must match LOWERCASE([app-name].v[app-version])
+func NewAppValidationWebhook(mgr manager.Manager) *admission.Webhook {
+	return &admission.Webhook{Handler: newAppValidator(mgr.GetScheme())}
+}
 
+// appValidator implements a validation webhook.
+type appValidator struct {
+	decoder runtime.Decoder
+}
+
+func newAppValidator(sc *runtime.Scheme) *appValidator {
+	return &appValidator{
+		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
 	}
+}
+
+func (v *appValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	cur := &apps.App{}
+	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if err := appValidate(cur); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+func appValidate(cur *apps.App) error {
+	name := cur.Name
+	appName, anok := cur.Labels[labelAppName]
+	appVersion, avok := cur.Labels[labelAppVersion]
+	if anok {
+		if avok {
+			// both name and version are defined
+			ename := strings.ToLower(fmt.Sprintf("%s.v%s", appName, appVersion))
+			if ename != name {
+				return fmt.Errorf("%q=%q, %q=%q: expected object name %q, got %q", labelAppName, appName, labelAppVersion, appVersion, ename, name)
+			}
+		} else {
+			// only name is defined
+			if appName != name {
+				return fmt.Errorf("%q=%q, undefined %q: expected object name %q, got %q", labelAppName, appName, labelAppVersion, appName, name)
+			}
+		}
+	}
+	// neither is defined, we're dealing with a legacy app
 	return nil
 }
 
-// NewValidationWebhook returns a new webhook that validates AppRollouts.
-func NewValidationWebhook(mgr manager.Manager) *admission.Webhook {
+// NewAppRolloutValidationWebhook returns a new webhook that validates AppRollouts.
+func NewAppRolloutValidationWebhook(mgr manager.Manager) *admission.Webhook {
 	return &admission.Webhook{Handler: newAppRolloutValidator(mgr.GetScheme())}
 }
 
@@ -754,13 +785,13 @@ func (v *appRolloutValidator) Handle(_ context.Context, req admission.Request) a
 	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	if err := validate(cur); err != nil {
+	if err := appRolloutValidate(cur); err != nil {
 		return admission.Denied(err.Error())
 	}
 	return admission.Allowed("")
 }
 
-func validate(cur *apps.AppRollout) error {
+func appRolloutValidate(cur *apps.AppRollout) error {
 	if cur.Spec.AppName == "" {
 		return errors.New("app name missing")
 	}

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"sort"
@@ -227,32 +228,20 @@ func (r *Reconciler) reconcile(ctx context.Context, ar *apps.AppRollout) (reconc
 	log.Printf("Reconcile AppRollout %q (version: %s)", ar.Name, ar.ResourceVersion)
 
 	// Apply spec.
-	var (
-		app    apps.App
-		curCAs apps.ChartAssignmentList
-		robots registry.RobotList
-	)
+	var curCAs apps.ChartAssignmentList
+
 	ar.Status.ObservedGeneration = ar.Generation
 	ar.Status.Assignments = 0
 	ar.Status.SettledAssignments = 0
 	ar.Status.ReadyAssignments = 0
 	ar.Status.FailedAssignments = 0
 
-	err := r.kube.Get(ctx, kclient.ObjectKey{Name: ar.Spec.AppName}, &app)
-	if err != nil {
-		return reconcile.Result{}, r.updateErrorStatus(ctx, ar, err.Error())
-	}
-	err = r.kube.List(ctx, &curCAs, kclient.MatchingFields(map[string]string{fieldIndexOwners: string(ar.UID)}))
+	err := r.kube.List(ctx, &curCAs, kclient.MatchingFields(map[string]string{fieldIndexOwners: string(ar.UID)}))
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "list ChartAssignments for owner UID %s", ar.UID)
 	}
-	// NOTE(freinartz): consider pushing this down to generateChartAssignments
-	// and passing the robot selectors directly to the client.
-	if err := r.kube.List(ctx, &robots); err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "list all Robots")
-	}
 
-	wantCAs, err := generateChartAssignments(&app, ar, robots.Items, r.baseValues)
+	wantCAs, err := r.generateChartAssignments(ctx, ar, r.baseValues)
 	if err != nil {
 		if _, ok := errors.Cause(err).(errRobotSelectorOverlap); ok {
 			return reconcile.Result{}, r.updateErrorStatus(ctx, ar, err.Error())
@@ -410,24 +399,64 @@ func (r errRobotSelectorOverlap) Error() string {
 
 // generateChartAssignments returns a list of all cloud and robot ChartAssignments
 // for the given app, its rollout, and set of robots.
-func generateChartAssignments(
-	app *apps.App,
+func (r *Reconciler) generateChartAssignments(
+	ctx context.Context,
 	rollout *apps.AppRollout,
-	allRobots []registry.Robot,
 	baseValues chartutil.Values,
 ) ([]*apps.ChartAssignment, error) {
+
+	// A spec can also specify that it wants to use a specific version
+	// of the app, rather than the canonical version of it.
+	// In that case, there is a naming convention for the app.
+	// NOTE: if version is indicated, the versioned app has to exist, we
+	// do not fall back to the canonical app, as this would introduce hard
+	// to reason behavior and hard to debug bugs.
+	appName := func (name, version string) string {
+		switch version {
+		case "":
+			return name
+		default:
+			return fmt.Sprintf("%s.v%s", name, version)
+		}
+	}
+
 	var (
+		// Different entries might request different app versions. This map
+		// is used to only retrieve them once.
+		appVersions = map[string]*apps.App{}
+		appVersionsList apps.AppList
+		robots registry.RobotList
 		cas   []*apps.ChartAssignment
-		comps = app.Spec.Components
 		// Robots that matched selectors for the rollout and which will be
 		// passed to the cloud chart.
 		selectedRobots = map[string]*registry.Robot{}
 	)
+
+	if err := r.kube.List(ctx, &robots); err != nil {
+		return nil, errors.Wrap(err, "list all Robots")
+	}
+
+	// TODO(coconutruben): consider refactoring this into its own function
+	// and use labels to avoid with the search.
+	// Find all app versions used across rollout.
 	for _, rcomp := range rollout.Spec.Robots {
-		robots, err := matchingRobots(allRobots, rcomp.Selector)
+		app := apps.App{}
+		v := rcomp.Version
+		aname := appName(rollout.Spec.AppName, v)
+		if err := r.kube.Get(ctx, kclient.ObjectKey{Name: aname}, &app); err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("app %q (app: %q, version: %q", aname, app, v))
+		}
+		appVersions[v] = &app
+	}
+
+	for _, rcomp := range rollout.Spec.Robots {
+		robots, err := matchingRobots(robots.Items, rcomp.Selector)
 		if err != nil {
 			return nil, errors.Wrap(err, "select robots")
 		}
+		// map is populated by for all the rcomp.Version, no need to check ok
+		app := appVersions[rcomp.Version]
+		comps := app.Spec.Components
 		for i := range robots {
 			// Ensure we don't pass a pointer to the most recent loop item.
 			r := &robots[i]
@@ -442,17 +471,34 @@ func generateChartAssignments(
 			}
 		}
 	}
-	if comps.Cloud.Name != "" || comps.Cloud.Inline != "" {
-		// Turn robot map into a sorted slice so we produce deterministic outputs.
-		// (Go randomizes map iteration.)
-		robots := make([]*registry.Robot, 0, len(selectedRobots))
-		for _, r := range selectedRobots {
-			robots = append(robots, r)
+	// The cloud has has no version, just the canonical version. We might
+	// not have it due to no robot using it.
+	if _, ok := appVersions[""]; !ok {
+		appo := apps.App{}
+		if err := r.kube.Get(ctx, kclient.ObjectKey{Name: rollout.Spec.AppName}, &appo); err != nil {
+			// This could be fine, or could be an error. It's likely an issue
+			// if the rollout has cloud values, and we don't find the app. Print in those cases.
+			if rollout.Spec.Cloud.Values != nil {
+				log.Printf("No canonical version of App %q. There won't be a Cloud ChartAssignment. AppRollout %q defines cloud values: %v", rollout.Spec.AppName, rollout.Name, err)
+			}
+		} else {
+			appVersions[""] = &appo
 		}
-		sort.Slice(robots, func(i, j int) bool {
-			return robots[i].Name < robots[j].Name
-		})
-		cas = append(cas, newCloudChartAssignment(app, rollout, baseValues, robots...))
+	}
+	if app, ok := appVersions[""]; ok {
+		comps := app.Spec.Components
+		if comps.Cloud.Name != "" || comps.Cloud.Inline != "" {
+			// Turn robot map into a sorted slice so we produce deterministic outputs.
+			// (Go randomizes map iteration.)
+			robots := make([]*registry.Robot, 0, len(selectedRobots))
+			for _, r := range selectedRobots {
+				robots = append(robots, r)
+			}
+			sort.Slice(robots, func(i, j int) bool {
+				return robots[i].Name < robots[j].Name
+			})
+			cas = append(cas, newCloudChartAssignment(app, rollout, baseValues, robots...))
+		}
 	}
 	sort.Slice(cas, func(i, j int) bool {
 		return cas[i].Name < cas[j].Name
@@ -633,6 +679,62 @@ func indexOwnerReferences(o kclient.Object) (vs []string) {
 func indexAppName(o kclient.Object) []string {
 	ar := o.(*apps.AppRollout)
 	return []string{ar.Spec.AppName}
+}
+
+// NewMutatingWebhook returns a new webhook that standardizes Apps.
+//
+// Apps can be a version of a canonical app. This is a naming convention
+// where an App named [App].v[something] is [App] version [something]
+// This hook sets known labels on the object to make indentifying those
+// apps easier in the reconciliation.
+func NewMutatingWebhook(mgr manager.Manager) *admission.Webhook {
+	return &admission.Webhook{Handler: newAppVersionLabelSetter(mgr.GetScheme())}
+}
+
+func newAppVersionLabelSetter(sc *runtime.Scheme) *appVersionLabelSetter {
+	return &appVersionLabelSetter{
+		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
+	}
+}
+
+// appVersionLabelSetter implements a version label setting webhook.
+type appVersionLabelSetter struct {
+	decoder runtime.Decoder
+}
+
+func (v *appVersionLabelSetter) Handle(_ context.Context, req admission.Request) admission.Response {
+	cur := &apps.App{}
+
+	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if err := v.label(cur); err != nil {
+		return admission.Denied(err.Error())
+	}
+	craw, err := json.Marshal(cur)
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, craw)
+}
+
+const (
+	// canonical name of an app
+	labelAppName = "cloudrobotics.com/app-name"
+	// version of that app. Note, the default version of the app has
+	// a version label of ""
+	labelAppVersion    = "cloudrobotics.com/app-version"
+)
+
+// label will use the labels above to create version and canonical app
+// labels
+func (v *appVersionLabelSetter) label(cur *apps.App) error {
+	if cur.ObjectMeta.Labels == nil {
+		cur.ObjectMeta.Labels = map[string]string{}
+	}
+	cur.ObjectMeta.Labels[labelAppVersion] = "test1"
+	cur.ObjectMeta.Labels[labelAppName] = "test2"
+	return nil
 }
 
 // NewValidationWebhook returns a new webhook that validates AppRollouts.

--- a/src/go/pkg/controller/approllout/controller_test.go
+++ b/src/go/pkg/controller/approllout/controller_test.go
@@ -323,33 +323,49 @@ spec:
 
 // generateApp will generate an app for testing
 func generateApp(name, version, robotPayload, cloudPayload string) apps.App {
-	app := apps.App{}
-	app.Name = name
-	app.Labels = map[string]string{
-		labelAppName:    name,
-		labelAppVersion: version,
+	return apps.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				labelAppName:    name,
+				labelAppVersion: version,
+			},
+		},
+		Spec: apps.AppSpec{
+			Components: apps.AppComponents{
+				Cloud: apps.AppComponent{
+					Name:   "cloud",
+					Inline: cloudPayload,
+				},
+				Robot: apps.AppComponent{
+					Name:   "robot",
+					Inline: robotPayload,
+				},
+			},
+		},
 	}
-	app.Spec.Components.Cloud.Name = "cloud"
-	app.Spec.Components.Cloud.Inline = cloudPayload
-	app.Spec.Components.Robot.Name = "robot"
-	app.Spec.Components.Robot.Inline = robotPayload
-	return app
 }
 
 // generateRobot will generate a robot named |name| with the labels
 func generateRobot(name string, labels map[string]string) registry.Robot {
-	robot := registry.Robot{}
-	robot.Name = name
-	robot.Labels = labels
-	return robot
+	return registry.Robot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
 }
 
 // generateRollout will create a rollout pointing at AppName
 func generateRollout(name, appName string) apps.AppRollout {
-	rollout := apps.AppRollout{}
-	rollout.Name = name
-	rollout.Spec.AppName = appName
-	return rollout
+	return apps.AppRollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: apps.AppRolloutSpec{
+			AppName: appName,
+		},
+	}
 }
 
 // addRobotToRollout will add a robot component with the match label & version.

--- a/src/go/pkg/controller/chartassignment/validator.go
+++ b/src/go/pkg/controller/chartassignment/validator.go
@@ -81,7 +81,7 @@ func (v *chartAssignmentValidator) validate(cur, old *apps.ChartAssignment) erro
 	c := cur.Spec.Chart
 	if c.Inline != "" {
 		if c.Repository != "" || c.Name != "" {
-			return fmt.Errorf("chart repository, name, and version must be empty for inline charts")
+			return fmt.Errorf("chart repository, and name must be empty for inline charts")
 		}
 	} else if c.Repository == "" || c.Name == "" || c.Version == "" {
 		return fmt.Errorf("non-inline chart must be fully specified")

--- a/src/go/pkg/controller/chartassignment/validator.go
+++ b/src/go/pkg/controller/chartassignment/validator.go
@@ -80,7 +80,7 @@ func (v *chartAssignmentValidator) validate(cur, old *apps.ChartAssignment) erro
 	}
 	c := cur.Spec.Chart
 	if c.Inline != "" {
-		if c.Repository != "" || c.Name != "" || c.Version != "" {
+		if c.Repository != "" || c.Name != "" {
 			return fmt.Errorf("chart repository, name, and version must be empty for inline charts")
 		}
 	} else if c.Repository == "" || c.Name == "" || c.Version == "" {


### PR DESCRIPTION
This change enables inline apps to be versioned as well.
It does so by adopting a label and naming convention,
and using the Version attribute in the Robot selector of
AppRollouts to fetch a different App depending on the version.
It finds those versioned apps using labels, and has a validator to
ensure app names and labels don't drift too far from each other.

Lastly, this change adds unit tests to test the new behavior.

Note: this removes a check in the chartassignment validator, namely that Inline
can now coexist with Version.

TEST=go test ./...
TEST=deploy to intrinsic-coconutruben
