### PR TITLE
Add cleanup policy for artifact repositories.

### DIFF
--- a/src/bootstrap/cloud/terraform/registry.tf
+++ b/src/bootstrap/cloud/terraform/registry.tf
@@ -35,6 +35,17 @@ resource "google_artifact_registry_repository" "gcrio_repositories" {
   location      = local.std_repositories[count.index].location
   repository_id = local.std_repositories[count.index].repository
   format        = "docker"
+
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    id     = "delete-untagged"
+    action = "DELETE"
+    condition {
+      tag_state    = "UNTAGGED"
+      older_than   = "7d"
+    }
+  }
+
   count         = length(local.std_repositories)
 }
 


### PR DESCRIPTION
This will delete untagged image layers. I tested this for a month by manually applying this to some projects.
The 7 days are a mere precaution to not cause races, when new images are pushed while the cleanup runs.