### PR TITLE
Set max idle connections per host also for oauth connections.

### DIFF
--- a/src/go/cmd/http-relay-client/BUILD.bazel
+++ b/src/go/cmd/http-relay-client/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_x_net//context:go_default_library",
         "@org_golang_x_net//http2:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
         "@org_golang_x_oauth2//google:go_default_library",
     ],
 )


### PR DESCRIPTION
This resolves issues where we were leaking connections which resulted in TIME_WAIT sockets.