### PR TITLE
Deploy navtest on cloud build

### DIFF
--- a/.github/ci/deploy_navtest.sh
+++ b/.github/ci/deploy_navtest.sh
@@ -6,9 +6,7 @@ source "${DIR}/common.sh"
 PROJECT_DIR="${DIR}/deployments/robco-navtest"
 source "${PROJECT_DIR}/config.sh"
 
-gcloud auth activate-service-account --key-file robco_navtest_credentials.json
 gcloud auth configure-docker --quiet
-export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/robco_navtest_credentials.json
 
 # TODO(skopecki) These variables should be declared in the run-install.sh and removed from this script.
 export BUCKET_URI="https://storage.googleapis.com/robco-ci-binary-builds"

--- a/.github/ci/deploy_navtest.sh
+++ b/.github/ci/deploy_navtest.sh
@@ -6,13 +6,11 @@ source "${DIR}/common.sh"
 PROJECT_DIR="${DIR}/deployments/robco-navtest"
 source "${PROJECT_DIR}/config.sh"
 
-# gcloud auth configure-docker --quiet
-
 # TODO(skopecki) These variables should be declared in the run-install.sh and removed from this script.
 export BUCKET_URI="https://storage.googleapis.com/robco-ci-binary-builds"
 export SOURCE_CONTAINER_REGISTRY="gcr.io/robco-team"
 
 # Deploy the binary release that was pushed by the last successful integration test.
-curl --silent --show-error "${BUCKET_URI}/run-install.sh" \
+curl --silent --show-error --fail "${BUCKET_URI}/run-install.sh" \
     | bash -x -s -- ${GCP_PROJECT_ID}
 

--- a/.github/ci/deploy_navtest.sh
+++ b/.github/ci/deploy_navtest.sh
@@ -6,13 +6,13 @@ source "${DIR}/common.sh"
 PROJECT_DIR="${DIR}/deployments/robco-navtest"
 source "${PROJECT_DIR}/config.sh"
 
-gcloud auth configure-docker --quiet
+# gcloud auth configure-docker --quiet
 
 # TODO(skopecki) These variables should be declared in the run-install.sh and removed from this script.
 export BUCKET_URI="https://storage.googleapis.com/robco-ci-binary-builds"
 export SOURCE_CONTAINER_REGISTRY="gcr.io/robco-team"
 
 # Deploy the binary release that was pushed by the last successful integration test.
-curl --silent --show-error --fail-with-body "${BUCKET_URI}/run-install.sh" \
+curl --silent --show-error "${BUCKET_URI}/run-install.sh" \
     | bash -x -s -- ${GCP_PROJECT_ID}
 

--- a/.github/ci/deploy_navtest_cloudbuild.yaml
+++ b/.github/ci/deploy_navtest_cloudbuild.yaml
@@ -1,0 +1,7 @@
+# DO NOT SUBMIT
+steps:
+  - name: "ubuntu"
+    entrypoint: "bash"
+    args: ["./.github/ci/deploy_navtest.sh"]
+
+timeout: 1200s

--- a/.github/ci/deploy_navtest_cloudbuild.yaml
+++ b/.github/ci/deploy_navtest_cloudbuild.yaml
@@ -1,7 +1,7 @@
-# DO NOT SUBMIT
+# Call deploy_navtest.sh on Cloud Build.
+# TODO(b/323509860): Run directly on the Action runner when it supports WIF.
 steps:
-  - name: "gcr.io/cloud-builders/kubectl"
+  - name: "gcr.io/cloud-builders/gcloud-slim"
     entrypoint: "bash"
     args: ["./.github/ci/deploy_navtest.sh"]
-
 timeout: 1200s

--- a/.github/ci/deploy_navtest_cloudbuild.yaml
+++ b/.github/ci/deploy_navtest_cloudbuild.yaml
@@ -1,6 +1,6 @@
 # DO NOT SUBMIT
 steps:
-  - name: "ubuntu"
+  - name: "gcr.io/cloud-builders/kubectl"
     entrypoint: "bash"
     args: ["./.github/ci/deploy_navtest.sh"]
 

--- a/.github/ci/deploy_navtest_cloudbuild.yaml
+++ b/.github/ci/deploy_navtest_cloudbuild.yaml
@@ -1,7 +1,7 @@
 # Call deploy_navtest.sh on Cloud Build.
 # TODO(b/323509860): Run directly on the Action runner when it supports WIF.
 steps:
