### PR TITLE
Fix handling of trailers in relay when chunking

### DIFF
--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -129,40 +129,55 @@ func extractBackendNameAndPath(r *http.Request) (backendName string, path string
 	return
 }
 
+type responseChunk struct {
+    Body []byte
+	Trailers []*pb.HttpHeader
+}
+
 // responseFilter enforces that there's at least one HttpResponse in the out
-// channel and that the first response has a status code. From the reposnses it
-// extracts and return headers, trailers, status-code and body data.
-func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*pb.HttpHeader, []*pb.HttpHeader, int, <-chan []byte) {
-	body := make(chan []byte, 1)
+// channel and that the first response has a status code. From the responses it
+// extracts it synchronously returns headers and status-code and asynchronously
+// returns body and trailers via a channel.
+func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*pb.HttpHeader, int, <-chan *responseChunk) {
+	responseChunks := make(chan *responseChunk, 1)
 	firstMessage, more := <-in
+
 	if !more {
 		brokerResponses.WithLabelValues("client", "missing_message", backendCtx.ServerName, backendCtx.Path).Inc()
-		body <- []byte(fmt.Sprintf("Timeout after %v, either the backend request took too long or the relay client died", inactiveRequestTimeout))
-		close(body)
-		return nil, nil, http.StatusInternalServerError, body
+		responseChunks <- &responseChunk{
+			Body: []byte(fmt.Sprintf("Timeout after %v, either the backend request took too long or the relay client died", inactiveRequestTimeout)),
+		}
+		close(responseChunks)
+		return nil, http.StatusInternalServerError, responseChunks
 	}
 	if firstMessage.StatusCode == nil {
 		brokerResponses.WithLabelValues("client", "missing_header", backendCtx.ServerName, backendCtx.Path).Inc()
-		body <- []byte("Received no header from relay client")
-		close(body)
+		responseChunks <- &responseChunk{
+			Body: []byte("Received no header from relay client"),
+		}
+		close(responseChunks)
 		// Flush remaining messages
 		for range in {
 		}
-		return nil, nil, http.StatusInternalServerError, body
+		return nil, http.StatusInternalServerError, responseChunks
 	}
-	body <- []byte(firstMessage.Body)
-	lastMessage := firstMessage
+
+    responseChunks <- &responseChunk{
+      Body: []byte(firstMessage.Body),
+	  Trailers: []*pb.HttpHeader(firstMessage.Trailer),
+	}
+
 	go func() {
 		for backendResp := range in {
 			brokerResponses.WithLabelValues("client", "ok", backendCtx.ServerName, backendCtx.Path).Inc()
-			body <- []byte(backendResp.Body)
-			lastMessage = backendResp
+			responseChunks <- &responseChunk{
+				Body: []byte(backendResp.Body),
+				Trailers: []*pb.HttpHeader(backendResp.Trailer),
+			}
 		}
-		close(body)
+        close(responseChunks)
 	}()
-	// TODO(haukeheibel): We are returning before the go-routine above finishes. How is
-	// lastMessage.Trailer different from firstMessage.Trailer?
-	return firstMessage.Header, lastMessage.Trailer, int(*firstMessage.StatusCode), body
+	return firstMessage.Header, int(*firstMessage.StatusCode), responseChunks
 }
 
 type backendContext struct {
@@ -195,7 +210,7 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 // bidirectionalStream handles a 101 Switching Protocols response from the
 // backend, by "hijacking" to get a bidirectional connection to the client,
 // and streaming data between client and broker/relay client.
-func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseWriter, response <-chan []byte) {
+func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseWriter, responseChunks <-chan *responseChunk) {
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "Backend returned 101 Switching Protocols, which is not supported by the relay server", http.StatusInternalServerError)
@@ -242,11 +257,11 @@ func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseW
 	}()
 
 	numBytes := 0
