### PR TITLE
Add remaining smtp related variables to values-cloud.yaml

### DIFF
--- a/src/app_charts/prometheus/values-cloud.yaml
+++ b/src/app_charts/prometheus/values-cloud.yaml
@@ -46,3 +46,9 @@ prom_ingress_error_page_403: "https://{{ .Values.domain }}/oauth2/start?rd=$esca
 prom_external_url: "https://${CLOUD_ROBOTICS_DOMAIN}/prometheus/"
 # Grafana SMTP configuration
 gf_smtp_enabled: false
+gf_smtp_host: "smtp-host"
+gf_smtp_user: "smtp-user"
+gf_smtp_password: "smtp-api-key"
+gf_smtp_from_address: "from-address"
+gf_smtp_from_name: "from-name"
+gf_smtp_skip_verify: true


### PR DESCRIPTION
Adds smtp related variables to values-cloud.yaml.

```
gf_smtp_host
gf_smtp_user
gf_smtp_password
gf_smtp_from_address
gf_smtp_from_name
gf_smtp_skip_verify
```

Follow up to https://github.com/googlecloudrobotics/core/pull/369