### PR TITLE
Add a placeholder ingress for the cert.

### DIFF
--- a/src/app_charts/base/cloud/cert-ingress.yaml
+++ b/src/app_charts/base/cloud/cert-ingress.yaml
@@ -1,0 +1,13 @@
+# Owns the 'tls' block to ensure a cert is generated and avoids repetition of 
+# the 'tls' block in other ingresses. Cert is associated via 'host' field.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: certificate-ingress
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .Values.domain }}
+  rules:
+  - {}

--- a/src/app_charts/base/cloud/kubernetes-api.yaml
+++ b/src/app_charts/base/cloud/kubernetes-api.yaml
@@ -12,9 +12,6 @@ metadata:
     nginx.ingress.kubernetes.io/client-body-buffer-size: "50m"
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -70,9 +70,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"  # seconds
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:
@@ -91,9 +88,6 @@ metadata:
   name: oauth2-proxy-interactive
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/src/app_charts/k8s-relay/cloud/ingress.yaml
+++ b/src/app_charts/k8s-relay/cloud/ingress.yaml
@@ -13,9 +13,6 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /client/$2
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:
@@ -39,9 +36,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/src/app_charts/prometheus/cloud/grafana-ingress.yaml
+++ b/src/app_charts/prometheus/cloud/grafana-ingress.yaml
@@ -15,9 +15,6 @@ metadata:
       error_page 403 = {{ tpl .Values.gf_ingress_error_page_403 . }};
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/src/app_charts/prometheus/cloud/prometheus-ingress.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-ingress.yaml
@@ -13,9 +13,6 @@ metadata:
       error_page 403 = {{ tpl .Values.prom_ingress_error_page_403 . }};
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/src/app_charts/prometheus/cloud/prometheus-relay.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-relay.yaml
@@ -71,9 +71,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/src/app_charts/token-vendor/cloud/ingress.yaml
+++ b/src/app_charts/token-vendor/cloud/ingress.yaml
@@ -6,9 +6,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:
@@ -29,9 +26,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=false"
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:
@@ -50,9 +44,6 @@ metadata:
   name: token-vendor
 spec:
   ingressClassName: nginx
-  tls:
-  - hosts:
-    - {{ .Values.domain }}
   rules:
   - host: {{ .Values.domain }}
     http:


### PR DESCRIPTION
This ensures that one ingress owns the tls-cert and avoids some repetition of the 'tls' block. The cert is determined through the 'host' field in the rules.