### PR TITLE
Use GitHub's concurrency control

### DIFF
--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -6,39 +6,6 @@ source "${DIR}/common.sh"
 # Because the format from common.sh is not recognized by Cloud Build.
 export 'PS4='
 
-LOCK_OBJECT=gs://robco-integration-test-lock/lock
-LOCK_BACKOFF_SECONDS=60
-
-lock() {
-  # Take the lock by creating the lock object. x-goog-if-generation-match:0 is a
-  # GCS precondition that causes `cp` to fail if the lock object already exists.
-  while ! echo "lock" | gsutil -q -h "x-goog-if-generation-match:0" cp - $LOCK_OBJECT
-  do
-    : "lock: failed to obtain lock, retrying in $LOCK_BACKOFF_SECONDS seconds"
-    : "Note to build cop: if you think there is a stale lock, run:"
-    : "    gsutil rm $LOCK_OBJECT"
-    : "This can occur when a previous job timed out or was canceled while"
-    : "holding the lock."
-    sleep $LOCK_BACKOFF_SECONDS
-  done
-  # TODO(rodrigoq): if the build is cancelled by GitHub, the lock is not
-  # released. The GCS lifecycle will delete the lock after a day, if the build
-  # cop doesn't delete it sooner. We could add a check here to delete the lock
-  # if it's too old, but I don't know how to do that safely - maybe a second
-  # lock would prevent races between deletion checks, but maybe it would just
-  # introduce other failure modes.
-}
-
-finalize_and_unlock() {
-  local sleep_time=1
-  while ! gsutil -q rm $LOCK_OBJECT
-  do
-    echo "unlock: failed to relinquish lock, retrying in $sleep_time seconds"
-    sleep $sleep_time
-    sleep_time=$(expr $sleep_time '*' 2)
-  done
-}
-
 # Need to source the project config from here
 PROJECT_DIR="${DIR}/deployments/robco-integration-test"
 source "${PROJECT_DIR}/config.sh"
@@ -47,13 +14,6 @@ gcloud container clusters get-credentials cloud-robotics --zone=${GCP_ZONE}
 
 BUILD_IDENTIFIER=$(generate_build_id)
 echo "INFO: Build identifier is $BUILD_IDENTIFIER"
-
-# Get the lock before deploying to the project. This ensures that other runs
-# will not change our deployment until we finish testing.
-lock
-
-# `set +x` avoids log spam and makes error messages more obvious.
-trap 'set +x; finalize_and_unlock' EXIT
 
 export BAZEL_FLAGS="--bazelrc=${DIR}/.bazelrc"
 bash -x ./deploy.sh update "${GCP_PROJECT_ID}"

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: integration_test
+  cancel-in-progress: true
+
 jobs:
   call-bazel:
     uses: ./.github/workflows/check-bazel.yml


### PR DESCRIPTION
This avoids needing to manually delete lock files after timeouts.
