### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
actions/cache was not updated, leading to a presubmit failure. I hope
this makes dependabot also update GitHub Actions avoiding this in
future.

I've never configured Dependabot before and don't know how to test this
so apologies in advance if it creates many noisy PRs.
