### PR TITLE
Make tokensource less stateful.

### DIFF
--- a/src/go/cmd/token-vendor/main.go
+++ b/src/go/cmd/token-vendor/main.go
@@ -139,12 +139,13 @@ func main() {
 		slog.Error("Failed to make verifier", ilog.Err(err))
 		os.Exit(1)
 	}
-	ts, err := tokensource.NewGCPTokenSource(ctx, nil, *project, *robotName, scopes)
+	ts, err := tokensource.NewGCPTokenSource(ctx, nil, scopes)
 	if err != nil {
 		slog.Error("Failed to make token source", ilog.Err(err))
 		os.Exit(1)
 	}
-	tv, err := app.NewTokenVendor(ctx, rep, verifier, ts, *acceptedAudience)
+	saName := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", *robotName, *project)
+	tv, err := app.NewTokenVendor(ctx, rep, verifier, ts, *acceptedAudience, saName)
 	if err != nil {
 		slog.Error("Failed to make token vendor", ilog.Err(err))
 		os.Exit(1)


### PR DESCRIPTION
Now it always gets the service-account-name. Putting the amail together has been move up to main.

This way we can log the used service accoutn in one place.