### PR TITLE
Extend the backup script to also backup the pubkeys.

### DIFF
--- a/scripts/backup_robots.sh
+++ b/scripts/backup_robots.sh
@@ -34,4 +34,9 @@ function kc {
 
 kc get robots -o yaml | \
   yq 2>/dev/null -ry '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"],.metadata.creationTimestamp,.metadata.generation,.metadata.managedFields,.metadata.resourceVersion,.metadata.selfLink,.metadata.uid,.status)' -
-
+echo "---"
+# the underlying parser yq is using is inserting blank lines into the scalar blocks
+# TODO: consider labeling the keys so that we can select them
+kc get cm -n app-token-vendor -o yaml --field-selector=metadata.name!=kube-root-ca.crt | \
+  yq 2>/dev/null -ry '.items[] | del(.metadata.creationTimestamp,.metadata.resourceVersion,.metadata.selfLink,.metadata.uid)' - | \
+  grep "\S"


### PR DESCRIPTION
This is mostly FYI. I don't like the hacks it requires. If I run this against g-w I get a 0.5 mb yaml and there are a lot of pubkeys:
```
egrep "^kind:" /tmp/crc-backup.yaml | sort | uniq -c
    706 kind: ConfigMap
     78 kind: Robot
```
Some of them are stale, but token-vendor can't do the cleanup, because the robot-cr is not necessarily available in the cloud.

Also the filtering is sub-par. WDYT if I change token-vendor to label them (and backfill the label via script).