### PR TITLE
cr-syncer: list robottypes in Health check

### DIFF
--- a/src/go/cmd/cr-syncer/health.go
+++ b/src/go/cmd/cr-syncer/health.go
@@ -14,9 +14,13 @@ import (
 
 var (
 	// gvr defines which resource we expect to be able to list in the
-	// remote cluster. We check for robots as the cr-syncer may only be
-	// authorized to list syncable resources.
-	gvr = schema.GroupVersionResource{"registry.cloudrobotics.com", "v1alpha1", "robots"}
+	// remote cluster. We check for robottypes as the cr-syncer may only be
+	// authorized to list syncable & unfiltered resources.
+	gvr = schema.GroupVersionResource{
+		Group:    "registry.cloudrobotics.com",
+		Version:  "v1alpha1",
+		Resource: "robottypes",
+	}
 )
 
 // handler handles HTTP health requests.


### PR DESCRIPTION
For simplicity, the health check doesn't limit its request to a single
resource. This generates a "robot impersonation rejected" log message in
the cloud when it tries to list all Robot CRs. This doesn't break the
check, since it only fails on 401 but this gets a 403. However, the log
message is confusing.

Instead, we can check for robottypes, which allows a successful &
simpler request.

Tested by pushing the cr-syncer change to the GKE cluster created by
scripts/robot-sim.sh (with --use-robot-jwt=true) and verifying that the
error logs from the cr-syncer-auth-webhook stop.
