### PR TITLE
Escape double quotes in release notes body

### DIFF
--- a/.github/ci/release_binary.sh
+++ b/.github/ci/release_binary.sh
@@ -47,7 +47,7 @@ output=$(curl -fsS \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/$REPO/releases/generate-notes \
   -d '{"tag_name":"'$RELEASE_NAME'","previous_tag_name":"'$PREVIOUS_RELEASE_NAME'"}')
-# Code newlines as literal \n and escape double quotes to make curl happy.
+# Code newlines as literal \n and escape double quotes to generate valid JSON.
 BODY="$(jq -r '.body'   <<< $output | awk '{printf "%s\\n", $0}' | sed 's/"/\\"/g')"
 echo "Generated release notes for $RELEASE_NAME"
 


### PR DESCRIPTION
Attempt to fix current failures in e.g. https://github.com/googlecloudrobotics/core/actions/runs/5947260705/job/16129080081.

Tested by running the GitHub release creation part locally from this branch.