### PR TITLE
Cleanup robotauth tokensource config.

### DIFF
--- a/src/go/pkg/robotauth/robotauth.go
+++ b/src/go/pkg/robotauth/robotauth.go
@@ -160,12 +160,14 @@ func (r *RobotAuth) getTokenEndpoint() string {
 // service account.
 func (r *RobotAuth) CreateRobotTokenSource(ctx context.Context) oauth2.TokenSource {
 	c := jwt.Config{
-		Email:      r.PublicKeyRegistryId, // Will be used as "issuer" of the outgoing JWT.
+		// Will be used as "issuer" of the outgoing JWT. Is not formatted as an email though
+		Email:      r.PublicKeyRegistryId,
 		Expires:    time.Minute * 30,
 		PrivateKey: r.PrivateKey,
-		Scopes:     []string{r.getTokenEndpoint()},
-		Subject:    r.RobotName,
-		TokenURL:   r.getTokenEndpoint(),
+		Scopes:     []string{},
+		// TODO: shouldn't this be the service-account name we want to get the token for?
+		Subject:  r.RobotName,
+		TokenURL: r.getTokenEndpoint(),
 	}
 	return c.TokenSource(ctx)
 }


### PR DESCRIPTION
Leave the scopes empty
This is optional and we already sent the data else where. I've deployed this to robco-ensonic and connected minikube to it. I also started hello-k8s and observed that the logs are captured in the cloud.

Add some more comments on the other fields as well.