### PR TITLE
Add support for enabling secret manager plugin on cluster

### DIFF
--- a/config.sh.tmpl
+++ b/config.sh.tmpl
@@ -51,3 +51,6 @@ APP_MANAGEMENT=true
 
 # Enable google cloud robotics layer 1
 ONPREM_FEDERATION=true
+
+# Disable the secret manager integration by default
+GKE_SECRET_MANAGER_PLUGIN=false

--- a/deploy.sh
+++ b/deploy.sh
@@ -51,6 +51,7 @@ function include_config_and_defaults {
   CLOUD_ROBOTICS_DOMAIN=${CLOUD_ROBOTICS_DOMAIN:-"www.endpoints.${GCP_PROJECT_ID}.cloud.goog"}
   APP_MANAGEMENT=${APP_MANAGEMENT:-false}
   ONPREM_FEDERATION=${ONPREM_FEDERATION:-true}
+  GKE_SECRET_MANAGER_PLUGIN=${GKE_SECRET_MANAGER_PLUGIN:-false}
 
   # lets-encrypt is used as the default certificate provider for backwards compatibility purposes
   CLOUD_ROBOTICS_CERTIFICATE_PROVIDER=${CLOUD_ROBOTICS_CERTIFICATE_PROVIDER:-lets-encrypt}
@@ -158,6 +159,7 @@ crc_version = "${CRC_VERSION}"
 certificate_provider = "${CLOUD_ROBOTICS_CERTIFICATE_PROVIDER}"
 cluster_type = "${GKE_CLUSTER_TYPE}"
 onprem_federation = ${ONPREM_FEDERATION}
+secret_manager_plugin = ${GKE_SECRET_MANAGER_PLUGIN}
 EOF
 
 # Add certificate information if the configured provider requires it
@@ -429,6 +431,7 @@ function helm_region_shared {
     --set-string "oauth2_proxy.client_secret=${CLOUD_ROBOTICS_OAUTH2_CLIENT_SECRET}"
     --set-string "oauth2_proxy.cookie_secret=${CLOUD_ROBOTICS_COOKIE_SECRET}"
     --set "use_tv_verbose=${CRC_USE_TV_VERBOSE}"
+    --set "secret_manager_plugin=${GKE_SECRET_MANAGER_PLUGIN}"
   )
 
   ${SYNK_COMMAND} --context "${CLUSTER_CONTEXT}" init

--- a/deploy.sh
+++ b/deploy.sh
@@ -431,7 +431,6 @@ function helm_region_shared {
     --set-string "oauth2_proxy.client_secret=${CLOUD_ROBOTICS_OAUTH2_CLIENT_SECRET}"
     --set-string "oauth2_proxy.cookie_secret=${CLOUD_ROBOTICS_COOKIE_SECRET}"
     --set "use_tv_verbose=${CRC_USE_TV_VERBOSE}"
-    --set "secret_manager_plugin=${GKE_SECRET_MANAGER_PLUGIN}"
   )
 
   ${SYNK_COMMAND} --context "${CLUSTER_CONTEXT}" init

--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -37,6 +37,9 @@ resource "google_container_cluster" "cloud-robotics" {
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
+  secret_manager_config {
+    enabled = var.secret_manager_plugin
+  }
 }
 
 resource "google_container_cluster" "cloud-robotics-ar" {

--- a/src/bootstrap/cloud/terraform/input.tf
+++ b/src/bootstrap/cloud/terraform/input.tf
@@ -80,3 +80,9 @@ variable "onprem_federation" {
   type        = bool
   default     = true
 }
+
+variable "secret_manager_plugin" {
+  description = "Enable GKE secret manager integration with GKE"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This allows integration with the secret manager via kubernetes secrets. It allows to keep secrets secure while providing it to applications via file.

Current intended usecase is an auth_password_file for alertmanager.

TESTED=not yet