### PR TITLE
Use longer names for the relay servers.

### DIFF
--- a/src/app_charts/k8s-relay/cloud/kubernetes-relay-server.yaml
+++ b/src/app_charts/k8s-relay/cloud/kubernetes-relay-server.yaml
@@ -13,7 +13,7 @@ spec:
         app: kubernetes-relay-server
     spec:
       containers:
-      - name: server
+      - name: kubernetes-relay-server
         image: {{ .Values.registry }}{{ .Values.images.http_relay_server }}
         args:
         - --port=8080

--- a/src/app_charts/prometheus/cloud/prometheus-relay.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-relay.yaml
@@ -15,7 +15,7 @@ spec:
         app: prometheus-relay-server
     spec:
       containers:
-      - name: server
+      - name: prometheus-relay-server
         image: {{ .Values.registry }}{{ .Values.images.http_relay_server }}
         args:
         - --port=8080


### PR DESCRIPTION
This aligns with the client names and makes it easier to find them in the logs.