### PR TITLE
Drop custom vars for cloud-robotics k8s cluster context

### DIFF
--- a/.github/ci/deployments/robco-integration-test/config.sh
+++ b/.github/ci/deployments/robco-integration-test/config.sh
@@ -12,3 +12,4 @@ TERRAFORM_GCS_BUCKET="robco-team-terraform-state"
 TERRAFORM_GCS_PREFIX="state/${GCP_PROJECT_ID}"
 CLOUD_ROBOTICS_CONTAINER_REGISTRY=gcr.io/robco-team
 PRIVATE_DOCKER_PROJECTS=robco-team
+CLOUD_ROBOTICS_CTX=gke_robco-integration-test_europe-west1-c_cloud-robotics

--- a/.github/ci/deployments/robco-navtest/config.sh
+++ b/.github/ci/deployments/robco-navtest/config.sh
@@ -11,3 +11,4 @@ TERRAFORM_GCS_BUCKET="robco-team-terraform-state"
 TERRAFORM_GCS_PREFIX="state/${GCP_PROJECT_ID}"
 CLOUD_ROBOTICS_CONTAINER_REGISTRY=gcr.io/robco-team
 PRIVATE_DOCKER_PROJECTS=robco-team
+CLOUD_ROBOTICS_CTX=gke_robco-navtest_europe-west1-c_cloud-robotics

--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -26,12 +26,11 @@ bash -x ./scripts/robot-sim.sh create "${GCP_PROJECT_ID}" "${ROBOT_RELAY_CLUSTER
 bazel_ci run //src/go/cmd/setup-dev -- --project="${GCP_PROJECT_ID}" --robot-name="${ROBOT_RELAY_CLUSTER}"
 
 DOMAIN=${CLOUD_ROBOTICS_DOMAIN:-"www.endpoints.${GCP_PROJECT_ID}.cloud.goog"}
-CLOUD_CONTEXT="gke_${GCP_PROJECT_ID}_${GCP_ZONE}_cloud-robotics"
 ROBOT_CONTEXT="gke_${GCP_PROJECT_ID}_${GCP_ZONE}_${ROBOT_RELAY_CLUSTER}"
 
 # Output state of cloud and robot k8s context to inspect the health of pods.
 kubectl config get-contexts || true
-kubectl --context ${CLOUD_CONTEXT} get pods || true
+kubectl --context ${CLOUD_ROBOTICS_CTX} get pods || true
 kubectl --context ${GCP_PROJECT_ID}-robot get pods || true
 kubectl --context ${ROBOT_CONTEXT} get pods || true
 

--- a/scripts/robot-sim.sh
+++ b/scripts/robot-sim.sh
@@ -29,7 +29,6 @@ function set_defaults {
   local GCP_PROJECT_ID="$1"
   include_config "${GCP_PROJECT_ID}"
   INITIAL_KUBECTL_CONTEXT="$(kubectl config current-context)"
-  GKE_CLOUD_CONTEXT="gke_${GCP_PROJECT_ID}_${GCP_ZONE}_cloud-robotics"
 
   if [[ -z "${ROBOT_LABELS}" ]]; then
     ROBOT_LABELS="simulated=true"
@@ -89,7 +88,7 @@ function delete {
 
   set_defaults "${GCP_PROJECT_ID}"
 
-  kubectl --context=${GKE_CLOUD_CONTEXT} delete robots.registry.cloudrobotics.com "${ROBOT_NAME}" || true
+  kubectl --context=${CLOUD_ROBOTICS_CTX} delete robots.registry.cloudrobotics.com "${ROBOT_NAME}" || true
   gcloud container clusters delete "${ROBOT_NAME}" \
     --zone=${GCP_ZONE} --project=${GCP_PROJECT_ID}
 }


### PR DESCRIPTION
I've also updated the config.sh files in the bucket. Not sure we we also have them in git.