### PR TITLE
Remove four-year-old transition helper.

### DIFF
--- a/config.sh.tmpl
+++ b/config.sh.tmpl
@@ -20,8 +20,8 @@ GCP_ZONE=europe-west1-c
 
 # A space-separated list of GCP alphanumeric project IDs for private image
 # repositories. The installer will provision GCR access to these projects,
-# both for the compute service account and for the robot service account.
-#PRIVATE_IMAGE_REPOSITORIES="my-project my-other-project"
+# both for the gke-node service account and for the robot service account.
+#PRIVATE_DOCKER_PROJECTS="my-project my-other-project"
 
 # A Google Group that should be a co-owner of the created GCP project.
 #CLOUD_ROBOTICS_SHARED_OWNER_GROUP=my-group@googlegroups.com

--- a/deploy.sh
+++ b/deploy.sh
@@ -103,14 +103,6 @@ function terraform_exec {
 }
 
 function terraform_init {
-  if [[ -z "${PRIVATE_DOCKER_PROJECTS:-}" ]]; then
-    # Transition helper: Until all configs have PRIVATE_DOCKER_PROJECTS,
-    # default to CLOUD_ROBOTICS_CONTAINER_REGISTRY.
-    if [[ -n "${CLOUD_ROBOTICS_CONTAINER_REGISTRY:-}" ]] && [[ "${CLOUD_ROBOTICS_CONTAINER_REGISTRY:-}" != "${GCP_PROJECT_ID}" ]]; then
-      PRIVATE_DOCKER_PROJECTS="$(echo ${CLOUD_ROBOTICS_CONTAINER_REGISTRY} | sed -n -e 's:^.*gcr.io/::p')"
-    fi
-  fi
-
   local ROBOT_IMAGE_DIGEST
   ROBOT_IMAGE_DIGEST=$(cat bazel-bin/src/bootstrap/cloud/setup-robot.digest)
 


### PR DESCRIPTION
We can add PRIVATE_DOCKER_PROJECTS anywhere it is necessary. The
transition helper breaks when switching between source and binary
deployments on the same project, because it's not valid to compare
CLOUD_ROBOTICS_CONTAINER_REGISTRY (which has the gcr.io/ prefix) and
GCP_PROJECT_ID (which doesn't).

Tested by inserting `exit 1` into deploy.sh before it doesn't anything
dangerous, then running `bash -x deploy.sh update my-binary-project`.
