### PR TITLE
Only deploy oauth2-proxy if client-id and -secret are configured.

### DIFF
--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -1,3 +1,4 @@
+{{ if and (ne .Values.oauth2_proxy.client_id "") (ne .Values.oauth2_proxy.client_secret "") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -104,3 +105,4 @@ spec:
             name: oauth2-proxy
             port:
               name: http
+{{ end }}


### PR DESCRIPTION
This makes it optional for installtions that don't use it. Right now we would produce a crash-looping instance in that case.