### PR TITLE
Start to apply the layer 1 customization.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -157,7 +157,7 @@ robot_image_reference = "${SOURCE_CONTAINER_REGISTRY}/setup-robot@${ROBOT_IMAGE_
 crc_version = "${CRC_VERSION}"
 certificate_provider = "${CLOUD_ROBOTICS_CERTIFICATE_PROVIDER}"
 cluster_type = "${GKE_CLUSTER_TYPE}"
-onprem_federation = "${ONPREM_FEDERATION}"
+onprem_federation = ${ONPREM_FEDERATION}
 EOF
 
 # Add certificate information if the configured provider requires it

--- a/src/bootstrap/cloud/terraform/gcs.tf
+++ b/src/bootstrap/cloud/terraform/gcs.tf
@@ -5,25 +5,29 @@ resource "google_storage_bucket" "robot" {
   uniform_bucket_level_access = "true"
   force_destroy               = "true"
   depends_on                  = [google_project_service.project-services["storage-component.googleapis.com"]]
+  count                       = var.onprem_federation ? 1 : 0
 }
 
 resource "google_storage_bucket_object" "setup_robot_image_reference" {
   name          = "setup_robot_image_reference.txt"
   content       = var.robot_image_reference
-  bucket        = google_storage_bucket.robot.name
+  bucket        = google_storage_bucket.robot[0].name
   cache_control = "private, max-age=0, no-transform"
+  count         = var.onprem_federation ? 1 : 0
 }
 
 resource "google_storage_bucket_object" "setup_robot_crc_version" {
   name          = "setup_robot_crc_version.txt"
   content       = var.crc_version
-  bucket        = google_storage_bucket.robot.name
+  bucket        = google_storage_bucket.robot[0].name
   cache_control = "private, max-age=0, no-transform"
+  count         = var.onprem_federation ? 1 : 0
 }
 
 resource "google_storage_bucket_object" "setup_robot" {
   name          = "setup_robot.sh"
   source        = "../../robot/setup_robot.sh"
-  bucket        = google_storage_bucket.robot.name
+  bucket        = google_storage_bucket.robot[0].name
   cache_control = "private, max-age=0, no-transform"
+  count         = var.onprem_federation ? 1 : 0
 }

--- a/src/bootstrap/cloud/terraform/registry.tf
+++ b/src/bootstrap/cloud/terraform/registry.tf
@@ -1,19 +1,19 @@
 # Container registry configuration
 
 locals {
-    service_acounts = [
+    service_acounts = flatten([
         "serviceAccount:${google_service_account.gke_node.email}",
         "serviceAccount:${google_service_account.human-acl.email}",
-        "serviceAccount:${google_service_account.robot-service.email}",
-    ]
-    private_repo_access = distinct(flatten([
+        var.onprem_federation ? ["serviceAccount:${google_service_account.robot-service[0].email}"] : [],
+    ])
+    private_repo_access = flatten([
         for sa in local.service_acounts : [
             for prj in var.private_image_repositories : {
                 prj = prj
                 sa   = sa
             }
         ]
-    ]))
+    ])
 }
 
 resource "google_artifact_registry_repository_iam_member" "gcrio_gar_reader" {
@@ -21,15 +21,15 @@ resource "google_artifact_registry_repository_iam_member" "gcrio_gar_reader" {
   location   = "us"
   repository = "gcr.io"
   role       = "roles/artifactregistry.reader"
-  for_each   = toset(local.service_acounts)
-  member     = each.key
+  count      = length(local.service_acounts)
+  member     = local.service_acounts[count.index]
 }
 
 resource "google_artifact_registry_repository_iam_member" "private_gcrio_gar_reader" {
-  for_each   = { for entry in local.private_repo_access: "${entry.sa}.${entry.prj}" => entry }
   location   = "us"
   repository = "gcr.io"
   role       = "roles/artifactregistry.reader"
-  project    = each.value.prj
-  member     = each.value.sa
+  count      = length(local.private_repo_access)
+  project    = local.private_repo_access[count.index].prj
+  member     = local.private_repo_access[count.index].sa
 }


### PR DESCRIPTION
* make the -robot bucket optional
* make the robot-service account optional

I wanted to also avoid the token-vendor rollout in base-cloud, but that is related to human-acl and oauth2-proxy usage.