### PR TITLE
Remove unused permission from robot-service.

### DIFF
--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -61,8 +61,6 @@ resource "google_project_iam_member" "robot-service-roles" {
   member  = "serviceAccount:${google_service_account.robot-service.email}"
   for_each = toset([
     "roles/cloudtrace.agent", # Upload cloud traces
-    # Unused by the cloud-robotics stack, but existing users might need to carefully migrate
-    "roles/datastore.user",
     "roles/logging.logWriter", # Upload text logs to Cloud logging
     # Required to use robot-service@ for GKE clusters that simulate robots
     "roles/monitoring.viewer",


### PR DESCRIPTION
Projects that are build on-top of this infrastructure will need to add the permission as needed.