### PR TITLE
Increase cr-syncer health check period

### DIFF
--- a/src/app_charts/base/robot/cr-syncer.yaml
+++ b/src/app_charts/base/robot/cr-syncer.yaml
@@ -30,11 +30,11 @@ spec:
             port: 8080
           failureThreshold: 3
           initialDelaySeconds: 10
-          periodSeconds: 10
+          periodSeconds: 120
           timeoutSeconds: 60
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true  
+          readOnlyRootFilesystem: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
On our integration test project, this makes up 90% of the requests from
the cr-syncer. I hope this will reduce the load on nginx.

b/299409898
