### PR TITLE
Add a label to the pubkey configmap.

### DIFF
--- a/scripts/backup_robots.sh
+++ b/scripts/backup_robots.sh
@@ -36,7 +36,6 @@ kc get robots -o yaml | \
   yq 2>/dev/null -ry '.items[] | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"],.metadata.creationTimestamp,.metadata.generation,.metadata.managedFields,.metadata.resourceVersion,.metadata.selfLink,.metadata.uid,.status)' -
 echo "---"
 # the underlying parser yq is using is inserting blank lines into the scalar blocks
-# TODO: consider labeling the keys so that we can select them
-kc get cm -n app-token-vendor -o yaml --field-selector=metadata.name!=kube-root-ca.crt | \
+kc get cm -n app-token-vendor -o yaml -l app.kubernetes.io/managed-by=token-vendor | \
   yq 2>/dev/null -ry '.items[] | del(.metadata.creationTimestamp,.metadata.resourceVersion,.metadata.selfLink,.metadata.uid)' - | \
   grep "\S"

--- a/src/go/cmd/token-vendor/repository/k8s/k8s.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s.go
@@ -120,6 +120,9 @@ func createPubKeyDeviceConfig(name string, pk string) (*corev1.ConfigMap, error)
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "token-vendor",
+			},
 		},
 		Data: map[string]string{pubKey: pk},
 	}, nil


### PR DESCRIPTION
This will let us efficiently filter, e.g. when backing them up. Adjust the backup script to filter by label.

Existing registrytion can be backfilled by e.g.:
```bash
function kc {
  kubectl --context="${KUBE_CONTEXT}" -n app-token-vendor "$@"
}

for cm in $(kc get cm -o name | egrep "^configmap/robot-"); do
 kc label "$cm" --overwrite app.kubernetes.io/managed-by=token-vendor
done
```

See also: #320 