### PR TITLE
Enable vertical autoscaling on GKE.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -103,16 +103,13 @@ function terraform_exec {
 }
 
 function terraform_cleanup {
-  # Terraform doesn't seem to remove node pool taints without recreating the
-  # node pool, whereas this approach causes less downtime.
-  pool=(base-pool "--cluster=cloud-robotics" "--zone=${GCP_ZONE}" "--project=${GCP_PROJECT_ID}")
-  if [[ -n "$(gcloud container node-pools describe "${pool[@]}" --format 'value(config.taints)')" ]] ; then
-    gcloud beta container node-pools update "${pool[@]}" --quiet \
-      --no-enable-autoscaling
-    gcloud beta container node-pools update "${pool[@]}" --quiet \
-      --node-taints=""
-    gcloud beta container node-pools update "${pool[@]}" --quiet \
-      --enable-autoscaling --min-nodes=2 --max-nodes=10
+  # Terraform doesn't seem to handle changes to vertical_pod_autoscaling for
+  # existing clusters, so apply the change with gcloud.
+  cluster=(cloud-robotics "--zone=${GCP_ZONE}" "--project=${GCP_PROJECT_ID}")
+  if [[ -z "$(gcloud container clusters describe "${cluster[@]}" --format 'value(verticalPodAutoscaling.enabled)')" ]] ; then
+    echo "Enabling vertical pod autoscaling in the GKE cluster. This can take a few minutes..."
+    gcloud container clusters update "${cluster[@]}" --quiet \
+      --enable-vertical-pod-autoscaling
   fi
 }
 

--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -60,6 +60,10 @@ resource "google_container_cluster" "cloud-robotics-ar" {
     delete = "1h"
   }
 
+  vertical_pod_autoscaling {
+    enabled = true
+  }
+
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }

--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -57,18 +57,18 @@ resource "google_project_iam_member" "robot-service-account-container-access" {
 }
 
 resource "google_project_iam_member" "robot-service-roles" {
-  project  = data.google_project.project.project_id
-  member   = "serviceAccount:${google_service_account.robot-service.email}"
+  project = data.google_project.project.project_id
+  member  = "serviceAccount:${google_service_account.robot-service.email}"
   for_each = toset([
-    "roles/cloudtrace.agent",      # Upload cloud traces
+    "roles/cloudtrace.agent", # Upload cloud traces
     # Unused by the cloud-robotics stack, but existing users might need to carefully migrate
     "roles/datastore.user",
-    "roles/logging.logWriter",      # Upload text logs to Cloud logging
+    "roles/logging.logWriter", # Upload text logs to Cloud logging
     # Required to use robot-service@ for GKE clusters that simulate robots
-    "roles/monitoring.viewer",      
+    "roles/monitoring.viewer",
     "roles/storage.objectAdmin",
   ])
-  role     = each.value
+  role = each.value
 }
 
 resource "google_project_iam_member" "robot-service-kubernetes" {

--- a/src/bootstrap/cloud/terraform/workload-identity.tf
+++ b/src/bootstrap/cloud/terraform/workload-identity.tf
@@ -32,7 +32,7 @@ resource "google_project_iam_member" "token_vendor_cloudiot_provisioner" {
   project = data.google_project.project.project_id
   role    = "roles/cloudiot.provisioner"
   member  = "serviceAccount:${google_service_account.token_vendor.email}"
-  count = var.use_cloudiot ? 1 : 0
+  count   = var.use_cloudiot ? 1 : 0
 }
 
 # Note: the policy in service-account.tf allows the token-vendor to create


### PR DESCRIPTION
This will be useful for pods that we can't easily scale horizontally and
are tolerant of downtime. Also, reformat the Terraform files to make the
pre-commit hook happy.
