### PR TITLE
Fixes issue #207

### DIFF
--- a/src/go/cmd/http-relay-server/server/BUILD.bazel
+++ b/src/go/cmd/http-relay-server/server/BUILD.bazel
@@ -31,8 +31,6 @@ go_test(
         "server_test.go",
     ],
     embed = [":go_default_library"],
-    # TODO(https://github.com/googlecloudrobotics/core/issues/207): fix
-    flaky = True,
     visibility = ["//visibility:private"],
     deps = [
         "//src/proto/http-relay:go_default_library",

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -69,7 +69,14 @@ func TestClientHandler(t *testing.T) {
 		}},
 		Body: []byte("body"),
 	}
-	relayRequest.Header = relayRequest.Header[:1]
+	// Remove the Traceparent header entry since we cannot assert on its value.
+	tempHeader := relayRequest.Header[:0]
+	for _, header := range relayRequest.Header {
+		if *header.Name != "Traceparent" {
+			tempHeader = append(tempHeader, header)
+		}
+	}
+	relayRequest.Header = tempHeader
 	if !proto.Equal(wantRequest, relayRequest) {
 		t.Errorf("Wrong encapsulated request; want %s; got '%s'", wantRequest, relayRequest)
 	}


### PR DESCRIPTION
After adding tracing, it was a wrong assumption to assume that the X-Deadline was stored as the first entry in a header. Manually removing the traceparent turns out to be the correct and reliable solution.