### PR TITLE
Revert "Allow robot-service@ to read from GCR explicitly. (#234)"

### DIFF
--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -78,13 +78,6 @@ resource "google_project_iam_member" "robot-service-kubernetes" {
   member = "serviceAccount:${google_service_account.robot-service.email}"
 }
 
-# Allow robot-service@ to fetch images from GCR.
-resource "google_storage_bucket_iam_member" "robot_service_container_viewer" {
-  bucket = "artifacts.${data.google_project.project.project_id}.appspot.com"
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.robot-service.email}"
-}
-
 resource "google_service_account" "human-acl" {
   account_id   = "human-acl"
   display_name = "human-acl"


### PR DESCRIPTION
This reverts commit 4f2065c322c12b77372f526c1f32c789ff9ec2fe. It breaks
on projects with "eu.artifacts..." buckets like the "navtest" CI
project.
