### PR TITLE
Allow to configure CRC to use regional clusters

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -225,7 +225,23 @@ function terraform_apply {
 
 function terraform_post {
   # Post terraform adjustents/cleanups
-  :
+
+  OLD_CLOUD_ROBOTICS_CTX="${CLOUD_ROBOTICS_CTX}"
+  location=$(gcloud container clusters list --filter='name=cloud-robotics' --format='value(location)' --project="${GCP_PROJECT_ID}")
+  if [[ "${location}" == "${GCP_ZONE}" || "${location}" == "${GCP_REGION}" ]]; then
+    CLOUD_ROBOTICS_CTX="gke_${GCP_PROJECT_ID}_${location}_${PROJECT_NAME}"
+  else
+    die "no cloud-robotics cluster found"
+  fi
+  if [[ "${OLD_CLOUD_ROBOTICS_CTX}" != "${CLOUD_ROBOTICS_CTX}" ]]; then
+    echo "updating CLOUD_ROBOTICS_CTX from ${OLD_CLOUD_ROBOTICS_CTX} to ${CLOUD_ROBOTICS_CTX}"
+    # update CLOUD_ROBOTICS_CTX in config.sh
+    # TODO(ensonc): need to store the changes:
+    # a) extend set-config.sh to have --edit-var="key=value" ?
+    #   - would also need to add --verbose to supress the print of the new config ...
+    # b) duplicate code here? 
+    # bash -c "${DIR}/scripts/set-config.sh; --edit-var=CLOUD_ROBOTICS_CTX=${CLOUD_ROBOTICS_CTX}"
+  fi
 }
 
 function terraform_delete {

--- a/deploy.sh
+++ b/deploy.sh
@@ -238,6 +238,9 @@ function terraform_apply {
 }
 
 function terraform_post {
+  local OLD_CLOUD_ROBOTICS_CTX
+  local location
+
   OLD_CLOUD_ROBOTICS_CTX="${CLOUD_ROBOTICS_CTX}"
   location=$(gcloud container clusters list --filter='name=cloud-robotics' --format='value(location)' --project="${GCP_PROJECT_ID}")
   if [[ "${location}" == "${GCP_ZONE}" || "${location}" == "${GCP_REGION}" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -242,12 +242,8 @@ function terraform_post {
   local location
 
   OLD_CLOUD_ROBOTICS_CTX="${CLOUD_ROBOTICS_CTX}"
-  location=$(gcloud container clusters list --filter='name=cloud-robotics' --format='value(location)' --project="${GCP_PROJECT_ID}")
-  if [[ "${location}" == "${GCP_ZONE}" || "${location}" == "${GCP_REGION}" ]]; then
-    CLOUD_ROBOTICS_CTX="gke_${GCP_PROJECT_ID}_${location}_${PROJECT_NAME}"
-  else
-    die "no cloud-robotics cluster found"
-  fi
+  CLOUD_ROBOTICS_CTX=$(gke_context_name "${GCP_PROJECT_ID}" "cloud-robotics" "${GCP_REGION}" "${GCP_ZONE}")
+  [[ -z "${CLOUD_ROBOTICS_CTX}" ]] && die "no cloud-robotics cluster found"
   if [[ "${OLD_CLOUD_ROBOTICS_CTX}" != "${CLOUD_ROBOTICS_CTX}" ]]; then
     echo "updating CLOUD_ROBOTICS_CTX from ${OLD_CLOUD_ROBOTICS_CTX} to ${CLOUD_ROBOTICS_CTX}"
     update_config_var ${GCP_PROJECT_ID} "CLOUD_ROBOTICS_CTX" "${CLOUD_ROBOTICS_CTX}"
@@ -484,7 +480,7 @@ function helm_additional_region {
   INGRESS_IP=$(terraform_exec output -json ingress-ip-ar | jq -r ."\"${CLUSTER_NAME}\"")
 
   helm_region_shared \
-    "gke_${GCP_PROJECT_ID}_${AR_ZONE}_${CLUSTER_NAME}" \
+    $(gke_context_name "${GCP_PROJECT_ID}" "${CLUSTER_NAME}" "${AR_REGION}" "${AR_ZONE}") \
     "${AR_NAME}.${CLOUD_ROBOTICS_DOMAIN}" \
     "${INGRESS_IP}" \
     "${AR_REGION}" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -153,6 +153,7 @@ shared_owner_group = "${CLOUD_ROBOTICS_SHARED_OWNER_GROUP}"
 robot_image_reference = "${SOURCE_CONTAINER_REGISTRY}/setup-robot@${ROBOT_IMAGE_DIGEST}"
 crc_version = "${CRC_VERSION}"
 certificate_provider = "${CLOUD_ROBOTICS_CERTIFICATE_PROVIDER}"
+cluster_type = "${GKE_CLUSTER_TYPE}"
 EOF
 
 # Add certificate information if the configured provider requires it

--- a/deploy.sh
+++ b/deploy.sh
@@ -204,6 +204,7 @@ terraform {
     bucket = "${TERRAFORM_GCS_BUCKET}"
     prefix = "${TERRAFORM_GCS_PREFIX}"
   }
+  experiments = [variable_validation]
 }
 EOF
   else

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -76,3 +76,21 @@ function gke_get_credentials {
       ;;
   esac
 }
+
+# Build GKE context name for existing cluster
+function gke_context_name {
+  local project
+  project="$1"
+  local cluster_name
+  name="$2"
+  local region
+  region="$3"
+  local zone
+  zone="$4"
+
+  local location
+  location=$(gcloud container clusters list --filter="name=${name}" --format='value(location)' --project="${project}")
+  if [[ "${location}" == "${zone}" || "${location}" == "${region}" ]]; then
+    echo "gke_${project}_${location}_${name}"
+  fi
+}

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2024 The Cloud Robotics Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Escapes the input "foo bar" -> "foo\ bar".
+function escape {
+  sed 's/[^a-zA-Z0-9,._+@%/-]/\\&/g' <<< "$@"
+}
+
+# Escapes the input twice "foo bar" -> "foo\\\ bar"
+function double_escape {
+  sed 's/[^a-zA-Z0-9,._+@%/-]/\\\\\\&/g' <<< "$@"
+}
+
+# Creates a substitution pattern for sed using an unprintable char as seperator.
+# This allows the user to use any normal char in the input.
+function sed_pattern {
+  local regexp="$1"
+  local replacement="$2"
+  echo s$'\001'${regexp}$'\001'${replacement}$'\001'
+}
+
+# Sets the given variable in config.sh. If $value is empty, the variable
+# assignement is commented out in config.sh.
+function save_variable {
+  local config_file="$1"
+  local name="$2"
+  local value="$3"
+
+  if [[ -z "${value}" ]]; then
+    sed -i "s/^\(${name}=.*\)$/#\1/" "${config_file}"
+  elif grep -q "^\(# *\)\{0,1\}${name}=" "${config_file}"; then
+    value=$( double_escape ${value} )
+    sed -i "$( sed_pattern "^\(# *\)\{0,1\}${name}=.*$" "${name}=${value}" )" "${config_file}"
+  else
+    value=$( escape ${value} )
+    echo >>"${config_file}"
+    echo "${name}=${value}" >>"${config_file}"
+  fi
+}

--- a/scripts/include-config.sh
+++ b/scripts/include-config.sh
@@ -56,4 +56,7 @@ function include_config {
 
   CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT=${CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT:-GCP}
   check_var_is_one_of CLOUD_ROBOTICS_DEPLOY_ENVIRONMENT "GCP" "GCP-testing"
+
+  GKE_CLUSTER_TYPE=${GKE_CLUSTER_TYPE:-zonal}
+  check_var_is_one_of GKE_CLUSTER_TYPE "zonal" "regional"
 }

--- a/scripts/set-config.sh
+++ b/scripts/set-config.sh
@@ -153,6 +153,17 @@ function set_default_vars {
 
   GCP_REGION=${GCP_ZONE%-?}
 
+  # Ask for gke cluster type
+  GKE_CLUSTER_TYPE="zonal"
+  while :; do
+    read_variable GKE_CLUSTER_TYPE "Should the cluster be 'zonal' or 'regional'?" "${GKE_CLUSTER_TYPE}"
+
+    if [[ "${GKE_CLUSTER_TYPE}" == "zonal" || "${GKE_CLUSTER_TYPE}" == "regional" ]]; then
+      break
+    fi
+    echo "Value must be one of: 'zonal','regional'"
+  done
+
   # Ask for Terraform bucket and location.
   OLD_TERRAFORM_GCS_BUCKET="${TERRAFORM_GCS_BUCKET}"
   OLD_TERRAFORM_GCS_PREFIX="${TERRAFORM_GCS_PREFIX}"
@@ -251,6 +262,7 @@ echo "========================"
 print_variable "GCP project ID" "${GCP_PROJECT_ID}"
 print_variable "GCP region" "${GCP_REGION}"
 print_variable "GCP zone" "${GCP_ZONE}"
+print_variable "GKE cluster type" "${GKE_CLUSTER_TYPE}"
 print_variable "Terraform state bucket" "${TERRAFORM_GCS_BUCKET}"
 print_variable "Terraform state directory" "${TERRAFORM_GCS_PREFIX}"
 print_variable "Docker container registry" "${CLOUD_ROBOTICS_CONTAINER_REGISTRY}"
@@ -283,6 +295,7 @@ save_variable "${CONFIG_FILE}" GCP_PROJECT_ID "${GCP_PROJECT_ID}"
 save_variable "${CONFIG_FILE}" GCP_REGION "${GCP_REGION}"
 save_variable "${CONFIG_FILE}" GCP_ZONE "${GCP_ZONE}"
 save_variable "${CONFIG_FILE}" CLOUD_ROBOTICS_CTX "gke_${GCP_PROJECT_ID}_${GCP_ZONE}_cloud-robotics"
+save_variable "${CONFIG_FILE}" GKE_CLUSTER_TYPE "${GKE_CLUSTER_TYPE}"
 save_variable "${CONFIG_FILE}" TERRAFORM_GCS_BUCKET "${TERRAFORM_GCS_BUCKET}"
 save_variable "${CONFIG_FILE}" TERRAFORM_GCS_PREFIX "${TERRAFORM_GCS_PREFIX}"
 save_variable "${CONFIG_FILE}" CLOUD_ROBOTICS_CONTAINER_REGISTRY "${CLOUD_ROBOTICS_CONTAINER_REGISTRY}"

--- a/scripts/set-config.sh
+++ b/scripts/set-config.sh
@@ -23,16 +23,7 @@ set -o pipefail -o errexit
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 source "${DIR}/scripts/common.sh"
-
-# Escapes the input "foo bar" -> "foo\ bar".
-function escape {
-  sed 's/[^a-zA-Z0-9,._+@%/-]/\\&/g' <<< "$@"
-}
-
-# Escapes the input twice "foo bar" -> "foo\\\ bar"
-function double_escape {
-  sed 's/[^a-zA-Z0-9,._+@%/-]/\\\\\\&/g' <<< "$@"
-}
+source "${DIR}/scripts/config.sh"
 
 # Reads a variable from user input.
 function read_variable {
@@ -63,33 +54,6 @@ function print_variable {
 
   if [[ -n "${value}" ]]; then
     echo "${description}: ${value}"
-  fi
-}
-
-# Creates a substitution pattern for sed using an unprintable char as seperator.
-# This allows the user to use any normal char in the input.
-function sed_pattern {
-  local regexp="$1"
-  local replacement="$2"
-  echo s$'\001'${regexp}$'\001'${replacement}$'\001'
-}
-
-# Sets the given variable in config.sh. If $value is empty, the variable
-# assignement is commented out in config.sh.
-function save_variable {
-  local config_file="$1"
-  local name="$2"
-  local value="$3"
-
-  if [[ -z "${value}" ]]; then
-    sed -i "s/^\(${name}=.*\)$/#\1/" "${config_file}"
-  elif grep -q "^\(# *\)\{0,1\}${name}=" "${config_file}"; then
-    value=$( double_escape ${value} )
-    sed -i "$( sed_pattern "^\(# *\)\{0,1\}${name}=.*$" "${name}=${value}" )" "${config_file}"
-  else
-    value=$( escape ${value} )
-    echo >>"${config_file}"
-    echo "${name}=${value}" >>"${config_file}"
   fi
 }
 

--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -43,7 +43,7 @@ resource "google_container_cluster" "cloud-robotics-ar" {
   for_each              = var.additional_regions
   project               = data.google_project.project.project_id
   name                  = format("%s-%s", each.key, "ar-cloud-robotics")
-  location              = var.cluster_type == "zonal" ? each.value.zone : each.value.region
+  location              = each.value.zone
   enable_shielded_nodes = true
   depends_on            = [google_project_service.project-services["container.googleapis.com"]]
 
@@ -109,7 +109,7 @@ resource "google_container_node_pool" "cloud_robotics_base_pool_ar" {
   for_each = var.additional_regions
   project  = data.google_project.project.project_id
   name     = format("%s-%s", "base-pool-ar", each.key)
-  location = var.cluster_type == "zonal" ? each.value.zone : each.value.region
+  location = each.value.zone
   cluster  = google_container_cluster.cloud-robotics-ar[each.key].name
 
   initial_node_count = 2

--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -4,15 +4,10 @@
 # service account for the nodes. This service account cannot be used by the
 # workloads: see workload-identity.tf for those service accounts.
 
-locals {
-  zonal = true
-  #zonal = false
-}
-
 resource "google_container_cluster" "cloud-robotics" {
   project               = data.google_project.project.project_id
   name                  = "cloud-robotics"
-  location              = local.zonal ? var.zone : var.region
+  location              = var.cluster_type == "zonal" ? var.zone : var.region
   enable_shielded_nodes = true
   depends_on            = [google_project_service.project-services["container.googleapis.com"]]
 
@@ -48,7 +43,7 @@ resource "google_container_cluster" "cloud-robotics-ar" {
   for_each              = var.additional_regions
   project               = data.google_project.project.project_id
   name                  = format("%s-%s", each.key, "ar-cloud-robotics")
-  location              = local.zonal ? each.value.zone : each.value.region
+  location              = var.cluster_type == "zonal" ? each.value.zone : each.value.region
   enable_shielded_nodes = true
   depends_on            = [google_project_service.project-services["container.googleapis.com"]]
 
@@ -86,7 +81,7 @@ resource "google_container_cluster" "cloud-robotics-ar" {
 resource "google_container_node_pool" "cloud_robotics_base_pool" {
   project  = data.google_project.project.project_id
   name     = "base-pool"
-  location = local.zonal ? var.zone : var.region
+  location = var.cluster_type == "zonal" ? var.zone : var.region
   cluster  = google_container_cluster.cloud-robotics.name
 
   initial_node_count = 2
@@ -114,7 +109,7 @@ resource "google_container_node_pool" "cloud_robotics_base_pool_ar" {
   for_each = var.additional_regions
   project  = data.google_project.project.project_id
   name     = format("%s-%s", "base-pool-ar", each.key)
-  location = local.zonal ? each.value.zone : each.value.region
+  location = var.cluster_type == "zonal" ? each.value.zone : each.value.region
   cluster  = google_container_cluster.cloud-robotics-ar[each.key].name
 
   initial_node_count = 2

--- a/src/bootstrap/cloud/terraform/input.tf
+++ b/src/bootstrap/cloud/terraform/input.tf
@@ -63,3 +63,14 @@ variable "certificate_subject_organizational_unit" {
   type        = string
   default     = null
 }
+
+variable "cluster_type" {
+  description = "GKE cluster type. Must be one of {zonal,regional}."
+  type = string
+  default = "zonal"
+
+  validation {
+    condition     = contains(["zonal", "regional"], var.cluster_type)
+    error_message = "Must be either \"zonal\" or \"regional\"."
+  }
+}


### PR DESCRIPTION
So far we always created "zonal" clusters. This set of changes introduced a new config.sh var `GKE_CLUSTER_TYPE` that defaults to "zonal". This var will be feed into terraforms input vars and allows to select create "regional" clusters instead.