-  - name: "gcr.io/cloud-builders/gcloud-slim"
+  - name: "gcr.io/cloud-builders/gcloud"
     entrypoint: "bash"
     args: ["./.github/ci/deploy_navtest.sh"]
 timeout: 1200s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,26 +49,17 @@ jobs:
           echo $CLOUD_ROBOTICS_RELEASES_GITHUB_ROBOT_JSON_KEY > cloud_robotics_releases_credentials.json
           echo $ROBCO_INTEGRATION_TEST_GITHUB_ROBOT_JSON_KEY > robco_integration_test_credentials.json
           echo $ROBCO_NAVTEST_GITHUB_ROBOT_JSON_KEY > robco_navtest_credentials.json
-
-      - name: Deploy Navtest
+      - name: Deploy Navtest on Cloud Build
         run: |
-          set -euo pipefail
-
-          # Set up gke-cloud-auth-plugin in order to allow for
-          # `gcloud container clusters get-credentials`
-          # From https://cloud.google.com/sdk/docs/install#deb
-          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
-            | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
-          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-          sudo apt-get update -y
-          sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
-
-          ./.github/ci/deploy_navtest.sh
+          gcloud auth activate-service-account --key-file robco_navtest_credentials.json
+          gcloud builds submit \
+            --project robco-navtest \
+            --config .github/ci/deploy_navtest_cloudbuild.yaml
 
       # Now we are ready to create the release.
-      - name: Run release_binary.sh
-        env:
-          REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FULL_SHA: ${{ steps.latest-green.outputs.latest_green }}
-        run: ./.github/ci/release_binary.sh
+      # - name: Run release_binary.sh
+      #   env:
+      #     REPO: ${{ github.repository }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     FULL_SHA: ${{ steps.latest-green.outputs.latest_green }}
+      #   run: ./.github/ci/release_binary.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,8 @@ jobs:
           echo "latest_green=$sha" >> $GITHUB_OUTPUT
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # tag=v3.2.0
-        # DO NOT SUBMIT
-        # with:
-        #   ref: ${{ steps.latest-green.outputs.latest_green }}
+        with:
+          ref: ${{ steps.latest-green.outputs.latest_green }}
       - name: Create service account credentials file
         env:
           CLOUD_ROBOTICS_RELEASES_GITHUB_ROBOT_JSON_KEY: ${{ secrets.CLOUD_ROBOTICS_RELEASES_GITHUB_ROBOT_JSON_KEY }}
@@ -59,9 +58,9 @@ jobs:
             --config .github/ci/deploy_navtest_cloudbuild.yaml
 
       # Now we are ready to create the release.
-      # - name: Run release_binary.sh
-      #   env:
-      #     REPO: ${{ github.repository }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     FULL_SHA: ${{ steps.latest-green.outputs.latest_green }}
-      #   run: ./.github/ci/release_binary.sh
+      - name: Run release_binary.sh
+        env:
+          REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FULL_SHA: ${{ steps.latest-green.outputs.latest_green }}
+        run: ./.github/ci/release_binary.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ jobs:
           echo "latest_green=$sha" >> $GITHUB_OUTPUT
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # tag=v3.2.0
-        with:
-          ref: ${{ steps.latest-green.outputs.latest_green }}
+        # DO NOT SUBMIT
+        # with:
+        #   ref: ${{ steps.latest-green.outputs.latest_green }}
       - name: Create service account credentials file
         env:
           CLOUD_ROBOTICS_RELEASES_GITHUB_ROBOT_JSON_KEY: ${{ secrets.CLOUD_ROBOTICS_RELEASES_GITHUB_ROBOT_JSON_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
           echo $CLOUD_ROBOTICS_RELEASES_GITHUB_ROBOT_JSON_KEY > cloud_robotics_releases_credentials.json
           echo $ROBCO_INTEGRATION_TEST_GITHUB_ROBOT_JSON_KEY > robco_integration_test_credentials.json
           echo $ROBCO_NAVTEST_GITHUB_ROBOT_JSON_KEY > robco_navtest_credentials.json
+
       - name: Deploy Navtest on Cloud Build
         run: |
           gcloud auth activate-service-account --key-file robco_navtest_credentials.json


### PR DESCRIPTION
Because of Terraform being too old (b/323509860), I'm blocked on landing https://github.com/googlecloudrobotics/core/pull/323 since `deploy_navtest.sh` does not work with WIF.

This circumvents the problem by running it on Cloud Build (using "within cloud credentials") instead of directly on the action runner.

I had to remove curl `--fail-with-body` because the version of curl in the cloud build image is too old and it is non-trivial to upgrade it on Ubuntu 20. And building a custom image just for this seemed overkill. In https://github.com/googlecloudrobotics/core/pull/239, the motivation was not this particular call site but the GitHub API calls, which are still kept as is.