### PR TITLE
Reduce the size of the broker metrics.

### DIFF
--- a/src/go/cmd/http-relay-server/main.go
+++ b/src/go/cmd/http-relay-server/main.go
@@ -90,10 +90,11 @@ import (
 
 var (
 	port      = flag.Int("port", 80, "Port number to listen on")
-	blockSize = flag.Int("block_size", 10*1024,
+	blockSize = flag.Int("block_size", server.DefaultBlockSize,
 		"Size of i/o buffer in bytes")
 	stackdriverProjectID = flag.String("trace-stackdriver-project-id", "",
 		"If not empty, traces will be uploaded to this Google Cloud Project.")
+	includePathInMetrics = flag.Bool("include_path_in_metrics", false, "Include path in broker metrics (increases cardinality of the metrics though)")
 )
 
 func main() {
@@ -114,6 +115,6 @@ func main() {
 		}
 	}
 
-	server := server.NewServer()
-	server.Start(*port, *blockSize)
+	server := server.NewServer(*port, *blockSize, *includePathInMetrics)
+	server.Start()
 }

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -106,7 +106,7 @@ func runReceiverStream(t *testing.T, b *broker, s string, wg *sync.WaitGroup, do
 }
 
 func TestNormalCase(t *testing.T) {
-	b := newBroker()
+	b := newBroker(false)
 	// create the request channels in advance to avoid race conditions with the below goroutinues.
 	b.req["foo"] = make(chan *pb.HttpRequest)
 	b.req["bar"] = make(chan *pb.HttpRequest)
@@ -122,7 +122,7 @@ func TestNormalCase(t *testing.T) {
 }
 
 func TestResponseStream(t *testing.T) {
-	b := newBroker()
+	b := newBroker(false)
 	var wg sync.WaitGroup
 	done := make(chan bool)
 	wg.Add(2)
@@ -133,7 +133,7 @@ func TestResponseStream(t *testing.T) {
 }
 
 func TestMissingId(t *testing.T) {
-	b := newBroker()
+	b := newBroker(false)
 	err := b.SendResponse(&pb.HttpResponse{Id: proto.String(idOne)})
 	if err == nil {
 		t.Errorf("Invalid response did not produce an error")
@@ -141,7 +141,7 @@ func TestMissingId(t *testing.T) {
 }
 
 func TestDuplicateId(t *testing.T) {
-	b := newBroker()
+	b := newBroker(false)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go runSender(t, b, "foo", idOne, &wg)
@@ -156,7 +156,7 @@ func TestDuplicateId(t *testing.T) {
 
 func TestRequestStream(t *testing.T) {
 	// Start a request that won't terminate until we send `done`.
-	b := newBroker()
+	b := newBroker(false)
 	var wg sync.WaitGroup
 	done := make(chan bool)
 	wg.Add(2)
@@ -184,7 +184,7 @@ func TestRequestStream(t *testing.T) {
 }
 
 func TestRequestStreamUnknownID(t *testing.T) {
-	b := newBroker()
+	b := newBroker(false)
 	if ok := b.PutRequestStream(unknownID, []byte{}); ok {
 		t.Error("ok := PutRequestStream(unknownID, \"\"); ok = true, want false")
 	}
@@ -194,7 +194,7 @@ func TestRequestStreamUnknownID(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	b := newBroker()
+	b := newBroker(false)
 	// create the request channel manually to avoid race condition between the 2
 	// goroutines below
 	b.req["foo"] = make(chan *pb.HttpRequest)

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -49,7 +49,7 @@ func TestClientHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/client/foo/bar?a=b#c", strings.NewReader("body"))
 	req.Header.Add("X-Deadline", "now")
 	respRecorder := httptest.NewRecorder()
-	server := NewServer()
+	server := NewServer(80, DefaultBlockSize, false)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() { server.userClientRequest(respRecorder, req); wg.Done() }()
@@ -117,7 +117,7 @@ func TestClientHandlerWithChunkedResponse(t *testing.T) {
 	req := httptest.NewRequest("GET", "/client/foo/bar?a=b#c", strings.NewReader("body"))
 	req.Header.Add("X-Deadline", "now")
 	respRecorder := httptest.NewRecorder()
-	server := NewServer()
+	server := NewServer(80, DefaultBlockSize, false)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() { server.userClientRequest(respRecorder, req); wg.Done() }()
@@ -210,7 +210,7 @@ func TestClientBadRequest(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			respRecorder := httptest.NewRecorder()
-			server := NewServer()
+			server := NewServer(80, DefaultBlockSize, false)
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() { server.userClientRequest(respRecorder, tc.req); wg.Done() }()
@@ -252,7 +252,7 @@ func TestRequestStreamHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/client/foo/bar?a=b#c", strings.NewReader("body"))
 	req.Header.Add("X-Deadline", "now")
 	respRecorder := hijacktest.NewRecorder(wantRequestStream)
-	server := NewServer()
+	server := NewServer(80, DefaultBlockSize, false)
 	server.blockSize = blockSize
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -333,7 +333,7 @@ func TestServerRequestResponseHandler(t *testing.T) {
 	resp := httptest.NewRequest("POST", "/server/response", bytes.NewReader(backendRespBody))
 	reqRecorder := httptest.NewRecorder()
 	respRecorder := httptest.NewRecorder()
-	server := NewServer()
+	server := NewServer(80, DefaultBlockSize, false)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -392,7 +392,7 @@ func TestServerResponseHandlerWithInvalidRequestID(t *testing.T) {
 
 	resp := httptest.NewRequest("POST", "/server/response", bytes.NewReader(backendRespBody))
 	respRecorder := httptest.NewRecorder()
-	server := NewServer()
+	server := NewServer(80, DefaultBlockSize, false)
 	server.serverResponse(respRecorder, resp)
 
 	if want, got := http.StatusBadRequest, respRecorder.Result().StatusCode; want != got {
@@ -405,7 +405,7 @@ func TestServerResponseHandlerWithInvalidRequestID(t *testing.T) {
 func TestRequestToUnknownBackendResponse503(t *testing.T) {
 	req := httptest.NewRequest("GET", "/client/test/path", bytes.NewReader([]byte{}))
 	respRecorder := httptest.NewRecorder()
-	server := NewServer()
+	server := NewServer(80, DefaultBlockSize, false)
 	server.userClientRequest(respRecorder, req)
 	if respRecorder.Code != http.StatusServiceUnavailable {
 		t.Errorf("Expected status 503, got %d", respRecorder.Code)

--- a/src/go/tests/relay/in_process_relay_test.go
+++ b/src/go/tests/relay/in_process_relay_test.go
@@ -48,8 +48,8 @@ func initRelay() {
 		glog.Infof("Setting up relay.\n\tBackend port: %d\n\tRelay port: %d", backendPort, relayPort)
 
 		go func() {
-			relayServer := server.NewServer()
-			relayServer.Start(relayPort, blockSize)
+			relayServer := server.NewServer(relayPort, blockSize, false)
+			relayServer.Start()
 		}()
 
 		go func() {


### PR DESCRIPTION
Make the path an optional attribute on the metric. We added that to see if there is a performance difference in the backend path. We're not using it in the dashbards for the relay though.
Put it behind a flag, so that we can enable it to debug performance.