### PR TITLE
Use the health-probes from the controller-runtime as liveness probes.

### DIFF
--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -32,6 +32,12 @@ spec:
         env:
         - name: GOOGLE_CLOUD_PROJECT
           value: {{ .Values.project }}
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          httpGet:
+            port: 8080
+            path: /healthz
         ports:
         - name: webhook
           containerPort: 9876
@@ -58,7 +64,6 @@ spec:
   type: ClusterIP
   ports:
   - port: 443
-    protocol: TCP
     targetPort: webhook
   selector:
     app: app-rollout-controller
@@ -151,6 +156,12 @@ spec:
         env:
         - name: GOOGLE_CLOUD_PROJECT
           value: {{ .Values.project }}
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          httpGet:
+            port: 8080
+            path: /healthz
         ports:
         - name: webhook
           containerPort: 9876
@@ -197,7 +208,6 @@ spec:
   type: ClusterIP
   ports:
   - port: 443
-    protocol: TCP
     targetPort: webhook
   selector:
     app: chart-assignment-controller

--- a/src/app_charts/base/robot/app-management.yaml
+++ b/src/app_charts/base/robot/app-management.yaml
@@ -27,6 +27,12 @@ spec:
           value: {{ .Values.project }}
         - name: ROBOT_NAME
           value: "{{ .Values.robot.name }}"
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          httpGet:
+            port: 8080
+            path: /healthz
         ports:
         - name: webhook
           containerPort: 9876
@@ -73,7 +79,6 @@ spec:
   type: ClusterIP
   ports:
   - port: 443
-    protocol: TCP
     targetPort: webhook
   selector:
     app: chart-assignment-controller


### PR DESCRIPTION
(removed the protocol:tcp from yaml as that's the default).

Tested on robco-ensonic

See b/315345823