### PR TITLE
Rate-limit token requests on error

### DIFF
--- a/src/go/cmd/metadata-server/metadata.go
+++ b/src/go/cmd/metadata-server/metadata.go
@@ -45,7 +45,7 @@ const (
 
 // rateLimitTokenSource is a TokenSource that applies exponential backoff on
 // errors, returning the previous error if called again too soon. It doesn't
-// rate-limit on success, as it assumes it wraps a reuseTokenSource.
+// rate-limit on success, as it assumes it wraps an oauth2.ReuseTokenSource.
 type rateLimitTokenSource struct {
 	wrapped oauth2.TokenSource
 


### PR DESCRIPTION
If the token-vendor encounters an error (such as being rate-limited by
the k8s apiserver), the metadata-server will retry as fast as it gets
requests from on-prem clients, which can be quite fast, as they don't
expect a round-trip to the cloud but just a local request.

This change applies exponential backoff with a max delay of around 2
minutes. I tested by turning off the token-vendor in robco-rodrigoq,
waiting for the metadata-server's token to expire, waiting another hour
or so, then turning it back on, and observing that it got a token within
a few minutes.

Alternative considered: Instead of using the TokenSource interface, I
could have created a goroutine that periodically refreshes the token and
does normal retries on failure, but this approach feels more composable?
(although the metadata-server log output is very spammy when the
token-vendor is unavailable, because it prints the error for every local
token request)

Fixes b/298948451.
