### PR TITLE
Avoid hanging after custom metrics are removed

### DIFF
--- a/src/go/pkg/controller/chartassignment/release.go
+++ b/src/go/pkg/controller/chartassignment/release.go
@@ -402,7 +402,6 @@ func decodeManifests(manifests map[string]string) ([]*unstructured.Unstructured,
 		default:
 			continue
 		}
-		slog.Info("decode manifest", slog.String("name", k), slog.String("manifest", v))
 		result := resource.NewLocalBuilder().
 			ContinueOnError().
 			Unstructured().


### PR DESCRIPTION
Previously, we had a hacky heuristic on when to trust partial discovery
information from the server, but this would still fail to apply
ChartAssignments when it got the error "stale GroupVersion discovery".
Instead, we can treat such errors as warnings, and instead look for
whether the resources in the charts are represented in the discovery
information.

Also, to reduce the frequency of the warnings, invalidate the discovery
cache before calling discovery - this means you just see the warning
once (due to a race in the apiserver I think) instead of the entire time
until the process is restarted.

Fixes #261. (well, we don't actually crash as that issue requests, but I like this way more)