### PR TITLE
chart-assignment-controller: use the same resource builder as synk

### DIFF
--- a/src/go/pkg/controller/chartassignment/BUILD.bazel
+++ b/src/go/pkg/controller/chartassignment/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/serializer:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/yaml:go_default_library",
+        "@io_k8s_cli_runtime//pkg/resource:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",
         "@io_k8s_client_go//util/workqueue:go_default_library",

--- a/src/go/pkg/controller/chartassignment/release.go
+++ b/src/go/pkg/controller/chartassignment/release.go
@@ -34,7 +34,7 @@ import (
 	"go.opencensus.io/trace"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/helm/pkg/chartutil"
@@ -393,6 +393,7 @@ func newHTTPGetter(url, certFile, keyFile, caFile string) (getter.Getter, error)
 }
 
 func decodeManifests(manifests map[string]string) (res []*unstructured.Unstructured, err error) {
+	var resources []*unstructured.Unstructured
 	for k, v := range manifests {
 		// Sometimes README.md or NOTES.txt files make it into the template directory.
 		// Filter files by extension.
@@ -401,16 +402,23 @@ func decodeManifests(manifests map[string]string) (res []*unstructured.Unstructu
 		default:
 			continue
 		}
-		dec := yaml.NewYAMLOrJSONDecoder(strings.NewReader(v), 4096)
-		for i := 0; ; i++ {
-			var u unstructured.Unstructured
-			if err := dec.Decode(&u); err == io.EOF {
-				break
-			} else if err != nil {
-				return nil, errors.Wrapf(err, "decode manifest %d in %q", i, k)
-			}
-			res = append(res, &u)
+		slog.Info("decode manifest", slog.String("name", k), slog.String("manifest", v))
+		result := resource.NewLocalBuilder().
+			ContinueOnError().
+			Unstructured().
+			Stream(bytes.NewBufferString(v), k).
+			Flatten().
+			Do()
+		if result.Err() != nil {
+			return nil, fmt.Errorf("get manifest: %w", result.Err())
+		}
+		infos, err := result.Infos()
+		if err != nil {
+			return nil, fmt.Errorf("get file information: %w", err)
+		}
+		for _, i := range infos {
+			resources = append(resources, i.Object.(*unstructured.Unstructured))
 		}
 	}
-	return res, nil
+	return resources, nil
 }

--- a/src/go/pkg/controller/chartassignment/release.go
+++ b/src/go/pkg/controller/chartassignment/release.go
@@ -392,7 +392,7 @@ func newHTTPGetter(url, certFile, keyFile, caFile string) (getter.Getter, error)
 	return getter.NewHTTPGetter(url, certFile, keyFile, caFile)
 }
 
-func decodeManifests(manifests map[string]string) (res []*unstructured.Unstructured, err error) {
+func decodeManifests(manifests map[string]string) ([]*unstructured.Unstructured, error) {
 	var resources []*unstructured.Unstructured
 	for k, v := range manifests {
 		// Sometimes README.md or NOTES.txt files make it into the template directory.


### PR DESCRIPTION
see b/207673353
there was a difference between manifest parsing in synk and in the chart-assignment-controller. the handling of 'kind: List' was causing an infinite resource creation by the controller but was handled correctly by synk. with this change manifest parsing is done by cli-runtime/pkg/resource as is already the case for synk.