### PR TITLE
Remove @cloud_robotics prefix.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,7 +69,7 @@ http_archive(
 # Binary build of the helm package manager for Kubernetes
 http_archive(
     name = "kubernetes_helm",
-    build_file = "@cloud_robotics//third_party/helm2:BUILD.bazel",
+    build_file = "//third_party/helm2:BUILD.bazel",
     sha256 = "f3bec3c7c55f6a9eb9e6586b8c503f370af92fe987fcbf741f37707606d70296",
     strip_prefix = "linux-amd64",
     urls = [
@@ -78,7 +78,7 @@ http_archive(
 )
 http_archive(
     name = "kubernetes_helm3",
-    build_file = "@cloud_robotics//third_party/helm3:BUILD.bazel",
+    build_file = "//third_party/helm3:BUILD.bazel",
     sha256 = "1484ffb0c7a608d8069470f48b88d729e88c41a1b6602f145231e8ea7b43b50a",
     strip_prefix = "linux-amd64",
     urls = [
@@ -89,7 +89,7 @@ http_archive(
 # Binary build of the terraform infrastructure management tool
 http_archive(
     name = "hashicorp_terraform",
-    build_file = "@cloud_robotics//third_party:terraform.BUILD",
+    build_file = "//third_party:terraform.BUILD",
     sha256 = "e5eeba803bc7d8d0cae7ef04ba7c3541c0abd8f9e934a5e3297bf738b31c5c6d",
     urls = [
         "https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip",
@@ -148,7 +148,7 @@ go_register_toolchains(version = "1.21.1")
 
 http_archive(
     name = "com_github_kubernetes_sigs_application",
-    build_file = "@cloud_robotics//third_party:app_crd.BUILD",
+    build_file = "//third_party:app_crd.BUILD",
     sha256 = "8bafd7fb97563d1a15d9afc68c87e3aabd664f60bd8005f1ae685d79842c1ac4",
     strip_prefix = "application-c8e2959e57a02b3877b394984a288f9178977d8b",
     urls = [

--- a/bazel/app.bzl
+++ b/bazel/app.bzl
@@ -1,4 +1,4 @@
-load("@cloud_robotics//bazel/build_rules/app_chart:run_parallel.bzl", "run_parallel")
+load("//bazel/build_rules/app_chart:run_parallel.bzl", "run_parallel")
 
 def app(name, charts, visibility = None):
     """Macro for a standard Cloud Robotics app.

--- a/bazel/app_chart.bzl
+++ b/bazel/app_chart.bzl
@@ -89,7 +89,7 @@ _app_chart_backend = rule(
             doc = "Images referenced by the chart.",
         ),
         "_chart_yaml_template": attr.label(
-            default = Label("@cloud_robotics//bazel/build_rules/app_chart:Chart.yaml.template"),
+            default = Label("//bazel/build_rules/app_chart:Chart.yaml.template"),
             allow_single_file = True,
         ),
         "_helm": attr.label(
@@ -134,9 +134,9 @@ def app_chart(
 
     if not values:
         if chart == "cloud":
-            values = "@cloud_robotics//bazel/build_rules/app_chart:values-cloud.yaml"
+            values = Label("//bazel/build_rules/app_chart:values-cloud.yaml")
         else:
-            values = "@cloud_robotics//bazel/build_rules/app_chart:values-robot.yaml"
+            values = Label("//bazel/build_rules/app_chart:values-robot.yaml")
 
     # We have a dict of string:target, but bazel rules only support target:string.
     reversed_images = {}

--- a/bazel/build_rules/app_chart/cache_gcr_credentials.bzl
+++ b/bazel/build_rules/app_chart/cache_gcr_credentials.bzl
@@ -33,7 +33,7 @@ cache_gcr_credentials = rule(
             doc = "If set, credentials for this GCR registry's domain will be precached",
         ),
         "_sh_tpl": attr.label(
-            default = Label("@cloud_robotics//bazel/build_rules/app_chart:cache_gcr_credentials.sh.tpl"),
+            default = Label("//bazel/build_rules/app_chart:cache_gcr_credentials.sh.tpl"),
             allow_single_file = True,
         ),
     },

--- a/bazel/build_rules/app_chart/push_all.bzl
+++ b/bazel/build_rules/app_chart/push_all.bzl
@@ -44,7 +44,7 @@ _push_all = rule(
             default = {},
         ),
         "_sh_tpl": attr.label(
-            default = Label("@cloud_robotics//bazel/build_rules/app_chart:push_all.sh.tpl"),
+            default = Label("//bazel/build_rules/app_chart:push_all.sh.tpl"),
             allow_single_file = True,
         ),
     },

--- a/bazel/build_rules/app_chart/run_parallel.bzl
+++ b/bazel/build_rules/app_chart/run_parallel.bzl
@@ -32,7 +32,7 @@ run_parallel = rule(
             mandatory = True,
         ),
         "_sh_tpl": attr.label(
-            default = Label("@cloud_robotics//bazel/build_rules/app_chart:run_parallel.sh.tpl"),
+            default = Label("//bazel/build_rules/app_chart:run_parallel.sh.tpl"),
             allow_single_file = True,
         ),
     },


### PR DESCRIPTION
Address the error from the migration tool:
```
Please remove the usages of referring your own repo via `@cloud_robotics//`, targets should be referenced directly with `//`.
```