### PR TITLE
Run Gazelle to fix BUILD files

### DIFF
--- a/src/app_charts/akri/BUILD.bazel
+++ b/src/app_charts/akri/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//bazel:build_rules/helm_template.bzl", "helm_template")
-load("//bazel:app_chart.bzl", "app_chart")
 load("//bazel:app.bzl", "app")
+load("//bazel:app_chart.bzl", "app_chart")
+load("//bazel:build_rules/helm_template.bzl", "helm_template")
 
 helm_template(
     name = "akri-chart.robot",

--- a/src/app_charts/k8s-relay/BUILD.bazel
+++ b/src/app_charts/k8s-relay/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bazel:app_chart.bzl", "app_chart")
 load("//bazel:app.bzl", "app")
+load("//bazel:app_chart.bzl", "app_chart")
 
 app_chart(
     name = "k8s-relay-cloud",

--- a/src/app_charts/prometheus/BUILD.bazel
+++ b/src/app_charts/prometheus/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//bazel:build_rules/helm_template.bzl", "helm_template")
-load("//bazel:app_chart.bzl", "app_chart")
 load("//bazel:app.bzl", "app")
+load("//bazel:app_chart.bzl", "app_chart")
+load("//bazel:build_rules/helm_template.bzl", "helm_template")
 
 helm_template(
     name = "prometheus-operator-chart.cloud",

--- a/src/app_charts/token-vendor/BUILD.bazel
+++ b/src/app_charts/token-vendor/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//bazel:app_chart.bzl", "app_chart")
 load("//bazel:app.bzl", "app")
+load("//bazel:app_chart.bzl", "app_chart")
 
 app_chart(
     name = "token-vendor-cloud",

--- a/src/go/cmd/token-vendor/repository/k8s/BUILD.bazel
+++ b/src/go/cmd/token-vendor/repository/k8s/BUILD.bazel
@@ -6,12 +6,12 @@ go_library(
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/repository/k8s",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/go/cmd/token-vendor/repository:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
-        "//src/go/cmd/token-vendor/repository:go_default_library",
     ],
 )
 
@@ -19,8 +19,5 @@ go_test(
     name = "go_default_test",
     srcs = ["k8s_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "@io_k8s_client_go//kubernetes/fake:go_default_library",
-        "//src/go/cmd/token-vendor/repository:go_default_library",
-    ],
+    deps = ["@io_k8s_client_go//kubernetes/fake:go_default_library"],
 )

--- a/src/go/cmd/token-vendor/repository/memory/BUILD.bazel
+++ b/src/go/cmd/token-vendor/repository/memory/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/go/cmd/token-vendor/repository:go_default_library",
-    ]
+    ],
 )
 
 go_test(

--- a/src/go/pkg/controller/chartassignment/BUILD.bazel
+++ b/src/go/pkg/controller/chartassignment/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@bazel_gomock//:gomock.bzl", "gomock")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/src/go/pkg/robotauth/BUILD.bazel
+++ b/src/go/pkg/robotauth/BUILD.bazel
@@ -22,5 +22,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "@io_k8s_client_go//kubernetes/fake:go_default_library",
+        "@org_golang_x_oauth2//jws:go_default_library",
     ],
 )

--- a/src/go/pkg/setup/BUILD.bazel
+++ b/src/go/pkg/setup/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@bazel_gomock//:gomock.bzl", "gomock")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/src/proto/http-relay/BUILD.bazel
+++ b/src/proto/http-relay/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # http relay api
 


### PR DESCRIPTION
This looks to be a no-op but makes it easier to keep BUILD dependencies
up to date with `bazel run :gazelle`.
