### PR TITLE
Update bazelbuild/buildtools to 6.4.0

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -68,9 +68,9 @@ def cloud_robotics_repositories():
     _maybe(
         http_archive,
         name = "com_github_bazelbuild_buildtools",
-        sha256 = "977a0bd4593c8d4c8f45e056d181c35e48aa01ad4f8090bdb84f78dca42f47dc",
-        strip_prefix = "buildtools-6.1.2",
-        urls = ["https://github.com/bazelbuild/buildtools/archive/v6.1.2.tar.gz"],
+        sha256 = "05c3c3602d25aeda1e9dbc91d3b66e624c1f9fdadf273e5480b489e744ca7269"
+        strip_prefix = "buildtools-6.4.0",
+        urls = ["https://github.com/bazelbuild/buildtools/archive/v6.4.0.tar.gz"],
     )
 
 def _maybe(repo_rule, name, **kwargs):


### PR DESCRIPTION
This is required by recent Gazelle versions.