-	for bytes := range response {
+	for responseChunk := range responseChunks {
 		// TODO(b/130706300): detect dropped connection and end request in broker
-		_, _ = bufrw.Write(bytes)
+		_, _ = bufrw.Write(responseChunk.Body)
 		bufrw.Flush()
-		numBytes += len(bytes)
+		numBytes += len(responseChunk.Body)
 	}
 	log.Printf("[%s] Wrote %d response bytes to bidi-stream", backendCtx.Id, numBytes)
 }
@@ -291,12 +306,12 @@ func (s *Server) relayRequest(ctx context.Context, backendCtx backendContext, re
 	return backendRespChan, nil
 }
 
-func (s *Server) waitForFirstResponseAndHandleSwitching(ctx context.Context, backendCtx backendContext, w http.ResponseWriter, backendRespChan <-chan *pb.HttpResponse) ([]*pb.HttpHeader, []*pb.HttpHeader, <-chan []byte, bool) {
+func (s *Server) waitForFirstResponseAndHandleSwitching(ctx context.Context, backendCtx backendContext, w http.ResponseWriter, backendRespChan <-chan *pb.HttpResponse) ([]*pb.HttpHeader, <-chan *responseChunk, bool) {
 	_, span := trace.StartSpan(ctx, "Waiting for first response")
 	addServiceName(span)
 	defer span.End()
 
-	header, trailer, status, backendRespBodyChan := responseFilter(backendCtx, backendRespChan)
+	header, status, responseChunksChan := responseFilter(backendCtx, backendRespChan)
 	if header != nil {
 		unmarshalHeader(w, header)
 	}
@@ -307,13 +322,13 @@ func (s *Server) waitForFirstResponseAndHandleSwitching(ctx context.Context, bac
 		// bidirectionalStream can set the status on error.
 		// TODO(haukeheibel): I don't get this comment. We never write the
 		// header and just return.
-		s.bidirectionalStream(backendCtx, w, backendRespBodyChan)
-		return nil, nil, nil, true
+		s.bidirectionalStream(backendCtx, w, responseChunksChan)
+		return nil, nil, true
 	}
 
 	w.WriteHeader(status)
 
-	return header, trailer, backendRespBodyChan, false
+	return header, responseChunksChan, false
 }
 
 // This function is used to handle requests by the user-client.
@@ -365,7 +380,7 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	header, trailer, backendRespBodyChannel, done := s.waitForFirstResponseAndHandleSwitching(ctx, *backendCtx, w, backendRespChan)
+	header, responseChunksChan, done := s.waitForFirstResponseAndHandleSwitching(ctx, *backendCtx, w, backendRespChan)
 	if done {
 		return
 	}
@@ -377,13 +392,19 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 	// This code here will block until we have actually received a response from the backend,
 	// i.e. this will block until
 	numBytes := 0
-	for bytes := range backendRespBodyChannel {
+	for responseChunk := range responseChunksChan {
 		// TODO(b/130706300): detect dropped connection and end request in broker
-		_, _ = w.Write(bytes)
+		_, _ = w.Write(responseChunk.Body)
 		if flush, ok := w.(http.Flusher); ok {
 			flush.Flush()
 		}
-		numBytes += len(bytes)
+		numBytes += len(responseChunk.Body)
+
+		// Only the last chunk will actually contain trailers.
+		for _, h := range responseChunk.Trailers {
+			w.Header().Add(http.TrailerPrefix+*h.Name, *h.Value)
+			log.Printf("[%s] Adding real trailer: %q:%q", backendCtx.Id, *h.Name, *h.Value)
+		}
 	}
 
 	// TODO(ensonic): open questions:
@@ -393,12 +414,6 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(*h.Name, "Grpc-") {
 			w.Header().Add(http.TrailerPrefix+*h.Name, *h.Value)
 			log.Printf("[%s] Adding trailer from header: %q:%q", backendCtx.Id, *h.Name, *h.Value)
-		}
-	}
-	if trailer != nil {
-		for _, h := range trailer {
-			w.Header().Add(http.TrailerPrefix+*h.Name, *h.Value)
-			log.Printf("[%s] Adding real trailer: %q:%q", backendCtx.Id, *h.Name, *h.Value)
 		}
 	}
 

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -134,10 +134,10 @@ type responseChunk struct {
 	Trailers []*pb.HttpHeader
 }
 
-// responseFilter enforces that there's at least one HttpResponse in the out
-// channel and that the first response has a status code. From the responses it
-// extracts it synchronously returns headers and status-code and asynchronously
-// returns body and trailers via a channel.
+// responseFilter enforces that there's at least one HttpResponse in the 'in'
+// channel and that the first response has a status code. It collects the
+// responses and then returns headers and status-code. Additionally, it
+// returns body and trailers asynchronously via the returned channel.
 func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*pb.HttpHeader, int, <-chan *responseChunk) {
 	responseChunks := make(chan *responseChunk, 1)
 	firstMessage, more := <-in

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -130,7 +130,7 @@ func extractBackendNameAndPath(r *http.Request) (backendName string, path string
 }
 
 type responseChunk struct {
-    Body []byte
+	Body []byte
 	Trailers []*pb.HttpHeader
 }
 
@@ -141,7 +141,6 @@ type responseChunk struct {
 func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*pb.HttpHeader, int, <-chan *responseChunk) {
 	responseChunks := make(chan *responseChunk, 1)
 	firstMessage, more := <-in
-
 	if !more {
 		brokerResponses.WithLabelValues("client", "missing_message", backendCtx.ServerName, backendCtx.Path).Inc()
 		responseChunks <- &responseChunk{
@@ -162,9 +161,9 @@ func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*p
 		return nil, http.StatusInternalServerError, responseChunks
 	}
 
-    responseChunks <- &responseChunk{
-      Body: []byte(firstMessage.Body),
-	  Trailers: []*pb.HttpHeader(firstMessage.Trailer),
+	responseChunks <- &responseChunk{
+		Body: []byte(firstMessage.Body),
+		Trailers: []*pb.HttpHeader(firstMessage.Trailer),
 	}
 
 	go func() {
@@ -175,7 +174,7 @@ func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*p
 				Trailers: []*pb.HttpHeader(backendResp.Trailer),
 			}
 		}
-        close(responseChunks)
+		close(responseChunks)
 	}()
 	return firstMessage.Header, int(*firstMessage.StatusCode), responseChunks
 }

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -130,7 +130,7 @@ func extractBackendNameAndPath(r *http.Request) (backendName string, path string
 }
 
 type responseChunk struct {
-	Body []byte
+	Body     []byte
 	Trailers []*pb.HttpHeader
 }
 
@@ -162,7 +162,7 @@ func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*p
 	}
 
 	responseChunks <- &responseChunk{
-		Body: []byte(firstMessage.Body),
+		Body:     []byte(firstMessage.Body),
 		Trailers: []*pb.HttpHeader(firstMessage.Trailer),
 	}
 
