### PR TITLE
Allow bypassing manual-run protection

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -5,6 +5,11 @@ on:
     - cron: "0 4 * * *" # Once a day at 4am.
   # Manual runs through Actions tab in the UI
   workflow_dispatch:
+    inputs:
+      force-binary-release:
+        description: >-
+          force-binary-release: Set to non-empty when running from main to
+          create a binary release that can be used by 'Create release'.
 
 permissions:
   contents: read
@@ -27,7 +32,7 @@ jobs:
           workload_identity_provider: "projects/1043719249528/locations/global/workloadIdentityPools/github-automation/providers/crc-dev"
       - name: Run integration_test.sh on Cloud Build
         env:
-          MANUAL_RUN: "${{ github.event_name == 'workflow_dispatch' }}"
+          MANUAL_RUN: "${{ github.event_name == 'workflow_dispatch' && inputs.force-binary-release == '' }}"
         run: |
           gcloud builds submit \
             --project robco-integration-test \


### PR DESCRIPTION
This means that when a release fails, you can push a fix to main and rerun to create the daily release.