### PR TITLE
Mark relay test as flaky

### DIFF
--- a/src/go/tests/relay/BUILD.bazel
+++ b/src/go/tests/relay/BUILD.bazel
@@ -5,6 +5,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "in_process_relay_test",
     size = "small",
+    # https://github.com/googlecloudrobotics/core/issues/507
+    flaky = True,
     srcs = ["in_process_relay_test.go"],
     deps = [
         "//src/go/cmd/http-relay-client/client:go_default_library",


### PR DESCRIPTION
https://github.com/googlecloudrobotics/core/issues/507 - it's 1-3%
flaky. I haven't looked into the details. Setting this flag makes Bazel
rerun the test so it's less likely to confuse people making unrelated
changes or affect presubmits.
