### PR TITLE
Drop duplicated setting from the wrong place.

### DIFF
--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -170,7 +170,6 @@ spec:
         emptyDir:
           medium: Memory
       securityContext:
-        readOnlyRootFilesystem: true  
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65532


### PR DESCRIPTION
readOnlyRootFilesystem is a container setting, not a pod setting. Fixes a warning when installing the chart.