### PR TITLE
Revert to `--remote-download-toplevel`

### DIFF
--- a/.github/ci/.bazelrc
+++ b/.github/ci/.bazelrc
@@ -11,7 +11,7 @@ build --google_default_credentials=true
 # This has not been tuned a lot.
 build --jobs=12
 # No neeed to download every intermediate output to the local runner.
-build --remote_download_minimal
+build --remote_download_toplevel
 
 # Use Result Store to store Build and Test logs .
 build --bes_backend=buildeventservice.googleapis.com


### PR DESCRIPTION
Things seem to break with --remote-download-minimal