### PR TITLE
Add more ci debug logging.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -104,7 +104,11 @@ function prepare_source_install {
   oldPwd=$(pwd)
   cd ${DIR}/bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh.runfiles/${RUNFILES_ROOT}
   # DEBUG breakage
-  test -n "$MANUAL_RUN" && ls -lR || /bin/true
+  if [[  -n "$MANUAL_RUN" ]]; then
+    echo "runfiles: --------------------"
+    find -L . -name index.json -exec ls -al {} \;
+    echo "runfiles: --------------------"
+  fi
   # DEBUG breakage
   ${DIR}/bazel-bin/src/go/cmd/setup-robot/push_setup-robot.push.sh \
     --repository="${CLOUD_ROBOTICS_CONTAINER_REGISTRY}/setup-robot" \


### PR DESCRIPTION
When running locally I get:
```
MANUAL_RUN=1 ./deploy.sh update robco-ensonic
...
runfiles: --------------------
-r-xr-xr-x 2 ensonic primarygroup 406 Sep 17 07:20 ./external/_main~extension_for_rules_oci~distroless_cc_linux_amd64/layout/index.json
-r-xr-xr-x 1 ensonic primarygroup 292 Sep 17 07:37 ./src/go/cmd/setup-robot/base_image_with_files/index.json
-r-xr-xr-x 1 ensonic primarygroup 292 Sep 17 07:37 ./src/go/cmd/setup-robot/setup-robot-image/index.json
runfiles: --------------------
```