### PR TITLE
Enable metadata-server on GKE

### DIFF
--- a/scripts/robot-sim.sh
+++ b/scripts/robot-sim.sh
@@ -65,6 +65,11 @@ function create {
 
   gke_get_credentials "${GCP_PROJECT_ID}" "${ROBOT_NAME}" "${GCP_REGION}" "${GCP_ZONE}"
 
+  POD_CIDR=$(gcloud container clusters describe "${ROBOT_NAME}" \
+    --project=${GCP_PROJECT_ID} \
+    --zone=${GCP_ZONE} \
+    | grep podIpv4CidrBlock | awk '{print $2;}')
+
   # shellcheck disable=2097 disable=2098
   KUBE_CONTEXT=${GKE_SIM_CONTEXT} \
   HOST_HOSTNAME="nic0.${ROBOT_NAME}${GCP_ZONE}.c.${GCP_PROJECT_ID}.internal.gcpnode.com" \
@@ -72,7 +77,11 @@ function create {
     $DIR/../src/bootstrap/robot/setup_robot.sh \
     ${ROBOT_NAME} \
     --project ${GCP_PROJECT_ID} \
-    --robot-type "${ROBOT_TYPE}" --robot-authentication=false \
+    --robot-type "${ROBOT_TYPE}" \
+    --fluentd=false \
+    --fluentbit=false \
+    --running-on-gke=true \
+    --pod-cidr "${POD_CIDR}" \
     --labels "${ROBOT_LABELS}"
 }
 

--- a/src/app_charts/base/robot/gcr-credential-refresher.yaml
+++ b/src/app_charts/base/robot/gcr-credential-refresher.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.robot_authentication "true") (ne .Values.project "") }}
+{{ if and (eq .Values.robot_authentication "true") (ne .Values.project "") (eq .Values.running_on_gke "false") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/app_charts/base/robot/metadata-server.yaml
+++ b/src/app_charts/base/robot/metadata-server.yaml
@@ -32,6 +32,7 @@ spec:
         - --port=8965
         - --robot_id_file=/credentials/robot-id.json
         - --source_cidr={{ .Values.pod_cidr }}
+        - --running_on_gke={{ .Values.running_on_gke }}
         securityContext:
           readOnlyRootFilesystem: true  
           capabilities:

--- a/src/app_charts/base/values-robot.yaml
+++ b/src/app_charts/base/values-robot.yaml
@@ -27,6 +27,9 @@ docker_data_root: "/var/lib/docker"
 # metadata-server or gcr-credential-refresher.
 robot_authentication: "true"
 
+# If running on GKE, skip setup steps that are unnecessary and will fail.
+running_on_gke: "false"
+
 robot:
   name: ""
 

--- a/src/go/cmd/setup-robot/main.go
+++ b/src/go/cmd/setup-robot/main.go
@@ -62,6 +62,7 @@ var (
 			"configuration (eg Cilium's clusterPoolIPv4PodCIDR). If this is incorrect, "+
 			"pods will get 403 Forbidden when trying to reach the metadata server.")
 	robotAuthentication = flag.Bool("robot-authentication", true, "Set up robot authentication.")
+	runningOnGKE        = flag.Bool("running-on-gke", false, "If running on GKE, skip setup steps that are unnecessary and will fail.")
 
 	robotGVR = schema.GroupVersionResource{
 		Group:    "registry.cloudrobotics.com",
@@ -352,6 +353,7 @@ func installChartOrDie(ctx context.Context, cs *kubernetes.Clientset, domain, re
 		"docker_data_root":     *dockerDataRoot,
 		"pod_cidr":             *podCIDR,
 		"robot_authentication": strconv.FormatBool(*robotAuthentication),
+		"running_on_gke":       strconv.FormatBool(*runningOnGKE),
 		"robot.name":           *robotName,
 	})
 	slog.Info("Installing chart using Synk",


### PR DESCRIPTION
This makes the GKE environment more similar to real systems, and in
particular will let the cr-syncer fetch robot JWTs from the
metadata-server.

Tested with:

```
./deploy.sh update my-test-project
./scripts/robot-sim.sh create my-test-project robot-sim
```

then checking that cr-syncer and metadata-server logs both looked OK.
