### PR TITLE
Proposal for token-vendor api-extension.

### DIFF
--- a/src/go/cmd/token-vendor/README.md
+++ b/src/go/cmd/token-vendor/README.md
@@ -85,10 +85,15 @@ keystore using this method.
 
 Robots sign JWTs with their local private keys. These get verified against the
 public keys from the keystore. If the key is present and enabled, the token
-vendor will hand out an OAuth access token for robot-service@ service account.
+vendor will hand out an OAuth access token for requested service account.
+The service account must be either the default one (robot-service@) or the
+account configured during registration (see /public-key.configure).
 
 * URL: /apis/core.token-vendor/v1/token.oauth2
 * Method: POST
+* URL Params:
+  * service-account: for which service account to return the access token,
+    (robot-service@<gcp-project>.iam.gserviceaccount.com" by default)
 * Body: JWT query (TokenSource)
 * Response: application/json
 

--- a/src/go/cmd/token-vendor/api/v1/v1.go
+++ b/src/go/cmd/token-vendor/api/v1/v1.go
@@ -239,7 +239,9 @@ func (h *HandlerContext) tokenOAuth2Handler(w http.ResponseWriter, r *http.Reque
 			fmt.Sprintf(`expected "%s=<jwt>" in body, invalid token format: %v`, paramAssert, err))
 		return
 	}
-	token, err := h.tv.GetOAuth2Token(r.Context(), assertion)
+	const paramServiceAccount = "service-account"
+	serviceAccount := values.Get(paramServiceAccount)
+	token, err := h.tv.GetOAuth2Token(r.Context(), assertion, serviceAccount)
 	if err != nil {
 		api.ErrResponse(w, http.StatusForbidden, "unable to retrieve cloud access token with given JWT")
 		slog.Error("unable to retrieve cloud access token with given JWT", ilog.Err(err))

--- a/src/go/cmd/token-vendor/app/tokenvendor_test.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor_test.go
@@ -55,3 +55,70 @@ func TestAcceptedAudience(t *testing.T) {
 		})
 	}
 }
+
+type serviceAccountNameTest struct {
+	desc      string
+	cfgSA     string
+	reqSA     string
+	wantSA    string
+	wantError bool
+}
+
+func TestServiceAccountName(t *testing.T) {
+	defaultSA := "robot-servcie@foo.iam.gserviceaccount.com"
+	configuredSA := "custom@bar.iam.gserviceaccount.com"
+	customSA := "unknowns@baz.iam.gserviceaccount.com"
+	var cases = []serviceAccountNameTest{
+		// happy cases
+		{
+			desc:   "nothing requested, nothign configured, gives default",
+			wantSA: defaultSA,
+		},
+		{
+			desc:   "nothing requested, sa configured, gives configured",
+			cfgSA:  configuredSA,
+			wantSA: configuredSA,
+		},
+		{
+			desc:   "def requested, nothing configured, gives def",
+			reqSA:  defaultSA,
+			wantSA: defaultSA,
+		},
+		{
+			desc:   "def requested, sa configured, gives def",
+			cfgSA:  configuredSA,
+			reqSA:  defaultSA,
+			wantSA: defaultSA,
+		},
+		{
+			desc:   "requested as configured, gives configured",
+			cfgSA:  configuredSA,
+			reqSA:  configuredSA,
+			wantSA: configuredSA,
+		},
+		// error cases
+		{
+			desc:      "unknown requested, nothign configured, gives error",
+			reqSA:     customSA,
+			wantError: true,
+		},
+		{
+			desc:      "unknown requested, sa configured, gives error",
+			cfgSA:     configuredSA,
+			reqSA:     customSA,
+			wantError: true,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.desc, func(t *testing.T) {
+			saName, err := serviceAccountName(defaultSA, test.cfgSA, test.reqSA)
+			if (err == nil && test.wantError) || (err != nil && !test.wantError) {
+				t.Fatalf("serviceAccountName(%q, %q, %q): got err %v, want %v",
+					defaultSA, test.cfgSA, test.reqSA, err, test.wantError)
+			} else if saName != test.wantSA {
+				t.Fatalf("serviceAccountName(%q, %q, %q): got err %v, want %v",
+					defaultSA, test.cfgSA, test.reqSA, err, test.wantError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will allow metadata-server or other clients (k8s-auth-plugins) to select which of the allowed service-accounts to use.