@@ -170,7 +170,7 @@ func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*p
 		for backendResp := range in {
 			brokerResponses.WithLabelValues("client", "ok", backendCtx.ServerName, backendCtx.Path).Inc()
 			responseChunks <- &responseChunk{
-				Body: []byte(backendResp.Body),
+				Body:     []byte(backendResp.Body),
 				Trailers: []*pb.HttpHeader(backendResp.Trailer),
 			}
 		}

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -43,9 +43,77 @@ func checkResponse(t *testing.T, resp *http.Response, wantStatus int, wantBody s
 	if want, got := wantBody, string(body); want != got {
 		t.Errorf("Wrong body; want %s; got %s", want, got)
 	}
-}
+} 
 
 func TestClientHandler(t *testing.T) {
+	req := httptest.NewRequest("GET", "/client/foo/bar?a=b#c", strings.NewReader("body"))
+	req.Header.Add("X-Deadline", "now")
+	respRecorder := httptest.NewRecorder()
+	server := NewServer()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() { server.userClientRequest(respRecorder, req); wg.Done() }()
+	relayRequest, err := server.b.GetRequest(context.Background(), "foo", "/")
+	if err != nil {
+		t.Errorf("Error when getting request: %v", err)
+	}
+
+	wantRequest := &pb.HttpRequest{
+		Id:     relayRequest.Id,
+		Method: proto.String("GET"),
+		Host:   proto.String("example.com"),
+		Url:    proto.String("http://invalid/bar?a=b#c"),
+		Header: []*pb.HttpHeader{{
+			Name:  proto.String("X-Deadline"),
+			Value: proto.String("now"),
+		}},
+		Body: []byte("body"),
+	}
+	// Remove the Traceparent header entry since we cannot assert on its value.
+	tempHeader := relayRequest.Header[:0]
+	for _, header := range relayRequest.Header {
+		if *header.Name != "Traceparent" {
+			tempHeader = append(tempHeader, header)
+		}
+	}
+	relayRequest.Header = tempHeader
+	if !proto.Equal(wantRequest, relayRequest) {
+		t.Errorf("Wrong encapsulated request; want %s; got '%s'", wantRequest, relayRequest)
+	}
+
+	server.b.SendResponse(&pb.HttpResponse{
+		Id:         relayRequest.Id,
+		StatusCode: proto.Int32(201),
+		Header: []*pb.HttpHeader{{
+			Name:  proto.String("X-GFE"),
+			Value: proto.String("google.com"),
+		}},
+		Body: []byte("thebody"),
+		Trailer: []*pb.HttpHeader{{
+			Name:  proto.String("Some-Trailer"),
+			Value: proto.String("trailer value"),
+		}},
+		Eof:  proto.Bool(true),
+	})
+
+	wg.Wait()
+	resp := respRecorder.Result()
+	checkResponse(t, resp, 201, "thebody")
+	if want, got := 1, len(resp.Header); want != got {
+		t.Errorf("Wrong # of headers; want %d; got %d", want, got)
+	}
+	if want, got := "google.com", resp.Header.Get("X-GFE"); want != got {
+		t.Errorf("Wrong header value; want %s; got %s", want, got)
+	}
+	if want, got := 1, len(resp.Trailer); want != got {
+		t.Errorf("Wrong # of trailers; want %d; got %d", want, got)
+	}
+	if want, got := "trailer value", resp.Trailer.Get("Some-Trailer"); want != got {
+		t.Errorf("Wrong trailer value; want %s; got %s", want, got)
+	}
+}
+
+func TestClientHandlerWithChunkedResponse(t *testing.T) {
 	req := httptest.NewRequest("GET", "/client/foo/bar?a=b#c", strings.NewReader("body"))
 	req.Header.Add("X-Deadline", "now")
 	respRecorder := httptest.NewRecorder()
@@ -94,6 +162,10 @@ func TestClientHandler(t *testing.T) {
 	server.b.SendResponse(&pb.HttpResponse{
 		Id:   relayRequest.Id,
 		Body: []byte("body"),
+		Trailer: []*pb.HttpHeader{{
+			Name:  proto.String("Some-Trailer"),
+			Value: proto.String("trailer value"),
+		}},
 		Eof:  proto.Bool(true),
 	})
 
@@ -105,6 +177,12 @@ func TestClientHandler(t *testing.T) {
 	}
 	if want, got := "google.com", resp.Header.Get("X-GFE"); want != got {
 		t.Errorf("Wrong header value; want %s; got %s", want, got)
+	}
+	if want, got := 1, len(resp.Trailer); want != got {
+		t.Errorf("Wrong # of trailers; want %d; got %d", want, got)
+	}
+	if want, got := "trailer value", resp.Trailer.Get("Some-Trailer"); want != got {
+		t.Errorf("Wrong trailer value; want %s; got %s", want, got)
 	}
 }
 

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -43,7 +43,7 @@ func checkResponse(t *testing.T, resp *http.Response, wantStatus int, wantBody s
 	if want, got := wantBody, string(body); want != got {
 		t.Errorf("Wrong body; want %s; got %s", want, got)
 	}
-} 
+}
 
 func TestClientHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/client/foo/bar?a=b#c", strings.NewReader("body"))

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -93,7 +93,7 @@ func TestClientHandler(t *testing.T) {
 			Name:  proto.String("Some-Trailer"),
 			Value: proto.String("trailer value"),
 		}},
