### PR TITLE
Delete obsolete CR_SYNCER_RBAC flag

### DIFF
--- a/config.sh.tmpl
+++ b/config.sh.tmpl
@@ -48,15 +48,3 @@ GCP_ZONE=europe-west1-c
 
 # Enable google cloud robotics layer 2
 APP_MANAGEMENT=true
-
-# Require explicit RBAC policies for the cr-syncer. If false, the
-# robot-service@ service account has broad permissions in the GKE cluster.
-# If true, you will have to create RBAC policies when enabling the cr-syncer
-# for your own CustomResourceDefinitions. As this is more secure, we plan
-# to enable everywhere after migration.
-#
-# Setting this will prevent the cr-syncer from automatically removing old
-# finalizers, which can block the deletion of old resources. You should either
-# update the cloud-robotics stack before setting CR_SYNCER_RBAC=true, or
-# manually remove the finalizers with kubectl edit.
-CR_SYNCER_RBAC=false

--- a/deploy.sh
+++ b/deploy.sh
@@ -138,7 +138,6 @@ region = "${GCP_REGION}"
 shared_owner_group = "${CLOUD_ROBOTICS_SHARED_OWNER_GROUP}"
 robot_image_reference = "${SOURCE_CONTAINER_REGISTRY}/setup-robot@${ROBOT_IMAGE_DIGEST}"
 crc_version = "${CRC_VERSION}"
-cr_syncer_rbac = "${CR_SYNCER_RBAC}"
 certificate_provider = "${CLOUD_ROBOTICS_CERTIFICATE_PROVIDER}"
 EOF
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -244,6 +244,12 @@ function terraform_post {
       --member "serviceAccount:robot-service@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
       --role "roles/storage.objectViewer"
   done
+
+  # I am paranoid that #273 will delete this binding as a result of Terraform
+  # races, so this makes sure that it is maintained.
+  gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+    --member "serviceAccount:robot-service@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+    --role "roles/container.clusterViewer" --condition=None
 }
 
 function terraform_delete {

--- a/scripts/include-config.sh
+++ b/scripts/include-config.sh
@@ -56,7 +56,4 @@ function include_config {
 
   CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT=${CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT:-GCP}
   check_var_is_one_of CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT "GCP" "GCP-testing"
-
-  CR_SYNCER_RBAC=${CR_SYNCER_RBAC:-true}
-  check_var_is_one_of CR_SYNCER_RBAC "true" "false"
 }

--- a/src/bootstrap/cloud/terraform/input.tf
+++ b/src/bootstrap/cloud/terraform/input.tf
@@ -43,16 +43,6 @@ variable "private_image_repositories" {
   default     = []
 }
 
-variable "cr_syncer_rbac" {
-  description = <<-EOD
-    If true, robot-service@ is granted the container.clusterViewer
-    role, and explicit RBAC policies must be created to let the cr-syncer
-    read/write resources in the GKE cluster. If false, robot-service@ is granted
-    the container.developer role, which gives it broad access to the GKE
-    cluster.
-  EOD
-}
-
 variable "certificate_provider" {
   description = "Certificate provider to use to generate certificates for in-cluster services. Should be one of: lets-encrypt, google-cas."
   type        = string

--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -71,8 +71,7 @@ resource "google_project_iam_member" "robot-service-roles" {
 resource "google_project_iam_member" "robot-service-kubernetes" {
   project = data.google_project.project.project_id
 
-  # TODO(rodrigoq): migrate to RBAC and remove roles/container.developer
-  role = var.cr_syncer_rbac == "true" ? "roles/container.clusterViewer" : "roles/container.developer"
+  role = "roles/container.clusterViewer"
 
   member = "serviceAccount:${google_service_account.robot-service.email}"
 }

--- a/src/bootstrap/cloud/terraform/service-account.tf
+++ b/src/bootstrap/cloud/terraform/service-account.tf
@@ -61,19 +61,12 @@ resource "google_project_iam_member" "robot-service-roles" {
   member  = "serviceAccount:${google_service_account.robot-service.email}"
   for_each = toset([
     "roles/cloudtrace.agent",  # Upload cloud traces
+    "roles/container.clusterViewer", # Sync CRs from the GKE cluster.
     "roles/logging.logWriter", # Upload text logs to Cloud logging
     # Required to use robot-service@ for GKE clusters that simulate robots
     "roles/monitoring.viewer",
   ])
   role = each.value
-}
-
-resource "google_project_iam_member" "robot-service-kubernetes" {
-  project = data.google_project.project.project_id
-
-  role = "roles/container.clusterViewer"
-
-  member = "serviceAccount:${google_service_account.robot-service.email}"
 }
 
 resource "google_service_account" "human-acl" {


### PR DESCRIPTION
This has been in use for a while. However, CR_SYNCER_RBAC is not
consistently true across all our projects - leading to excessive
robot-service@ privileges in some case. Deleting this simplifies the
code and improves security.

After this is applied, robot-service@ will be limited to "Kubernetes
Engine Cluster Viewer" in all other projects, which allows it to list
GKE clusters (via IAM) and other Robot CRs and ChartAssignments (via
RBAC) but not much more. This role is not to be confused with
"Kubernetes Engine Viewer" which would allow reading all resources in
the GKE clusters, rather than just listing clusters and reading select
resources.
