### PR TITLE
Restore comments which have been lost in the Bzlmod migration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -99,12 +99,14 @@ use_repo(
 #######
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+# gcloud container images describe gcr.io/distroless/base:latest --format='value(image_summary.digest)'
 oci.pull(
     name = "distroless_base",
     digest = "sha256:b31a6e02605827e77b7ebb82a0ac9669ec51091edd62c2c076175e05556f4ab9",
     image = "gcr.io/distroless/base",
     platforms = ["linux/amd64"],
 )
+# gcloud container images describe gcr.io/distroless/cc:latest --format='value(image_summary.digest)'
 oci.pull(
     name = "distroless_cc",
     digest = "sha256:8aad707f96620ee89e27febef51b01c6ff244277a3560fcfcfbe68633ef09193",
@@ -113,8 +115,9 @@ oci.pull(
 )
 oci.pull(
     name = "iptables_base",
-    digest = "sha256:9c41b4c326304b94eb96fdd2e181aa6e9995cc4642fcdfb570cedd73a419ba39",
+    digest = "sha256:656e45c00083359107b1d6ae0411ff3894ba23011a8533e229937a71be84e063",
     image = "gcr.io/google-containers/debian-iptables",
+    platforms = ["linux/amd64"],
 )
 use_repo(
     oci,


### PR DESCRIPTION
We can now specify platform directly, so we use the manifest and platform now directly and the outdated comment for debian-iptables has been removed.

The `iptables_base` image doesn't have a latest tag: https://pantheon.corp.google.com/gcr/images/google-containers/GLOBAL/debian-iptables