### PR TITLE
Fix typo in overview.md

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -57,7 +57,7 @@ How-to Guide.
 
 Layer 1 also provides a light-weight cluster federation system that synchronizes selected custom
 resources accross the fleet. This provides developers with a pattern for command & control that is
-robust against intermittent conenctivity and fits well with the overall declarative Kubernetes
+robust against intermittent connectivity and fits well with the overall declarative Kubernetes
 model. You can read more in the concept guide about [Federation](concepts/federation.md).
 
 > **Note:** Layer 2 and 3 (below) are currently under development. You'll find an early


### PR DESCRIPTION
I just fixed a typo in  `docs/overwiew.md`. 
It's not much, but I believe anything help.

Keep up the good work team :rocket:  ! (Really interesting project)