### PR TITLE
Run buildifier to add loads

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "28.0-rc2", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_oci", version = "2.0.1")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_proto", version = "6.0.2")
+bazel_dep(name = "rules_shell", version = "0.4.0")
 # -- bazel_dep definitions -- #
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
@@ -99,6 +99,7 @@ use_repo(
 #######
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+
 # gcloud container images describe gcr.io/distroless/base:latest --format='value(image_summary.digest)'
 oci.pull(
     name = "distroless_base",
@@ -106,6 +107,7 @@ oci.pull(
     image = "gcr.io/distroless/base",
     platforms = ["linux/amd64"],
 )
+
 # gcloud container images describe gcr.io/distroless/cc:latest --format='value(image_summary.digest)'
 oci.pull(
     name = "distroless_cc",

--- a/src/app_charts/base/BUILD.bazel
+++ b/src/app_charts/base/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bazel:app_chart.bzl", "app_chart")
 load("//bazel:build_rules/helm_template.bzl", "helm_template")
 

--- a/src/go/cmd/token-vendor/api/v1/BUILD.bazel
+++ b/src/go/cmd/token-vendor/api/v1/BUILD.bazel
@@ -6,10 +6,10 @@ go_library(
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/api/v1",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/go/cmd/token-vendor/repository:go_default_library",
         "//src/go/cmd/token-vendor/api:go_default_library",
         "//src/go/cmd/token-vendor/app:go_default_library",
         "//src/go/cmd/token-vendor/oauth:go_default_library",
+        "//src/go/cmd/token-vendor/repository:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
     ],
 )

--- a/src/go/cmd/token-vendor/repository/k8s/BUILD.bazel
+++ b/src/go/cmd/token-vendor/repository/k8s/BUILD.bazel
@@ -25,6 +25,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//src/go/cmd/token-vendor/repository:go_default_library",
-        "@io_k8s_client_go//kubernetes/fake:go_default_library"
+        "@io_k8s_client_go//kubernetes/fake:go_default_library",
     ],
 )

--- a/src/go/tests/BUILD.bazel
+++ b/src/go/tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 go_test(
     name = "go_default_test",

--- a/src/go/tests/relay/BUILD.bazel
+++ b/src/go/tests/relay/BUILD.bazel
@@ -5,9 +5,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "in_process_relay_test",
     size = "small",
+    srcs = ["in_process_relay_test.go"],
     # https://github.com/googlecloudrobotics/core/issues/507
     flaky = True,
-    srcs = ["in_process_relay_test.go"],
     deps = [
         "//src/go/cmd/http-relay-client/client:go_default_library",
         "//src/go/cmd/http-relay-server/server:go_default_library",

--- a/src/proto/http-relay/BUILD.bazel
+++ b/src/proto/http-relay/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # http relay api
 

--- a/third_party/kubernetes_proto/meta/BUILD.bazel
+++ b/third_party/kubernetes_proto/meta/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/third_party/kubernetes_proto/runtime/BUILD.bazel
+++ b/third_party/kubernetes_proto/runtime/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/third_party/kubernetes_proto/schema/BUILD.bazel
+++ b/third_party/kubernetes_proto/schema/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 


### PR DESCRIPTION
Run `buildifier --lint=fix  -r -v .`. This adds loads for the rules that were removed from Bazel 8. By Bazel 9 automatic loads will be disabled and all loads will need to be explicitly present.

Remove @rules_proto dependency from MODULE.bazel. This has been replaced with @protobuf.

Add @rules_shell dependency to MODULE.bazel. This is needed for the used Shell rules.

See: https://github.com/bazelbuild/bazel/issues/25755