### PR TITLE
Use ${TEST_SRCDIR}/_main/ to reference test-data.

### DIFF
--- a/src/app_charts/base/app_management_test.sh
+++ b/src/app_charts/base/app_management_test.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HELM="external/_main~non_module_deps~kubernetes_helm/helm template"
-CLOUD_BASE="src/app_charts/base/base-cloud-0.0.1.tgz"
-ROBOT_BASE="src/app_charts/base/base-robot-0.0.1.tgz"
+HELM="${TEST_SRCDIR}/_main/external/_main~non_module_deps~kubernetes_helm/helm template"
+CLOUD_BASE="${TEST_SRCDIR}/_main/src/app_charts/base/base-cloud-0.0.1.tgz"
+ROBOT_BASE="${TEST_SRCDIR}/_main/src/app_charts/base/base-robot-0.0.1.tgz"
 
 function test_failed() {
   echo "TEST FAILED: $1"


### PR DESCRIPTION
This has been recommened in:
https://bazel.build/concepts/dependencies#data-dependencies

and hopefully fixes the tests on buildkite, see
https://github.com/googlecloudrobotics/core/issues/417#issuecomment-2360650787