### PR TITLE
Revert "Add option to configure Kubernetes QPS limit. (#206)"

### DIFF
--- a/src/go/cmd/token-vendor/main.go
+++ b/src/go/cmd/token-vendor/main.go
@@ -64,7 +64,7 @@ var (
 		"key-store",
 		string(Kubernetes),
 		"Public key repository implementation to use. Options: "+strings.Join(keyStoreOpts, ","))
-	k8sQPS = flag.Int("k8s-qps", 25, "Limit of QPS to the Kubernetes API server.")
+
 	// API options
 	bind     = flag.String("bind", "0.0.0.0", "Address to bind to")
 	port     = flag.Int("port", 9090, "Port number to listen on")
@@ -104,7 +104,6 @@ func main() {
 		if err != nil {
 			log.Panic(err)
 		}
-		config.QPS = float32(*k8sQPS)
 		cs, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			log.Panic(err)


### PR DESCRIPTION
This reverts commit 38fec517958adcd03371e5a8ffc6a5a4769ca6fa. It causes
token-vendor to panic with `"burst is required to be greater than 0 when
RateLimiter is not set and QPS is set to greater than 0"`.
