### PR TITLE
Add toolchain=None to shell actions.

### DIFF
--- a/bazel/app_chart.bzl
+++ b/bazel/app_chart.bzl
@@ -41,6 +41,7 @@ def _impl(ctx):
         outputs = [values_yaml],
         inputs = ctx.files.values + source_digests,
         command = "\n".join(cmds),
+        toolchain = None,
     )
 
     helm_chart(

--- a/bazel/build_rules/helm_chart.bzl
+++ b/bazel/build_rules/helm_chart.bzl
@@ -42,4 +42,5 @@ def helm_chart(ctx, name, chart, files, templates, values, version, helm, out):
         tools = [helm],
         outputs = [out],
         command = cmd,
+        toolchain = None,
     )


### PR DESCRIPTION
This prepares us for bazel-head. We still need to bump used rules (e.g. rules_oci) when they ship a fix.

See #451.