### PR TITLE
Hide integration tests from Buildkite CI

### DIFF
--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -140,7 +140,7 @@ bazel_ci test \
   --test_output=streamed \
   --test_tag_filters="external" \
   --strategy=TestRunner=standalone \
-  //...
+  //... //src/go/tests:go_default_test //src/go/tests:relay_test
 
 # If this is running on main (ie, not a manual run) then update the `latest`
 # binary.

--- a/.github/ci/presubmit.sh
+++ b/.github/ci/presubmit.sh
@@ -35,7 +35,8 @@ bazel_ci test \
   --test_env REGISTRY="${REGISTRY}" \
   --test_tag_filters="requires-docker" \
   --test_output=errors \
-  --strategy=TestRunner=standalone //...
+  --strategy=TestRunner=standalone //src/go/tests/apps:go_default_test
+
 set -o xtrace
 
 echo "Timestamp: presubmit.sh done"

--- a/src/go/tests/BUILD.bazel
+++ b/src/go/tests/BUILD.bazel
@@ -27,5 +27,8 @@ sh_test(
     data = [
         "@kubernetes_helm//:helm",
     ],
-    tags = ["external"],
+    tags = [
+        "external",
+        "manual",
+    ],
 )

--- a/src/go/tests/apps/BUILD.bazel
+++ b/src/go/tests/apps/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
     ],
     rundir = ".",
     tags = [
+        "manual",
         "requires-access-token",
         "requires-docker",
     ],


### PR DESCRIPTION
The Bazel team hosts a CI project on Buildkite, which expects to be able
to run all our tests with recent versions of Bazel. We like this because
the Bazel team file issues on our repo to tell us when a future Bazel
release will break our build, but to keep this, we need to make sure our
project is always green on their CI. I don't know why, but we just got a
report that our integration tests are red there due to missing
dependencies (kubectl, docker, credentials): #4380.

We can work around this by using the "manual" tag to exclude our tests
from target expansion, and then manually listing them in our own CI.

I will need to manually check that the tests are still running in
presubmit and postsubmit.
