### PR TITLE
Upgrade terraform to 0.15.5.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -152,7 +152,7 @@
   "moduleExtensions": {
     "//:non_module_deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "R2I0G7VpA/JD7pO6tH12hw00F91iINkJfRn3vrDE2so=",
+        "bzlTransitiveDigest": "o0sirQuZL1+0joXZIy8BeTUhX1eDDtIeuo5Cu2r0nVk=",
         "usagesDigest": "zfnL/SmA7XDGXo53LgkU5djkne78t1HNugCpAtbfc84=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -209,9 +209,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "urls": [
-                "https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip"
+                "https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip"
               ],
-              "sha256": "4a52886e019b4fdad2439da5ff43388bbcc6cce9784fde32c53dcd0e28ca9957",
+              "sha256": "3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d",
               "build_file": "@@//third_party:terraform.BUILD"
             }
           },

--- a/deploy.sh
+++ b/deploy.sh
@@ -454,7 +454,7 @@ function helm_region_shared {
 
 function helm_main_region {
   local INGRESS_IP
-  INGRESS_IP=$(terraform_exec output ingress-ip)
+  INGRESS_IP=$(terraform_exec output ingress-ip | tr -d '"')
 
   helm_region_shared \
     "${CLOUD_ROBOTICS_CTX}" \

--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -47,9 +47,9 @@ def _non_module_deps_impl(ctx):
     http_archive(
         name = "hashicorp_terraform",
         urls = [
-            "https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip",
+            "https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip",
         ],
-        sha256 = "4a52886e019b4fdad2439da5ff43388bbcc6cce9784fde32c53dcd0e28ca9957",
+        sha256 = "3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d",
         build_file = "//third_party:terraform.BUILD",
     )
     http_archive(

--- a/src/bootstrap/cloud/terraform/input.tf
+++ b/src/bootstrap/cloud/terraform/input.tf
@@ -20,7 +20,7 @@ variable "region" {
 
 variable "additional_regions" {
   description = "Cloud regions to deploy additional relays to"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
@@ -39,7 +39,7 @@ variable "crc_version" {
 
 variable "private_image_repositories" {
   description = "Projects with private GCR image repositories where we need to add IAM access rules."
-  type        = list
+  type        = list(any)
   default     = []
 }
 

--- a/src/bootstrap/cloud/terraform/versions.tf
+++ b/src/bootstrap/cloud/terraform/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/google"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
 }


### PR DESCRIPTION
We need to strip the quotes from the ingress-ip output. This otherwise breaks
our charts left and right.
    
Lets again roll this out everywhere, so that we can finally make the jump
to 1.x next.