### PR TITLE
Changed the http status code from 500 Internal Server Error to 504 Gateway Timeout after timing out from the backend

### DIFF
--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -144,10 +144,10 @@ func responseFilter(backendCtx backendContext, in <-chan *pb.HttpResponse) ([]*p
 	if !more {
 		brokerResponses.WithLabelValues("client", "missing_message", backendCtx.ServerName, backendCtx.Path).Inc()
 		responseChunks <- &responseChunk{
-			Body: []byte(fmt.Sprintf("Timeout after %v, either the backend request took too long or the relay client died", inactiveRequestTimeout)),
+			Body: []byte(fmt.Sprintf("Timeout after %v, indicating that the backend request took too long", inactiveRequestTimeout)),
 		}
 		close(responseChunks)
-		return nil, http.StatusInternalServerError, responseChunks
+		return nil, http.StatusGatewayTimeout, responseChunks
 	}
 	if firstMessage.StatusCode == nil {
 		brokerResponses.WithLabelValues("client", "missing_header", backendCtx.ServerName, backendCtx.Path).Inc()


### PR DESCRIPTION
Tested by using curl through a relay-server to a slow backend, and seeing the relay-server responding with a "HTTP/2 504" error instead of 500 and "Timeout after 1m0s, indicating that the backend request took too long" in the body.

Copied from here https://github.com/googlecloudrobotics/core/pull/227 to make the presubmit tests to work.