### PR TITLE
fix leaking connections when user client closes connection

### DIFF
--- a/src/go/cmd/http-relay-client/client/client.go
+++ b/src/go/cmd/http-relay-client/client/client.go
@@ -657,6 +657,9 @@ func (c *Client) handleRequest(remote *http.Client, local *http.Client, pbreq *p
 		)
 		if _, ok := err.(*RelayServerError); ok {
 			// A permanent error suggests the request should be aborted.
+			log.Printf("[%s] %s", *resp.Id, err)
+			log.Printf("[%s] Closing backend connection", *resp.Id)
+			hresp.Body.Close()
 			break
 		}
 	}

--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -171,6 +171,12 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 	}
 }
 
+// StopRelayRequest forgets a relaying request, this causes the next chunk from the backend
+// with the relay id to not be recognized, resulting in the relay server returning an error.
+func (r *broker) StopRelayRequest(requestId string) {
+	delete(r.resp, requestId)
+}
+
 // GetRequest obtains a client's request for the server identifier. It blocks
 // until a client makes a request.
 func (r *broker) GetRequest(ctx context.Context, server, path string) (*pb.HttpRequest, error) {

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -379,7 +379,10 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 	numBytes := 0
 	for bytes := range backendRespBodyChannel {
 		// TODO(b/130706300): detect dropped connection and end request in broker
-		_, _ = w.Write(bytes)
+		if _, err = w.Write(bytes); err != nil {
+			delete(s.b.resp, backendReq.GetId())
+			return
+		}
 		if flush, ok := w.(http.Flusher); ok {
 			flush.Flush()
 		}

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -257,8 +257,10 @@ func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseW
 
 	numBytes := 0
 	for responseChunk := range responseChunks {
-		// TODO(b/130706300): detect dropped connection and end request in broker
-		_, _ = bufrw.Write(responseChunk.Body)
+		if _, err = w.Write(responseChunk.Body); err != nil {
+			log.Printf("[%s] %s", backendCtx.Id, err)
+			return
+		}
 		bufrw.Flush()
 		numBytes += len(responseChunk.Body)
 	}
@@ -378,6 +380,7 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	defer s.b.StopRelayRequest(backendCtx.Id)
 
 	header, responseChunksChan, done := s.waitForFirstResponseAndHandleSwitching(ctx, *backendCtx, w, backendRespChan)
 	if done {
@@ -392,9 +395,8 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 	// i.e. this will block until
 	numBytes := 0
 	for responseChunk := range responseChunksChan {
-		// TODO(b/130706300): detect dropped connection and end request in broker
 		if _, err = w.Write(responseChunk.Body); err != nil {
-			delete(s.b.resp, backendReq.GetId())
+			log.Printf("[%s] %s", backendCtx.Id, err)
 			return
 		}
 		if flush, ok := w.(http.Flusher); ok {

--- a/src/go/tests/relay/nok8s_relay_test.go
+++ b/src/go/tests/relay/nok8s_relay_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -127,7 +128,7 @@ func (r *relay) stop() error {
 }
 
 // TestHttpRelay launches a local http relay (client + server) and connects a
-// test-hhtp-server as a backend. The test is then interacting with the backend
+// test-http-server as a backend. The test is then interacting with the backend
 // through the local relay.
 func TestHttpRelay(t *testing.T) {
 	tests := []struct {
@@ -197,6 +198,64 @@ func TestHttpRelay(t *testing.T) {
 				t.Errorf("Wrong body - got %q, expected it to contain %q, ", body, tc.body)
 			}
 		})
+	}
+}
+
+func TestDroppedUserClientFreesRelayChannel(t *testing.T) {
+	// setup http test server
+	connClosed := make(chan error)
+	finishServer := make(chan bool)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for {
+			select {
+			case <-finishServer:
+				return
+			default:
+				if _, err := fmt.Fprintln(w, "DEADBEEF"); err != nil {
+					connClosed <- err
+					println("server closed")
+					return
+				}
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				} else {
+					t.Fatal("cannot flush")
+				}
+				time.Sleep(time.Second)
+			}
+		}
+	}))
+	defer ts.Close()
+	defer func() { finishServer <- true }()
+
+	backendAddress := strings.TrimPrefix(ts.URL, "http://")
+	r := &relay{}
+	if err := r.start(backendAddress); err != nil {
+		t.Fatal("failed to start relay: ", err)
+	}
+	defer func() {
+		if err := r.stop(); err != nil {
+			t.Fatal("failed to stop relay: ", err)
+		}
+	}()
+	relayAddress := "http://127.0.0.1:" + r.rsPort
+
+	res, err := http.Get(relayAddress + "/client/remote1/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// receive the first chunk then terminates the connection
+	if _, err := bufio.NewReader(res.Body).ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	println("client closed")
+
+	// wait for up to 10s for server to close connection
+	select {
+	case <-connClosed:
+	case <-time.After(10 * time.Second):
+		t.Error("Server did not close connection")
 	}
 }
 


### PR DESCRIPTION
When the user client closes the connection, it is not propagated to the backend. For simple "one shot" requests, there is no huge impact as the response would just be dropped, however for long running requests (chunked encoding or websockets), the backend doesn't know that the user client has closed the connection and it keeps sending new updates to the relay client, which also doesn't know and so keep forwarding that to the relay server.

The fix applied is:

* Add `StopRelayRequest` to the broker to "forget" a relaying request. This will cause the relay server to response with a permanent error the next time the relay client tries to send a response for that id. This will in turn cause the relay client to close the connection to the backend.
* There is a bug in the relay client when checking for backoff permanent errors. When the backoff operation encounters a permanent error, it actually unwraps it and return the underlying error, but the client is still checking for `backoff.Permanent`, resulting in the check to always fail and never handling it.