### PR TITLE
Enable --incompatible_use_plus_in_repo_names

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,10 @@ build --incompatible_strict_action_env=true
 # See: https://github.com/bazelbuild/bazel/issues/8195
 build --incompatible_disallow_empty_glob
 
+# Use the new paths.
+# https://github.com/bazelbuild/bazel/issues/23127
+build --incompatible_use_plus_in_repo_names
+
 # Always use the pre-configured toolchain.
 build --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,16 +28,8 @@ RUNFILES_ROOT="_main"
 
 if is_source_install; then
   # Not using bazel run to not clobber the bazel-bin dir
-  TERRAFORM="${DIR}/bazel-out/../../../external/_main~non_module_deps~hashicorp_terraform/terraform"
-  HELM_COMMAND="${DIR}/bazel-out/../../../external/_main~non_module_deps~kubernetes_helm/helm"
-  if [[ ! -x "${TERRAFORM}" ]] ; then
-    TERRAFORM="${DIR}/bazel-out/../../../external/+non_module_deps+hashicorp_terraform/terraform"
-    HELM_COMMAND="${DIR}/bazel-out/../../../external/+non_module_deps+kubernetes_helm/helm"
-  fi
-  if [[ ! -x "${TERRAFORM}" ]] ; then
-    echo >&2 "Failed to locate terraform in ${DIR}."
-    exit 1
-  fi
+  TERRAFORM="${DIR}/bazel-out/../../../external/+non_module_deps+hashicorp_terraform/terraform"
+  HELM_COMMAND="${DIR}/bazel-out/../../../external/+non_module_deps+kubernetes_helm/helm"
   # To avoid a dependency on the host's glibc, we build synk with pure="on".
   # Because this is a non-default build configuration, it results in a separate
   # subdirectory of bazel-out/, which is not as easy to hardcode as

--- a/src/app_charts/base/app_management_test.sh
+++ b/src/app_charts/base/app_management_test.sh
@@ -14,10 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HELM="${TEST_SRCDIR}/_main/external/_main~non_module_deps~kubernetes_helm/helm"
-if [[ ! -x "${HELM}" ]] ; then
-  HELM="${TEST_SRCDIR}/+non_module_deps+kubernetes_helm/helm"
-fi
+HELM="${TEST_SRCDIR}/+non_module_deps+kubernetes_helm/helm"
 if [[ ! -x "${HELM}" ]] ; then
   # If we hit this again, consider using the runfiles library:
   # https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash#L55-L86

--- a/src/go/pkg/kubetest/kubetest.go
+++ b/src/go/pkg/kubetest/kubetest.go
@@ -89,9 +89,7 @@ type cluster struct {
 // New creates a new test environment.
 func New(t *testing.T, cfg Config) *Environment {
 	e := &Environment{
-		// When updating Bazel, you'll need to change this to
-		// "../+non_module_deps+kubernetes_helm/helm".
-		helmPath: "../_main~non_module_deps~kubernetes_helm/helm",
+		helmPath: "../+non_module_deps+kubernetes_helm/helm",
 		synkPath: "src/go/cmd/synk/synk_/synk",
 		t:        t,
 		cfg:      cfg,


### PR DESCRIPTION
This avoids the complexity of handling two different paths.
See #447.
