### PR TITLE
cr-syncer: authenticate with robot JWTs from metadata-server

### DIFF
--- a/src/go/cmd/cr-syncer/BUILD.bazel
+++ b/src/go/cmd/cr-syncer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/cr-syncer",
     visibility = ["//visibility:private"],
     deps = [
+        "//src/go/pkg/robotauth:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@com_github_motemen_go_loghttp//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/src/go/pkg/robotauth/robotauth.go
+++ b/src/go/pkg/robotauth/robotauth.go
@@ -236,25 +236,25 @@ func (ts *robotJWTSource) Token() (*oauth2.Token, error) {
 	defer resp.Body.Close()
 
 	// Read body before checking status to ensure connection can be reused.
-	tokenBytes, err := io.ReadAll(resp.Body)
+	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}
-	tokenString := string(tokenBytes)
+	responseString := string(responseBytes)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %d, body:\n%s", resp.StatusCode, tokenString)
+		return nil, fmt.Errorf("status code %d, body:\n%s", resp.StatusCode, responseString)
 	}
 
 	// Decode token so we can set the expiry and the client knows when to
 	// refresh. No need to check the signature here (onprem) as it will be
 	// checked by the cloud backend.
-	claims, err := jws.Decode(tokenString)
+	claims, err := jws.Decode(responseString)
 	if err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 	return &oauth2.Token{
 		TokenType:   "Bearer",
-		AccessToken: tokenString,
+		AccessToken: responseString,
 		Expiry:      time.Unix(claims.Exp, 0),
 	}, nil
 }


### PR DESCRIPTION
These are more limited than the GCP access token, as they can't list all
syncable CRs in the GKE cluster.

Tested by deploying the WIP cr-syncer-auth-webhook from the
rodrigoq/cr-syncer-auth branch, creating a fake-robot-sim CR, and then testing
the following cr-syncer flag combinations:

- `--robot-name=robot-sim      --use-robot-jwt=false`: syncs changes to the robot-sim CR
- `--robot-name=fake-robot-sim --use-robot-jwt=false`: syncs changes to the fake-robot-sim CR
- `--robot-name=robot-sim      --use-robot-jwt=true`: syncs changes to the robot-sim CR
- `--robot-name=fake-robot-sim --use-robot-jwt=true`: fails with Forbidden errors
