### PR TITLE
Protect PutRequestStream with a mutex

### DIFF
--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -319,7 +319,7 @@ func (r *broker) ReapInactiveRequests(threshold time.Time) {
 	for id, pr := range r.resp {
 		if pr.lastActivity.Before(threshold) {
 			slog.Info("Timeout on inactive request", slog.String("ID", id))
-			// Closing `pr.markReap` tells `SendResponse` to stop waiting for the client.
+			// Closing `pr.markReap` tells `SendResponse` and `PutRequestStream` to stop.
 			close(pr.markReap)
 
 			pr.requestStreamMutex.Lock()

--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -237,13 +237,13 @@ func (r *broker) GetRequestStream(id string) ([]byte, bool) {
 func (r *broker) PutRequestStream(id string, data []byte) bool {
 	r.m.Lock()
 	pr := r.resp[id]
+	if pr == nil {
+		r.m.Unlock()
+		return false
+	}
 	pr.requestStreamMutex.Lock()
 	defer pr.requestStreamMutex.Unlock()
 	r.m.Unlock()
-
-	if pr == nil {
-		return false
-	}
 
 	select {
 	case pr.requestStream <- data:

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -303,3 +303,50 @@ func TestReapWhileSendingResponse(t *testing.T) {
 	b.ReapInactiveRequests(time.Now().Add(10 * time.Second))
 	wg.Wait()
 }
+
+func TestReapWhileSendingRequest(t *testing.T) {
+	b := newBroker()
+	b.req["foo"] = make(chan *pb.HttpRequest)
+
+	// create a broker connection between the user client and backend side, but don't
+	// start sending data. "req" is backend side and "resp" is user client side.
+	var req *pb.HttpRequest
+	var reqErr error
+	// var resp <-chan *pb.HttpResponse
+	var respErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		req, reqErr = b.GetRequest(context.Background(), "foo", "/")
+		if reqErr != nil {
+			t.Errorf("GetRequest error:", reqErr)
+		}
+		wg.Done()
+	}()
+	go func() {
+		_, respErr = b.RelayRequest("foo", &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com/foo")})
+		if respErr != nil {
+			t.Errorf("RelayRequest error:", respErr)
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+	if reqErr != nil || respErr != nil {
+		t.Errorf("Error making broker connection")
+	}
+
+	// start sending response to backend, BUT do not start consuming on the backend side
+	wg.Add(1)
+	go func() {
+		if ok := b.PutRequestStream(*req.Id, []byte(*req.Id)); !ok {
+			t.Errorf("Error putting request stream")
+		}
+		wg.Done()
+	}()
+	// FIXME(koonpeng): we need to wait for the goroutinue to be blocked on writing the request, currently
+	// there is no way to confirm that so we use a sleep.
+	time.Sleep(100 * time.Millisecond)
+	// reap the request
+	b.ReapInactiveRequests(time.Now().Add(10 * time.Second))
+	wg.Wait()
+}


### PR DESCRIPTION
`pr.requestStream` may be closed while it is writing because there is no mutex protecting it. This can happen when the request is reaped due to inactivity, if this happens then the server will panic.