### PR TITLE
Update the nginx-inress to 1.8.4.

### DIFF
--- a/METADATA
+++ b/METADATA
@@ -4,7 +4,7 @@ third_party {
   # https://nvd.nist.gov/products/cpe/search
   security {
     tag: "NVD-CPE2.3:cpe:/a:grafana:grafana:9.1.17"
-    tag: "NVD-CPE2.3:cpe:/a:kubernetes:ingress-nginx:1.8.0"
+    tag: "NVD-CPE2.3:cpe:/a:kubernetes:ingress-nginx:1.8.4"
     tag: "NVD-CPE2.3:cpe:/a:oauth2_proxy_project:oauth2_proxy:7.5.1"
     tag: "NVD-CPE2.3:cpe:/a:prometheus:prometheus:2.39.1"
   }

--- a/current_versions.txt
+++ b/current_versions.txt
@@ -1,6 +1,6 @@
 {
   "cert-manager": "1.12.1",
-  "ingress-nginx": "1.8.0",
+  "ingress-nginx": "1.8.4",
   "oauth2-proxy": "7.5.1",
   "stackdriver-logging-agent": "1.9.5"
 }

--- a/src/app_charts/base/cloud/nginx-ingress-controller.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller.yaml
@@ -31,7 +31,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: nginx-ingress-controller
-          image: registry.k8s.io/ingress-nginx/controller-chroot:v1.8.0@sha256:a45e41cd2b7670adf829759878f512d4208d0aec1869dae593a0fecd09a5e49e
+          image: registry.k8s.io/ingress-nginx/controller-chroot:v1.8.4@sha256:76100ab4c1b3cdc2697dd26492ba42c6519e99c5df1bc839ac5d6444a2c58d17
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
Not updating to 1.9.X yet, as there are breaking changes (*-snippet annotations are disabled and we use them for error pages).

https://github.com/kubernetes/ingress-nginx/releases