### PR TITLE
frontend-relay-client: reduce the log level of the top 2 messages

### DIFF
--- a/src/go/cmd/http-relay-client/client/client.go
+++ b/src/go/cmd/http-relay-client/client/client.go
@@ -323,7 +323,7 @@ func (c *Client) createBackendRequest(breq *pb.HttpRequest) (*http.Request, erro
 	targetUrl.Scheme = c.config.BackendScheme
 	targetUrl.Host = c.config.BackendAddress
 	targetUrl.Path = c.config.BackendPath + targetUrl.Path
-	slog.Info("Sending request to backend",
+	slog.Debug("Sending request to backend",
 		slog.String("ID", id),
 		slog.String("Method", *breq.Method),
 		slog.Any("TargetURL", *targetUrl))
@@ -684,7 +684,7 @@ func (c *Client) handleRequest(remote *http.Client, local *http.Client, pbreq *p
 					resp.BackendDurationMs = proto.Int64(duration.Milliseconds())
 					// see makeBackendRequest()
 					urlPath := strings.TrimPrefix(*pbreq.Url, "http://invalid")
-					slog.Info("Backend request",
+					slog.Debug("Backend request",
 						slog.String("ID", *resp.Id),
 						slog.Float64("Duration", duration.Seconds()),
 						slog.String("Path", urlPath))

--- a/src/go/cmd/http-relay-client/main.go
+++ b/src/go/cmd/http-relay-client/main.go
@@ -35,6 +35,7 @@ var (
 	config client.ClientConfig
 
 	stackdriverProjectID string
+	logLevel             int
 )
 
 func init() {
@@ -84,11 +85,13 @@ func init() {
 	// initialize it independently.
 	flag.StringVar(&stackdriverProjectID, "trace-stackdriver-project-id", "",
 		"If not empty, traces will be uploaded to this Google Cloud Project.")
+	flag.IntVar(&logLevel, "log_level", int(slog.LevelInfo),
+		"the log message level required to be logged")
 }
 
 func main() {
 	flag.Parse()
-	logHandler := ilog.NewLogHandler(slog.LevelInfo, os.Stderr)
+	logHandler := ilog.NewLogHandler(slog.Level(logLevel), os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
 	if stackdriverProjectID != "" {


### PR DESCRIPTION
the cl also adds a command line flag to modify the log level at which messages get logged.
this should significantly reduce the number of log messages produced.