### PR TITLE
Only consider scheduled postsubmit runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,12 @@ jobs:
           set -euo pipefail
           output=$(curl --fail-with-body -sS \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&event=schedule&status=success")
+          repo_id=$(jq -r '.workflow_runs[0].head_repository.id' <<< $output)
+          if [[ "${repo_id}" != "${{ github.repository_id }}" ]] ; then
+            echo >&2 "Unexpected head repository ID: ${repo_id} - check postsubmit.yml configuration"
+            exit 1
+          fi
           sha=$(jq -r '.workflow_runs[0].head_sha' <<< $output)
           echo "latest_green=$sha" >> $GITHUB_OUTPUT
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           output=$(curl --fail-with-body -sS \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&status=success")
+            "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&event=schedule&status=success")
           sha=$(jq -r '.workflow_runs[0].head_sha' <<< $output)
           echo "latest_green=$sha" >> $GITHUB_OUTPUT
       - name: Checkout repository


### PR DESCRIPTION
Without this parameter, the API will also return commits from PRs, which
may not have been reviewed and could be malicious.

This has the downside that if you're trying to fix the release workflow
you need to change the schedules or be limited to one attempted fix per
day, but the alternatives (see below) are also not ideal.

For defense in depth, we also check against the head_repository id, which I tested by temporarily changing `event=schedule` to `actor=totoro642`, [in which case the action fails](https://github.com/googlecloudrobotics/core/actions/runs/9662992790/job/26654091527) with:

```
Unexpected head repository ID: 817231418 - check postsubmit.yml configuration
```

Alternatives considered:

- Changing postsubmit to run on `push` and then having the release workflow filter with `event=push` instead. This would make it easier to manually trigger a release from a recently submitted change, but doesn't address the (more common) issue that the Postsubmit fails due to some unrelated cloud-side breakage, and must be retriggered after intervening on the GKE cluster to get a green run.
- Changing postsubmit to directly trigger the release action on the current commit: This would let us remove the `git clone` pattern that makes the attack possible, but at the cost of allowing actions to trigger other actions, which feels like it could open another class of attacks (such as triggering a release from older, insecure code).
- Changing release to trigger on tag creation rather than a schedule. This would mean that only people with permissions to create tags can create releases, which is probably more standard on GitHub , but diverges from the "autopush" model we're using so would need discussion with other team members.

http://b/348316770
