### PR TITLE
Implement cr-syncer-auth-webhook

### DIFF
--- a/src/go/cmd/cr-syncer-auth-webhook/BUILD.bazel
+++ b/src/go/cmd/cr-syncer-auth-webhook/BUILD.bazel
@@ -6,12 +6,16 @@ package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "request.go",
+    ],
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/cr-syncer-auth-webhook",
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@org_golang_x_oauth2//jws:go_default_library",
     ],
 )
 

--- a/src/go/cmd/cr-syncer-auth-webhook/main.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/main.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -48,19 +47,9 @@ var (
 
 	logLevel = flag.Int("log-level", int(slog.LevelInfo),
 		"the log message level required to be logged")
-
-	// Regex for RFC 1123 subdomain format
-	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	// https://github.com/kubernetes/kubernetes/blob/976a940f4a4e84fe814583848f97b9aafcdb083f/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L209
-	isValidRobotName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`).MatchString
 )
 
-const (
-	verifyJWTEndpoint = "/apis/core.token-vendor/v1/jwt.verify"
-
-	// the prefix of the label selector query param used by the cr-syncer
-	robotNameSelectorPrefix = "cloudrobotics.com/robot-name="
-)
+const verifyJWTEndpoint = "/apis/core.token-vendor/v1/jwt.verify"
 
 type handlers struct {
 	client *http.Client

--- a/src/go/cmd/cr-syncer-auth-webhook/request.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/request.go
@@ -5,11 +5,20 @@ package main
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
 )
+
+// Regex for RFC 1123 subdomain format
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+// https://github.com/kubernetes/kubernetes/blob/976a940f4a4e84fe814583848f97b9aafcdb083f/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L209
+var isValidRobotName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`).MatchString
+
+// the prefix of the label selector query param used by the cr-syncer
+const robotNameSelectorPrefix = "cloudrobotics.com/robot-name="
 
 // incomingRequest contains the authz-relevant properties of the resource
 type incomingRequest struct {

--- a/src/go/cmd/cr-syncer-auth-webhook/request.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/request.go
@@ -1,0 +1,75 @@
+// request.go contains methods for understanding and validating the incoming
+// request.
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// incomingRequest contains the authz-relevant properties of the resource
+type incomingRequest struct {
+	// GroupKind, eg "registry.cloudrobotics.com/robots"
+	GroupKind string
+
+	// RobotName, or empty if no label selector is used (eg for a Get or Update)
+	RobotName string
+
+	// ResourceName, or empty if no resource is specified (eg for a List or Watch of a filtered resource)
+	ResourceName string
+}
+
+// parseURL parses the URL that the cr-syncer is hitting to find the
+// authz-relevant properties.
+func parseURL(urlString string) (*incomingRequest, error) {
+	result := incomingRequest{}
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	// Path should be one of:
+	//  /apis/core.kubernetes/apis/<group>/<version>/<kind>
+	//  /apis/core.kubernetes/apis/<group>/<version>/namespaces/<namespace>/<kind>
+	//  /apis/core.kubernetes/apis/<group>/<version>/namespaces/<namespace>/<kind>/<resourceName>
+	//  /apis/core.kubernetes/apis/<group>/<version>/namespaces/<namespace>/<kind>/<resourceName>/status
+	//                             parts[0] parts[1] parts[2]   parts[3]   parts[4] parts[5]
+	parts := strings.Split(strings.TrimPrefix(url.Path, "/apis/core.kubernetes/apis/"), "/")
+	if len(parts) < 3 || len(parts) > 7 {
+		return nil, errors.New("unexpected URL length")
+	}
+	if parts[2] != "namespaces" {
+		// Add in "/namespaces/default" so remaining code can use fixed indices.
+		// I also considered a regexp but it's not pretty:
+		// "/apis/core.kubernetes/apis/([^/]*)/([^/]*)(/namespaces/[^/]*)?/([^/]*)/?([^/]*)(/status)?"
+		parts = slices.Insert(parts, 2, "namespaces", "default")
+	}
+
+	result.GroupKind = fmt.Sprintf("%s/%s", parts[0], parts[4])
+	if len(parts) > 5 {
+		// if a resourceName is in the URL, we don't need to look at the query parameters
+		result.ResourceName = parts[5]
+		return &result, nil
+	}
+
+	// If we have no resourceName, this is a list/watch request, so check for a
+	// labelSelector.
+	params := url.Query()
+	labelSelectors := params["labelSelector"]
+	if len(labelSelectors) == 0 {
+		// This is an unfiltered List or Watch request (eg for robottypes).
+		return &result, nil
+	}
+	if len(labelSelectors) > 1 || !strings.HasPrefix(labelSelectors[0], robotNameSelectorPrefix) {
+		return nil, errors.New("invalid label selector")
+	}
+	result.RobotName = strings.TrimPrefix(labelSelectors[0], robotNameSelectorPrefix)
+	if !isValidRobotName(result.RobotName) {
+		return nil, errors.New("invalid robot name")
+	}
+	return &result, nil
+}

--- a/src/go/cmd/cr-syncer-auth-webhook/request_test.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/request_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		desc string
+		url  string
+		want incomingRequest
+	}{
+		{
+			desc: "watch request, filtered",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/chartassignments?labelSelector=cloudrobotics.com%2Frobot-name%3Dmy-robot",
+			want: incomingRequest{
+				GroupKind: "apps.cloudrobotics.com/chartassignments",
+				RobotName: "my-robot",
+			},
+		},
+		{
+			desc: "watch request, unfiltered",
+			url:  "http://host/apis/core.kubernetes/apis/registry.cloudrobotics.com/v1alpha1/robottypes",
+			want: incomingRequest{
+				GroupKind: "registry.cloudrobotics.com/robottypes",
+			},
+		},
+		{
+			desc: "watch request, with namespace",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/namespaces/default/chartassignments?labelSelector=cloudrobotics.com%2Frobot-name%3Dmy-robot",
+			want: incomingRequest{
+				GroupKind: "apps.cloudrobotics.com/chartassignments",
+				RobotName: "my-robot",
+			},
+		},
+		{
+			desc: "get request",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/namespaces/default/chartassignments/resource-for-my-robot",
+			want: incomingRequest{
+				GroupKind:    "apps.cloudrobotics.com/chartassignments",
+				ResourceName: "resource-for-my-robot",
+			},
+		},
+		{
+			desc: "status post request, with namespace",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/namespaces/default/chartassignments/resource-for-my-robot/status",
+			want: incomingRequest{
+				GroupKind:    "apps.cloudrobotics.com/chartassignments",
+				ResourceName: "resource-for-my-robot",
+			},
+		},
+		{
+			desc: "status post request, without namespace",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/chartassignments/resource-for-my-robot/status?timeout=5m5s",
+			want: incomingRequest{
+				GroupKind:    "apps.cloudrobotics.com/chartassignments",
+				ResourceName: "resource-for-my-robot",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := parseURL(tc.url)
+			if err != nil {
+				t.Fatalf("parseURL(%q) returned error: %v", tc.url, err)
+			}
+			if diff := cmp.Diff(tc.want, *got); diff != "" {
+				t.Errorf("parseURL(%q) returned diff (-want +got):\n%s", tc.url, diff)
+			}
+		})
+	}
+}
+func TestParseURLErrors(t *testing.T) {
+	tests := []struct {
+		desc string
+		url  string
+	}{
+		{
+			desc: "empty robot name",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/chartassignments?labelSelector=cloudrobotics.com%2Frobot-name%3D",
+		},
+		{
+			desc: "over-broad label selector: robot-name!=my-robot",
+			url:  "http://host/apis/core.kubernetes/apis/apps.cloudrobotics.com/v1alpha1/chartassignments?labelSelector=cloudrobotics.com%2Frobot-name%21%3Dmy-robot",
+		},
+		{
+			desc: "core API (not a CR)",
+			url:  "http://host/apis/core.kubernetes/api/v1/namespaces/default/pods/cr-syncer-6676b4958d-p9hqw",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := parseURL(tc.url)
+			if err == nil {
+				t.Fatalf("parseURL(%q) succeeded unexpected", tc.url)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds code to verify and decode the JWTs and then to only allow
requests for resources corresponding to this robot.

Because this doesn't talk to the GKE apiserver itself, it is very
limited:

- it hardcodes the list of supported CRs
- it assumes that any CR with the suffix "robotName" is visible to that
  robot (could be exploited by creating robots called 0, 1, 2, ...)

I've tested this by setting --use-robot-jwt=true on the cr-syncer on a
test system, but the new codepath won't be used until that becomes the
default.
