### PR TITLE
Add multi-cluster ingress support

### DIFF
--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -28,6 +28,9 @@ resource "google_container_cluster" "cloud-robotics" {
     delete = "1h"
   }
 
+  gateway_api_config {
+    channel = "CHANNEL_STANDARD"
+  }
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }

--- a/src/bootstrap/cloud/terraform/multi-cluster-ingress.tf
+++ b/src/bootstrap/cloud/terraform/multi-cluster-ingress.tf
@@ -1,0 +1,60 @@
+# Multi-Cluster Ingress
+#
+# If the config calls for additional regions, this registers them all into one
+# "fleet" (aka GKE Hub). It enables multi-cluster services and multi-cluster
+# ingress, so that the primary "cloud-robotics" cluster is the source-of-truth
+# for gateway configuration.
+
+resource "google_gke_hub_feature" "multi_cluster_service_discovery" {
+  count = length(var.additional_regions) > 0 ? 1 : 0
+
+  name = "multiclusterservicediscovery"
+  location = "global"
+  project = data.google_project.project.project_id
+}
+
+resource "google_gke_hub_feature" "multi_cluster_ingress" {
+  count = length(var.additional_regions) > 0 ? 1 : 0
+
+  name = "multiclusteringress"
+  location = "global"
+  project = data.google_project.project.project_id
+  spec {
+    multiclusteringress {
+      config_membership = google_gke_hub_membership.cloud_robotics[0].id
+    }
+  }
+}
+
+# The GKE cluster called "cloud-robotics" is the primary cluster and the source
+# for Gateway configs.
+#
+# Both of these memberships set location = <cluster region>. I don't know if
+# this is important or if it's just Anthos metadata, but this is what
+# `gcloud container fleet memberships register` does (as opposed to what its
+# docs say, which is that it uses the location rather than the region of the
+# cluster, which could be a zone).
+resource "google_gke_hub_membership" "cloud_robotics" {
+  count = length(var.additional_regions) > 0 ? 1 : 0
+
+  membership_id = "cloud-robotics"
+  project = data.google_project.project.project_id
+  location = var.region
+  endpoint {
+    gke_cluster {
+      resource_link = google_container_cluster.cloud-robotics.id
+    }
+  }
+}
+
+resource "google_gke_hub_membership" "cloud_robotics_ar" {
+  for_each              = var.additional_regions
+  project               = data.google_project.project.project_id
+  membership_id         = format("%s-%s", each.key, "ar-cloud-robotics")
+  location = each.value.region
+  endpoint {
+    gke_cluster {
+      resource_link = google_container_cluster.cloud-robotics-ar[each.key].id
+    }
+  }
+}

--- a/src/bootstrap/cloud/terraform/project.tf
+++ b/src/bootstrap/cloud/terraform/project.tf
@@ -14,7 +14,7 @@ resource "google_project_iam_member" "owner_group" {
 resource "google_project_service" "project-services" {
   project            = data.google_project.project.project_id
   disable_on_destroy = false
-  for_each = toset([
+  for_each = toset(concat([
     "artifactregistry.googleapis.com",
     # Next 2 are needed for Terraform's data.google_project.project.resource to work.
     "cloudbilling.googleapis.com",
@@ -32,7 +32,14 @@ resource "google_project_service" "project-services" {
     "servicemanagement.googleapis.com",
     "serviceusage.googleapis.com",
     "storage-component.googleapis.com",
-  ])
+  ], length(var.additional_regions) == 0 ? [] : [
+    # Following APIs are only needed when using multi-cluster gateways.
+		"gkeconnect.googleapis.com",
+		"gkehub.googleapis.com",
+		"trafficdirector.googleapis.com",
+		"multiclusterservicediscovery.googleapis.com",
+		"multiclusteringress.googleapis.com",
+  ]))
   service = each.value
 }
 


### PR DESCRIPTION
When defining multiple regions, as an alternative to using one IP per
region, you can set up a global gateway. This doesn't add the gateway,
but it does add the necessary "fleet" or "GKE Hub" features to do this.
