### PR TITLE
Remove invalid part of certificate spec.

### DIFF
--- a/src/app_charts/base/cloud/cert-manager-certificates.yaml
+++ b/src/app_charts/base/cloud/cert-manager-certificates.yaml
@@ -28,12 +28,6 @@ spec:
 {{ if eq .Values.certificate_provider "lets-encrypt" }}
   issuerRef:
     name: letsencrypt-prod
-  acme:
-    config:
-    - http01:
-        ingressClass: nginx
-      domains:
-      - {{ .Values.domain }}
 {{ else if eq .Values.certificate_provider "google-cas" }}
   issuerRef:
     name: google-cas


### PR DESCRIPTION
This fixes a warnign on the cert validation. I wend back in the git history and can't figre why we have these lines here. These belong to the issuer config and are not valid fro Certificates, see
https://cert-manager.io/docs/usage/certificate/