### PR TITLE
We only need to expose the GKE k8s api if we enable onprem-federation.

### DIFF
--- a/src/app_charts/base/cloud/kubernetes-api.yaml
+++ b/src/app_charts/base/cloud/kubernetes-api.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.onprem_federation }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -37,3 +38,4 @@ spec:
             name: kubernetes
             port:
               number: 443
+{{ end }}


### PR DESCRIPTION
The ingress is used by the cr-syncer.

See #440