### PR TITLE
Fix a silly error in URL cleanup

### DIFF
--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -91,7 +91,7 @@ type pendingResponse struct {
 	requestPath string
 }
 
-var numberRegexp = regexp.MustCompile(`(?i)[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[a-f0-9]{20}|[0-9]{2,}`)
+var numberRegexp = regexp.MustCompile(`(?i)[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[a-f0-9]{20,}|[0-9]{2,}`)
 
 // cleanPath replaces decimal/hex numbers and GUIDS with "XXX" to make a path
 // that is more suitable as a metric label, reducing the risk of

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -256,6 +256,11 @@ func TestCleanPath(t *testing.T) {
 			input: "/api/logItems/6113d19fca7ff66ccc66",
 			want:  "/api/logItems/XXX",
 		},
+		{
+			desc:  "even longer hex should be removed",
+			input: "/api/executive/operations/a04478091806ceb8a04478091806c1ab",
+			want:  "/api/executive/operations/XXX",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Previously it only removed exactly 20 characters of hex characters,
rather than 20+ characters, which severely limited its value. I promise
that this is my last attempt to save this duct-tape solution, and next
time I will remove request_path from the URL entirely.
