### PR TITLE
Set def. log level for token-vendor to WARN

### DIFF
--- a/src/app_charts/token-vendor/cloud/token-vendor.yaml
+++ b/src/app_charts/token-vendor/cloud/token-vendor.yaml
@@ -16,6 +16,7 @@ spec:
       - name: token-vendor
         image: {{ .Values.registry }}{{ .Values.images.token_vendor_go }}
         args:
+        - --log-level=4 # WARN
         - --project={{ .Values.project }}
         - --accepted_audience=https://{{ .Values.domain }}/apis/core.token-vendor/v1/token.oauth2
         - --service_account=robot-service


### PR DESCRIPTION
This aligns the default logging with the other services.