-		Eof:  proto.Bool(true),
+		Eof: proto.Bool(true),
 	})
 
 	wg.Wait()
@@ -166,7 +166,7 @@ func TestClientHandlerWithChunkedResponse(t *testing.T) {
 			Name:  proto.String("Some-Trailer"),
 			Value: proto.String("trailer value"),
 		}},
-		Eof:  proto.Bool(true),
+		Eof: proto.Bool(true),
 	})
 
 	wg.Wait()

--- a/src/go/tests/relay/BUILD.bazel
+++ b/src/go/tests/relay/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     ],
     rundir = ".",
     deps = [
+        "//src/go/cmd/http-relay-client/client:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/src/go/tests/relay/nok8s_relay_test.go
+++ b/src/go/tests/relay/nok8s_relay_test.go
@@ -219,11 +219,11 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 }
 
 type relayWithGrpcServer struct {
-	Listener net.Listener
+	Listener   net.Listener
 	GrpcServer *grpc.Server
-	Relay *relay
-	Conn *grpc.ClientConn
-	Ctx context.Context
+	Relay      *relay
+	Conn       *grpc.ClientConn
+	Ctx        context.Context
 }
 
 func (r *relayWithGrpcServer) mustStop(t *testing.T) {
@@ -231,7 +231,7 @@ func (r *relayWithGrpcServer) mustStop(t *testing.T) {
 	r.GrpcServer.Stop()
 	if err := r.Relay.stop(); err != nil {
 		t.Fatal("failed to stop relay: ", err)
-	}a
+	}
 	r.Conn.Close()
 }
 
