### PR TITLE
Refactor the repository to return NotFound for unknown keys

### DIFF
--- a/src/go/cmd/token-vendor/api/v1/BUILD.bazel
+++ b/src/go/cmd/token-vendor/api/v1/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/api/v1",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/go/cmd/token-vendor/repository:go_default_library",
         "//src/go/cmd/token-vendor/api:go_default_library",
         "//src/go/cmd/token-vendor/app:go_default_library",
         "//src/go/cmd/token-vendor/oauth:go_default_library",

--- a/src/go/cmd/token-vendor/api/v1/v1.go
+++ b/src/go/cmd/token-vendor/api/v1/v1.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,6 +31,7 @@ import (
 	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/api"
 	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/app"
 	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/oauth"
+	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/repository"
 	"github.com/googlecloudrobotics/ilog"
 )
 
@@ -85,7 +87,11 @@ func (h *HandlerContext) publicKeyReadHandler(w http.ResponseWriter, r *http.Req
 	// retrieve public key from key repository
 	publicKey, err := h.tv.ReadPublicKey(r.Context(), deviceID)
 	if err != nil {
-		api.ErrResponse(w, http.StatusInternalServerError, "request to repository failed")
+		if errors.Is(err, repository.ErrNotFound) {
+			api.ErrResponse(w, http.StatusNotFound, "request to repository failed")
+		} else {
+			api.ErrResponse(w, http.StatusInternalServerError, "request to repository failed")
+		}
 		slog.Error("request to repository failed", ilog.Err(err))
 		return
 	}

--- a/src/go/cmd/token-vendor/repository/k8s/BUILD.bazel
+++ b/src/go/cmd/token-vendor/repository/k8s/BUILD.bazel
@@ -19,5 +19,8 @@ go_test(
     name = "go_default_test",
     srcs = ["k8s_test.go"],
     embed = [":go_default_library"],
-    deps = ["@io_k8s_client_go//kubernetes/fake:go_default_library"],
+    deps = [
+        "//src/go/cmd/token-vendor/repository:go_default_library",
+        "@io_k8s_client_go//kubernetes/fake:go_default_library"
+    ],
 )

--- a/src/go/cmd/token-vendor/repository/k8s/k8s_test.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s_test.go
@@ -16,9 +16,12 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/repository"
 )
 
 // Publish a key, retrieve it again and check listing of all keys.
@@ -77,10 +80,10 @@ func TestLookupDoesNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 	k, err := kcl.LookupKey(context.TODO(), "testdevice")
-	if err != nil {
-		t.Fatalf("LookupKey produced error %v, want nil", err)
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("LookupKey produced wrong error: got %v, want %v", err, repository.ErrNotFound)
 	}
 	if k != nil {
-		t.Fatalf("LookupKey(..) = %q, want empty string", k)
+		t.Fatalf("LookupKey(..) = %q, want nil", k)
 	}
 }

--- a/src/go/cmd/token-vendor/repository/memory/memory.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory.go
@@ -42,7 +42,7 @@ func (m *MemoryRepository) LookupKey(ctx context.Context, deviceID string) (*rep
 	// key not found does not need to be an error
 	k, found := m.keys[deviceID]
 	if !found {
-		return nil, nil
+		return nil, repository.ErrNotFound
 	}
 	return &repository.Key{k, "", ""}, nil
 }

--- a/src/go/cmd/token-vendor/repository/memory/memory_test.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory_test.go
@@ -16,7 +16,10 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/repository"
 )
 
 // Test publish and lookup key
@@ -53,8 +56,8 @@ func TestMemoryNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 	k, err := m.LookupKey(context.TODO(), "a")
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("LookupKey produced wrong error: got %v, want %v", err, repository.ErrNotFound)
 	}
 	if k != nil {
 		t.Fatalf("LookupKey: got %q, expected empty response", k)

--- a/src/go/cmd/token-vendor/repository/repository.go
+++ b/src/go/cmd/token-vendor/repository/repository.go
@@ -17,6 +17,12 @@ package repository
 
 import (
 	"context"
+	"errors"
+)
+
+var (
+	// ErrNotFound indicates that the requested key is not known.
+	ErrNotFound = errors.New("key not found")
 )
 
 // Key holds data + metadata of a public key entry


### PR DESCRIPTION
Previously we returned "" and later changed that to a nil struct. This causes panics, as we also don't return any error and without it dereference the returned value.

Define an error, return it and update the commetns accordingly.