### PR TITLE
More fixes post OCI migration

### DIFF
--- a/.github/ci/common.sh
+++ b/.github/ci/common.sh
@@ -86,13 +86,19 @@ function release_binary {
       //src/app_charts:push \
       //src/go/cmd/setup-robot:setup-robot.push
 
+  # The push scripts depends on binaries in the runfiles.
+  local oldPwd=$(pwd)
   # The tag variable must be called 'TAG', see cloud-robotics/bazel/container_push.bzl
   for t in latest ${DOCKER_TAG}; do
-    bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh \
+    cd ${oldPwd}/bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh.runfiles/cloud_robotics
+    ${oldPwd}/bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh \
       --repository="${CLOUD_ROBOTICS_CONTAINER_REGISTRY}/setup-robot" \
       --tag="${t}"
-    TAG="$t" bazel-bin/src/app_charts/push "${CLOUD_ROBOTICS_CONTAINER_REGISTRY}"
+
+    cd ${oldPwd}/bazel-bin/src/app_charts/push.runfiles/cloud_robotics
+    TAG="$t" ${oldPwd}/bazel-bin/src/app_charts/push "${CLOUD_ROBOTICS_CONTAINER_REGISTRY}"
   done
+  cd ${oldPwd}
 
   gsutil cp -a public-read \
       bazel-bin/src/bootstrap/cloud/crc-binary.tar.gz \

--- a/.github/ci/common.sh
+++ b/.github/ci/common.sh
@@ -87,7 +87,8 @@ function release_binary {
       //src/go/cmd/setup-robot:setup-robot.push
 
   # The push scripts depends on binaries in the runfiles.
-  local oldPwd=$(pwd)
+  local oldPwd
+  oldPwd=$(pwd)
   # The tag variable must be called 'TAG', see cloud-robotics/bazel/container_push.bzl
   for t in latest ${DOCKER_TAG}; do
     cd ${oldPwd}/bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh.runfiles/cloud_robotics

--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -144,6 +144,6 @@ bazel_ci test \
 
 # If this is running on main (ie, not a manual run) then update the `latest`
 # binary.
-# if [[ "$MANUAL_RUN" == "false" ]] ; then
+if [[ "$MANUAL_RUN" == "false" ]] ; then
   release_binary "robco-ci-binary-builds" "crc-${BUILD_IDENTIFIER}" "latest"
-# fi
+fi

--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -144,6 +144,6 @@ bazel_ci test \
 
 # If this is running on main (ie, not a manual run) then update the `latest`
 # binary.
-if [[ "$MANUAL_RUN" == "false" ]] ; then
+# if [[ "$MANUAL_RUN" == "false" ]] ; then
   release_binary "robco-ci-binary-builds" "crc-${BUILD_IDENTIFIER}" "latest"
-fi
+# fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -125,7 +125,7 @@ function terraform_init {
   fi
 
   local ROBOT_IMAGE_DIGEST
-  ROBOT_IMAGE_DIGEST=$(grep -Eo 'sha256:.{,64}' bazel-bin/src/go/cmd/setup-robot/setup-robot-image/index.json)
+  ROBOT_IMAGE_DIGEST=$(grep -Eo 'sha256:.{,64}' bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh.runfiles/cloud_robotics/src/go/cmd/setup-robot/setup-robot-image/index.json)
 
   # We only need to create dns resources if a custom domain is used.
   local CUSTOM_DOMAIN

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,6 +70,7 @@ function prepare_source_install {
       //src/app_charts/base:base-cloud \
       //src/app_charts/platform-apps:platform-apps-cloud \
       //src/app_charts:push \
+      //src/bootstrap/cloud:setup-robot.digest \
       //src/go/cmd/setup-robot:setup-robot.push \
       //src/go/cmd/synk
 
@@ -125,7 +126,7 @@ function terraform_init {
   fi
 
   local ROBOT_IMAGE_DIGEST
-  ROBOT_IMAGE_DIGEST=$(grep -Eo 'sha256:.{,64}' bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh.runfiles/cloud_robotics/src/go/cmd/setup-robot/setup-robot-image/index.json)
+  ROBOT_IMAGE_DIGEST=$(cat bazel-bin/src/bootstrap/cloud/setup-robot.digest)
 
   # We only need to create dns resources if a custom domain is used.
   local CUSTOM_DOMAIN


### PR DESCRIPTION
I missed this in https://github.com/googlecloudrobotics/core/pull/186.

Now tested by actually running this part of the code too: https://github.com/googlecloudrobotics/core/actions/runs/5655155089
https://github.com/googlecloudrobotics/core/actions/runs/5655020052

How we read the setup robot digest also needed to change, as the `.json` was not part of the binary distribution. I manually checked that `bazel-bin/src/bootstrap/cloud/setup-robot.digest` and `src/go/cmd/setup-robot/setup-robot-image/index.json` contains the same digest.