### PR TITLE
Add retry for TestIamPermissions on context deadline exceeded.

### DIFF
--- a/src/go/cmd/token-vendor/oauth/BUILD.bazel
+++ b/src/go/cmd/token-vendor/oauth/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_api//iam/v1:go_default_library",
         "@org_golang_google_api//option:go_default_library",
     ],

--- a/src/go/cmd/token-vendor/oauth/verifier.go
+++ b/src/go/cmd/token-vendor/oauth/verifier.go
@@ -68,7 +68,7 @@ func (v *TokenVerifier) Verify(ctx context.Context, token Token, sa string) erro
 
 // doTestIamPermissions retry parameters
 const (
-	timeout       = time.Second * 2
+	timeout       = time.Second * 5
 	retryInterval = time.Second * 1
 	retries       = 2
 )


### PR DESCRIPTION
This change adds retries with static retry interval to the TestIamPermissions calls. Exponential retries should not be necessary here with the small number of retries.