### PR TITLE
Add option to configure Kubernetes QPS limit (fixed burst parameter)

### DIFF
--- a/src/go/cmd/token-vendor/main.go
+++ b/src/go/cmd/token-vendor/main.go
@@ -65,6 +65,7 @@ var (
 		string(Kubernetes),
 		"Public key repository implementation to use. Options: "+strings.Join(keyStoreOpts, ","))
 	k8sQPS = flag.Int("k8s-qps", 25, "Limit of QPS to the Kubernetes API server.")
+	k8sBurst = flag.Int("k8s-burst", 50, "Burst limit of QPS to the Kubernetes API server.")
 	// API options
 	bind     = flag.String("bind", "0.0.0.0", "Address to bind to")
 	port     = flag.Int("port", 9090, "Port number to listen on")
@@ -105,6 +106,7 @@ func main() {
 			log.Panic(err)
 		}
 		config.QPS = float32(*k8sQPS)
+		config.Burst = *k8sBurst
 		cs, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			log.Panic(err)

--- a/src/go/cmd/token-vendor/main.go
+++ b/src/go/cmd/token-vendor/main.go
@@ -64,7 +64,7 @@ var (
 		"key-store",
 		string(Kubernetes),
 		"Public key repository implementation to use. Options: "+strings.Join(keyStoreOpts, ","))
-
+	k8sQPS = flag.Int("k8s-qps", 25, "Limit of QPS to the Kubernetes API server.")
 	// API options
 	bind     = flag.String("bind", "0.0.0.0", "Address to bind to")
 	port     = flag.Int("port", 9090, "Port number to listen on")
@@ -104,6 +104,7 @@ func main() {
 		if err != nil {
 			log.Panic(err)
 		}
+		config.QPS = float32(*k8sQPS)
 		cs, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			log.Panic(err)


### PR DESCRIPTION
We have seen that on the integration test project the current default limit of 5 is reached.

This second iteration of the PR fixes the missing burst parameter.