### PR TITLE
Reduce the required scope on the oauth2-proxy.

### DIFF
--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -23,7 +23,7 @@ spec:
         - --http-address=0.0.0.0:8080
         - --pass-access-token
         - --pass-host-header
-        - "--scope=profile email https://www.googleapis.com/auth/cloud-platform"
+        - "--scope=profile email https://www.googleapis.com/auth/iam"
         - --cookie-expire=168h
         - --cookie-refresh=1h
         env:


### PR DESCRIPTION
We're calling https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/testIamPermissions and for that we only need 'auth/iam'.