### PR TITLE
Update values-cloud.yaml

### DIFF
--- a/src/app_charts/prometheus/values-cloud.yaml
+++ b/src/app_charts/prometheus/values-cloud.yaml
@@ -44,3 +44,5 @@ prom_ingress_auth_signin: "https://{{ .Values.domain }}/oauth2/start?rd=$escaped
 prom_ingress_error_page_403: "https://{{ .Values.domain }}/oauth2/start?rd=$escaped_request_uri"
 # Prometheus: Using ${} replacement
 prom_external_url: "https://${CLOUD_ROBOTICS_DOMAIN}/prometheus/"
+# Grafana SMTP configuration
+gf_smtp_enabled: false


### PR DESCRIPTION
Add default value to prevent:
```
'render chart: render error in "prometheus-cloud/templates/prometheus-operator.yaml":
      template: prometheus-cloud/templates/prometheus-operator.yaml:8:298: executing
      "prometheus-cloud/templates/prometheus-operator.yaml" at <.Values.gf_smtp_enabled>:
      wrong type for value; expected string; got interface {}'
```