### PR TITLE
Fix path to image push script

### DIFF
--- a/.github/ci/common.sh
+++ b/.github/ci/common.sh
@@ -88,7 +88,7 @@ function release_binary {
 
   # The tag variable must be called 'TAG', see cloud-robotics/bazel/container_push.bzl
   for t in latest ${DOCKER_TAG}; do
-    bazel-bin/src/go/cmd/setup-robot/setup-robot.push \
+    bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh \
       --repository="${CLOUD_ROBOTICS_CONTAINER_REGISTRY}/setup-robot" \
       --tag="${t}"
     TAG="$t" bazel-bin/src/app_charts/push "${CLOUD_ROBOTICS_CONTAINER_REGISTRY}"

--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -63,7 +63,7 @@ lock
 # `set +x` avoids log spam and makes error messages more obvious.
 trap 'set +x; finalize_and_unlock' EXIT
 
-export BAZEL_FLAGS="--bazelrc=${DIR}/rbe.bazelrc"
+export BAZEL_FLAGS="--bazelrc=${DIR}/.bazelrc"
 bash -x .//deploy.sh update robco-integration-test
 
 DOMAIN=${CLOUD_ROBOTICS_DOMAIN:-"www.endpoints.${GCP_PROJECT_ID}.cloud.goog"}


### PR DESCRIPTION
After https://github.com/googlecloudrobotics/core/pull/163 this file was no longer present, which manifests as a broken postsubmit: https://console.cloud.google.com/cloud-build/builds;region=europe-west1/a9a2ed28-0966-49ae-acb4-5e6b11187010;step=1?project=robco-integration-test

Also fixing a missing rename in https://github.com/googlecloudrobotics/core/pull/159

Postsubmit passes with this PR: https://pantheon.corp.google.com/cloud-build/builds;region=europe-west1/6e67162e-b19d-435a-8726-15c3bf202255?project=robco-integration-test