@@ -245,7 +245,7 @@ func mustStartRelayWithGrpcServer(t *testing.T, service testpb.TestServiceServer
 	result.Listener, err = net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
-	} 
+	}
 	result.GrpcServer = grpc.NewServer()
 	testpb.RegisterTestServiceServer(result.GrpcServer, service)
 	go result.GrpcServer.Serve(result.Listener)
@@ -271,7 +271,7 @@ func mustStartRelayWithGrpcServer(t *testing.T, service testpb.TestServiceServer
 // TestGrpcRelaySimpleCallWorks launches a local http relay (client + server), connects a
 // grpc service as backend and issues a simple call.
 func TestGrpcRelaySimpleCallWorks(t *testing.T) {
-	client, relayAndServer := mustStartRelayWithGrpcServer(t,  &testServer{})
+	client, relayAndServer := mustStartRelayWithGrpcServer(t, &testServer{})
 	defer relayAndServer.mustStop(t)
 
 	if _, err := client.EmptyCall(relayAndServer.Ctx, &testpb.Empty{}); err != nil {
@@ -288,12 +288,12 @@ func TestGrpcRelaySimpleCallWorks(t *testing.T) {
 // with a response that has to be chunked.
 func TestGrpcRelayChunkingOfLargeResponseWorks(t *testing.T) {
 	// Make responses from gRPC server larger than the default MaxChunkSize.
-	payload := make([]byte, client.DefaultClientConfig().MaxChunkSize * 5)
+	payload := make([]byte, client.DefaultClientConfig().MaxChunkSize*5)
 	for i := 0; i < len(payload); i++ {
 		payload[i] = byte(i) // Fill with non-zeroes
-	} 
+	}
 	testServer := &testServer{responsePayload: payload}
-	client, relayAndServer := mustStartRelayWithGrpcServer(t,  testServer)
+	client, relayAndServer := mustStartRelayWithGrpcServer(t, testServer)
 	defer relayAndServer.mustStop(t)
 
 	response, err := client.UnaryCall(relayAndServer.Ctx, &testpb.SimpleRequest{})
@@ -306,7 +306,7 @@ func TestGrpcRelayChunkingOfLargeResponseWorks(t *testing.T) {
 	}
 
 	if !bytes.Equal(response.Payload.Body, testServer.responsePayload) {
-		t.Errorf("Received payload not equal to payload returned by server.")	
+		t.Errorf("Received payload not equal to payload returned by server.")
 	}
 }
 
@@ -314,7 +314,7 @@ func TestGrpcRelayChunkingOfLargeResponseWorks(t *testing.T) {
 // grpc service as backend and issues a simple call.
 func TestGrpcRelayErrorArePropagated(t *testing.T) {
 	// UnimplementedTestServiceServer returns Unimplemented for all RPCs.
-	client, relayAndServer := mustStartRelayWithGrpcServer(t,  &testpb.UnimplementedTestServiceServer{})
+	client, relayAndServer := mustStartRelayWithGrpcServer(t, &testpb.UnimplementedTestServiceServer{})
 	defer relayAndServer.mustStop(t)
 
 	if _, err := client.EmptyCall(relayAndServer.Ctx, &testpb.Empty{}); err != nil {

--- a/src/go/tests/relay/nok8s_relay_test.go
+++ b/src/go/tests/relay/nok8s_relay_test.go
@@ -219,11 +219,11 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 }
 
 type relayWithGrpcServer struct {
-  Listener net.Listener
-  GrpcServer *grpc.Server
-  Relay *relay
-  Conn *grpc.ClientConn
-  Ctx context.Context
+	Listener net.Listener
+	GrpcServer *grpc.Server
+	Relay *relay
+	Conn *grpc.ClientConn
+	Ctx context.Context
 }
 
 func (r *relayWithGrpcServer) mustStop(t *testing.T) {
@@ -231,12 +231,12 @@ func (r *relayWithGrpcServer) mustStop(t *testing.T) {
 	r.GrpcServer.Stop()
 	if err := r.Relay.stop(); err != nil {
 		t.Fatal("failed to stop relay: ", err)
-	}
+	}a
 	r.Conn.Close()
 }
 
 func mustStartRelayWithGrpcServer(t *testing.T, service testpb.TestServiceServer) (testpb.TestServiceClient, *relayWithGrpcServer) {
-    t.Helper()
+	t.Helper()
 
 	result := &relayWithGrpcServer{}
 	var err error
@@ -288,11 +288,11 @@ func TestGrpcRelaySimpleCallWorks(t *testing.T) {
 // with a response that has to be chunked.
 func TestGrpcRelayChunkingOfLargeResponseWorks(t *testing.T) {
 	// Make responses from gRPC server larger than the default MaxChunkSize.
-    payload := make([]byte, client.DefaultClientConfig().MaxChunkSize * 5)
+	payload := make([]byte, client.DefaultClientConfig().MaxChunkSize * 5)
 	for i := 0; i < len(payload); i++ {
 		payload[i] = byte(i) // Fill with non-zeroes
 	} 
-    testServer := &testServer{responsePayload: payload}
+	testServer := &testServer{responsePayload: payload}
 	client, relayAndServer := mustStartRelayWithGrpcServer(t,  testServer)
 	defer relayAndServer.mustStop(t)
 


### PR DESCRIPTION
The relay client splits responses from the backend into multiple chunks based on MaxChunkSize and sends these chunks to the relay server. Currently, the relay client includes HTTP trailers in the last chunk sent - which makes sense - but the relay server code does not correctly handle the case with more than one chunk and always returns the trailers sent with the first chunk (ignoring the trailers in all other chunks). Thus when chunking responses we currently do not return any trailers. 

This PR fixes this issue in the relay server by handling trailers similar to the message body and collecting all trailers from all chunks before appending them to the HTTP response sent to the user client. We add an integration test and unit tests that cover chunked responses.

This fixes the issue that relaying gRPC requests with responses larger than MaxChunkSize leads to a `UNKNOWN` (`No status received`) error. This also removes an existing [TODO](https://github.com/googlecloudrobotics/core/blob/63b665ba7a0a9d9e46d0e387397ceade6db6659e/src/go/cmd/http-relay-server/server/server.go#L163) which has spotted exactly this issue before.