### PR TITLE
Add HPA to the nginx-ingress-controller

### DIFF
--- a/src/app_charts/base/cloud/nginx-ingress-controller.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller.yaml
@@ -37,6 +37,10 @@ spec:
               exec:
                 command:
                   - /wait-shutdown
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: 1
           args:
             - /nginx-ingress-controller
             - --v=1
@@ -127,6 +131,25 @@ metadata:
     ingressclass.kubernetes.io/is-default-class: "true"
 spec:
   controller: k8s.io/ingress-nginx
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx-ingress-controller
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx-ingress-controller
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Why?
This allows the nginx-ingress-controller to scale horizontally when under load. Load is directly correlated to cpu usage in the case of the nginx-ingress-controller