### PR TITLE
Add support for intermediate delegates.

### DIFF
--- a/src/go/cmd/token-vendor/README.md
+++ b/src/go/cmd/token-vendor/README.md
@@ -66,6 +66,7 @@ Configure optional properties of the on-prem robot registration.
   * device-id: unique device name (by default robot-<robot-id>)
 * Body: json {
   service-account: str, defaults to robot-service@<gcp-project>.iam.gserviceaccount.com"
+  service-account-delegate: str, optional intermediate delegate
 }
 * Response: only http status code
 

--- a/src/go/cmd/token-vendor/repository/k8s/k8s.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s.go
@@ -47,6 +47,8 @@ const (
 	pubKey = "pubKey" // Configmap key for the public key
 	// Configmap annotation specifies the service account to use (optional)
 	serviceAccountAnnotation = "cloudrobotics.com/gcp-service-account"
+	// Configmap annotation specifies the intermediate service account delegate to use (optional)
+	serviceAccountDelegateAnnotation = "cloudrobotics.com/gcp-service-account-delegate"
 )
 
 // ListAllDeviceIDs returns a slice of all device identifiers found in the namespace.
@@ -82,7 +84,8 @@ func (k *K8sRepository) LookupKey(ctx context.Context, deviceID string) (*reposi
 		return nil, fmt.Errorf("configmap %q/%q does not contain key %q", k.ns, deviceID, pubKey)
 	}
 	sa, _ := cm.ObjectMeta.Annotations[serviceAccountAnnotation]
-	return &repository.Key{key, sa}, nil
+	saDelegate, _ := cm.ObjectMeta.Annotations[serviceAccountDelegateAnnotation]
+	return &repository.Key{key, sa, saDelegate}, nil
 }
 
 // PublishKey sets or updates a public key for a given device identifier.

--- a/src/go/cmd/token-vendor/repository/memory/memory.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory.go
@@ -44,5 +44,5 @@ func (m *MemoryRepository) LookupKey(ctx context.Context, deviceID string) (*rep
 	if !found {
 		return nil, nil
 	}
-	return &repository.Key{k, ""}, nil
+	return &repository.Key{k, "", ""}, nil
 }

--- a/src/go/cmd/token-vendor/repository/repository.go
+++ b/src/go/cmd/token-vendor/repository/repository.go
@@ -25,6 +25,8 @@ type Key struct {
 	PublicKey string
 	// SAName is the optional GCP IAM service-account that has been associated.
 	SAName string
+	// SADelegateName is the optional GCP IAM service-account to act as an intermediate delegate
+	SADelegateName string
 }
 
 // PubKeyRepository defines the api for the pub key stores


### PR DESCRIPTION
This allows for setups where actual permisisons are granted on the delegate and the robot-sa only needs the permisisons to impersonate the delegate.

See b/367635510