### PR TITLE
Fix references of the old java token vendor.

### DIFF
--- a/docs/concepts/device_identity.md
+++ b/docs/concepts/device_identity.md
@@ -17,7 +17,7 @@ The following components are part of the whole setup:
 
 The following chapters explain the flows in more detail. Further information
 about the Token Vendor can be found in its
-[docs](https://github.com/googlecloudrobotics/core/tree/master/src/java/com/cloudrobotics/tokenvendor/README.md)
+[docs](https://github.com/googlecloudrobotics/core/tree/master/src/go/cmd/token-vendor/README.md)
 
 ## Setup
 

--- a/src/go/cmd/token-vendor/app/tokenvendor.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor.go
@@ -139,7 +139,7 @@ func (tv *TokenVendor) getOAuth2Token(ctx context.Context, jwtk string) (*tokens
 	return cloudToken, nil
 }
 
-// acceptedAudience validates JWT audience as defined by Java-based token vendor
+// acceptedAudience validates JWT audience as defined by the token vendor
 //
 // `aud` is the value of the audience key from the JWT and `accAud` the configured
 // accepted audience of the token vendor.


### PR DESCRIPTION
For the 2nd, update the link to the new codebase.