### PR TITLE
Add no-op cr-syncer-auth-webhook

### DIFF
--- a/src/app_charts/base/BUILD.bazel
+++ b/src/app_charts/base/BUILD.bazel
@@ -103,6 +103,7 @@ app_chart(
     images = {
         "app-rollout-controller": "//src/go/cmd/app-rollout-controller:app-rollout-controller-image",
         "chart-assignment-controller": "//src/go/cmd/chart-assignment-controller:chart-assignment-controller-image",
+        "cr-syncer-auth-webhook": "//src/go/cmd/cr-syncer-auth-webhook:cr-syncer-auth-webhook-image",
     },
     values = "values-cloud.yaml",
     visibility = ["//visibility:public"],

--- a/src/app_charts/base/cloud/cr-syncer-auth-webhook.yaml
+++ b/src/app_charts/base/cloud/cr-syncer-auth-webhook.yaml
@@ -1,0 +1,66 @@
+{{ if .Values.onprem_federation }}
+# The cr-syncer-auth-webhook verifies that requests from the cr-syncer are
+# limited to the robot named in the credentials.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cr-syncer-auth-webhook
+spec:
+  selector:
+    matchLabels:
+      app: cr-syncer-auth-webhook
+  template:
+    metadata:
+      labels:
+        app: cr-syncer-auth-webhook
+    spec:
+      containers:
+      - name: cr-syncer-auth-webhook
+        image: {{ .Values.registry }}{{ .Values.images.cr_syncer_auth_webhook }}
+        args:
+        - --port=8080
+        - --accept-legacy-service-account-credentials
+        - --token-vendor=http://token-vendor.app-token-vendor.svc.cluster.local
+        ports:
+        - name: webhook
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      serviceAccountName: cr-syncer-auth-webhook
+---
+# The incoming request from the cr-syncer will be extended with a header to
+# impersonate this SA if it passes the webhook's policy checks.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cr-syncer-auth-webhook
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cr-syncer-auth-webhook
+  labels:
+    app: cr-syncer-auth-webhook
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: cr-syncer-auth-webhook
+  type: ClusterIP
+{{ end }}

--- a/src/app_charts/base/cloud/cr-syncer-policy.yaml
+++ b/src/app_charts/base/cloud/cr-syncer-policy.yaml
@@ -69,3 +69,8 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: robot-service@{{ .Values.project }}.iam.gserviceaccount.com
+# The grant for the cr-syncer-auth-webhook replaces the grant for the
+# robot-service@ account.
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: cr-syncer-auth-webhook

--- a/src/app_charts/base/cloud/kubernetes-api.yaml
+++ b/src/app_charts/base/cloud/kubernetes-api.yaml
@@ -4,6 +4,8 @@ kind: Ingress
 metadata:
   name: kubernetes-api
   annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://cr-syncer-auth-webhook.default.svc.cluster.local/auth
+    nginx.ingress.kubernetes.io/auth-response-headers: Authorization
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"  # seconds

--- a/src/go/cmd/cr-syncer-auth-webhook/BUILD.bazel
+++ b/src/go/cmd/cr-syncer-auth-webhook/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/googlecloudrobotics/core/src/go/cmd/cr-syncer-auth-webhook",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_googlecloudrobotics_ilog//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cr-syncer-auth-webhook-app",
+    embed = [":go_default_library"],
+)
+
+pkg_tar(
+    name = "cr-syncer-auth-webhook-layer",
+    srcs = [":cr-syncer-auth-webhook-app"],
+    extension = "tar.gz",
+)
+
+oci_image(
+    name = "cr-syncer-auth-webhook-image",
+    base = "@distroless_base",
+    entrypoint = ["/cr-syncer-auth-webhook-app"],
+    tars = [":cr-syncer-auth-webhook-layer"],
+)

--- a/src/go/cmd/cr-syncer-auth-webhook/main.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/main.go
@@ -27,8 +27,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/googlecloudrobotics/ilog"
 	"github.com/pkg/errors"
+
+	"github.com/googlecloudrobotics/ilog"
 )
 
 var (

--- a/src/go/cmd/cr-syncer-auth-webhook/main.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/main.go
@@ -40,6 +40,9 @@ var (
 
 	tokenVendor = flag.String("token-vendor", "http://token-vendor.app-token-vendor.svc.cluster.local",
 		"Hostname of the token-vendor service")
+
+	logLevel = flag.Int("log-level", int(slog.LevelInfo),
+		"the log message level required to be logged")
 )
 
 type handlers struct {
@@ -69,7 +72,7 @@ func (h *handlers) auth(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	logHandler := ilog.NewLogHandler(slog.LevelInfo, os.Stderr)
+	logHandler := ilog.NewLogHandler(slog.Level(*logLevel), os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
 	server := &http.Server{

--- a/src/go/cmd/cr-syncer-auth-webhook/main.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/main.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Cloud Robotics Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The cr-syncer-auth-webhook verifies that requests from the cr-syncer are
+// limited to the robot named in the credentials.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/googlecloudrobotics/ilog"
+	"github.com/pkg/errors"
+)
+
+var (
+	port = flag.Int("port", 8080,
+		"Listening port for HTTP requests")
+
+	acceptLegacyCredentials = flag.Bool("accept-legacy-service-account-credentials", false,
+		"Whether to accept legacy GCP service account credentials")
+
+	tokenVendor = flag.String("token-vendor", "http://token-vendor.app-token-vendor.svc.cluster.local",
+		"Hostname of the token-vendor service")
+)
+
+type handlers struct {
+	client *http.Client
+}
+
+func newHandlers() handlers {
+	return handlers{
+		client: &http.Client{},
+	}
+}
+
+func (h *handlers) health(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *handlers) auth(w http.ResponseWriter, r *http.Request) {
+	// TODO(rodrigoq): check for JWT and compare to request pattern
+	if *acceptLegacyCredentials {
+		// The request already has the necessary credentials, so preserve these.
+		w.Header().Add("Authorization", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	http.Error(w, "No valid credentials provided", http.StatusUnauthorized)
+}
+
+func main() {
+	flag.Parse()
+	logHandler := ilog.NewLogHandler(slog.LevelInfo, os.Stderr)
+	slog.SetDefault(slog.New(logHandler))
+
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%d", *port),
+	}
+	handlers := newHandlers()
+	http.HandleFunc("/healthz", handlers.health)
+	http.HandleFunc("/auth", handlers.auth)
+
+	go func() {
+		slog.Info("Serving requests...")
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("server.ListenAndServe() failed unexpectedly", ilog.Err(err))
+			os.Exit(1)
+		}
+		slog.Info("Stopped serving new connections.")
+	}()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		slog.Error("server.Shutdown() failed unexpectedly", ilog.Err(err))
+		os.Exit(1)
+	}
+	slog.Info("Server shutdown complete.")
+}


### PR DESCRIPTION
This just allows all requests so that they pass through to GKE with
their existing (GCP access token) credentials.

A followup will fix the TODO by accepting robot JWTs.
