### PR TITLE
Allow 30m for integration_test.sh

### DIFF
--- a/.github/ci/integration_test_cloudbuild.yaml
+++ b/.github/ci/integration_test_cloudbuild.yaml
@@ -24,4 +24,4 @@ substitutions:
 options:
   dynamicSubstitutions: true
   substitutionOption: "MUST_MATCH"
-timeout: 1200s
+timeout: 1800s


### PR DESCRIPTION
Some green runs were close to 20m (I saw one at 18m) so this should make it more robust to unexpectedly slow dependencies like BES.