### PR TITLE
Update protobuf rule in repositories.bzl

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -7,7 +7,6 @@ def cloud_robotics_repositories():
         sha256 = "f66073dee0bc159157b0bd7f502d7d1ee0bc76b3c1eac9836927511bdc4b3fc1",
         strip_prefix = "protobuf-3.21.9",
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.21.9.zip",
             "https://github.com/protocolbuffers/protobuf/archive/v3.21.9.zip",
         ],
     )


### PR DESCRIPTION
Remove mirror path as the file there is gone. We're also trying to bump the dependency, but that takes more effort.