### PR TITLE
Add new "public-key.configure" endpoint for token-vendor

### DIFF
--- a/src/app_charts/token-vendor/cloud/ingress.yaml
+++ b/src/app_charts/token-vendor/cloud/ingress.yaml
@@ -30,6 +30,13 @@ spec:
   - host: {{ .Values.domain }}
     http:
       paths:
+      - path: "/apis/core.token-vendor/v1/public-key.configure"
+        pathType: Prefix
+        backend:
+          service:
+            name: token-vendor
+            port:
+              name: token-vendor
       - path: "/apis/core.token-vendor/v1/public-key.publish"
         pathType: Prefix
         backend:

--- a/src/go/cmd/token-vendor/README.md
+++ b/src/go/cmd/token-vendor/README.md
@@ -56,9 +56,8 @@ refuse eg. robots to register other robots.
 
 ### /public-key.configure: Customize robot registration
 
-Status: Proposed
-
-Configure optional properties of the on-prem robot registration.
+Configure optional properties of the on-prem robot registration. This call needs
+to be authorized by an access token for a human administrator).
 
 * URL: /apis/core.token-vendor/v1/public-key.configure
 * Method: POST

--- a/src/go/cmd/token-vendor/README.md
+++ b/src/go/cmd/token-vendor/README.md
@@ -173,6 +173,12 @@ Publish a key for the device `robot-dev-testuser`:
 curl -D - --max-time 3 --data-binary "@api/v1/testdata/rsa_cert.pem" -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "Content-type: application/x-pem-file" https://www.endpoints.${PROJECT}.cloud.goog/apis/core.token-vendor/v1/public-key.publish?device-id=robot-dev-testuser
 ```
 
+Optionally set extra options for the device:
+
+```bash
+curl -D - --max-time 3 -d '{"service-account":"svc@${PROJECT}.iam.gserviceaccount.com"}' -H "Content-Type: application/json" -H "Authorization: Bearer $(gcloud auth print-access-token)" -H "Content-type: application/x-pem-file" https://www.endpoints.${PROJECT}.cloud.goog/apis/core.token-vendor/v1/public-key.configure?device-id=robot-dev-testuser
+```
+
 Read the key again:
 
 ```bash

--- a/src/go/cmd/token-vendor/app/BUILD.bazel
+++ b/src/go/cmd/token-vendor/app/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//src/go/cmd/token-vendor/oauth/jwt:go_default_library",
         "//src/go/cmd/token-vendor/repository:go_default_library",
         "//src/go/cmd/token-vendor/tokensource:go_default_library",
+        "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/src/go/cmd/token-vendor/app/tokenvendor.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/mail"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -29,7 +31,7 @@ import (
 	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/oauth/jwt"
 	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/repository"
 	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/tokensource"
-	"github.com/pkg/errors"
+	"github.com/googlecloudrobotics/ilog"
 )
 
 type TokenVendor struct {
@@ -62,9 +64,32 @@ func (tv *TokenVendor) ReadPublicKey(ctx context.Context, deviceID string) (stri
 }
 
 func (tv *TokenVendor) ConfigurePublicKey(ctx context.Context, deviceID string, opts repository.KeyOptions) error {
+	if err := validateKeyOptions(opts); err != nil {
+		slog.Error("Configuring public key", ilog.Err(err))
+		return err
+	}
 	slog.Debug("Configuring public key", slog.String("DeviceID", deviceID))
-	// Shall we sanity check the opts?
 	return tv.repo.ConfigureKey(ctx, deviceID, opts)
+}
+
+func validateKeyOptions(opts repository.KeyOptions) error {
+	// Sanity check for the config values
+	if opts.ServiceAccount != "" {
+		if err := validateEmail(opts.ServiceAccount); err != nil {
+			return fmt.Errorf("ServiceAccount field is not a valid email address: %v", err)
+		}
+	}
+	if opts.ServiceAccountDelegate != "" {
+		if err := validateEmail(opts.ServiceAccountDelegate); err != nil {
+			return fmt.Errorf("ServiceAccountDelegate field is not a valid email address: %v", err)
+		}
+	}
+	return nil
+}
+
+func validateEmail(e string) error {
+	_, err := mail.ParseAddress(e)
+	return err
 }
 
 var (

--- a/src/go/cmd/token-vendor/app/tokenvendor.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor.go
@@ -61,6 +61,19 @@ func (tv *TokenVendor) ReadPublicKey(ctx context.Context, deviceID string) (stri
 	return "", err
 }
 
+func (tv *TokenVendor) ConfigurePublicKey(ctx context.Context, deviceID string, opts repository.KeyOptions) error {
+	slog.Debug("Configuring public key", slog.String("DeviceID", deviceID))
+	// Extend repository with ConfigureKey method and use that instead
+	// return tv.repo.ConfigureKey(ctx, deviceID, opts)
+	key, err := tv.repo.LookupKey(ctx, deviceID)
+	if key != nil {
+		// TODO: update config from opts
+		slog.Info("Apply new opts:", "opts", opts)
+		return nil
+	}
+	return err
+}
+
 var (
 	tokensRequested = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/src/go/cmd/token-vendor/app/tokenvendor.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor.go
@@ -63,15 +63,8 @@ func (tv *TokenVendor) ReadPublicKey(ctx context.Context, deviceID string) (stri
 
 func (tv *TokenVendor) ConfigurePublicKey(ctx context.Context, deviceID string, opts repository.KeyOptions) error {
 	slog.Debug("Configuring public key", slog.String("DeviceID", deviceID))
-	// Extend repository with ConfigureKey method and use that instead
-	// return tv.repo.ConfigureKey(ctx, deviceID, opts)
-	key, err := tv.repo.LookupKey(ctx, deviceID)
-	if key != nil {
-		// TODO: update config from opts
-		slog.Info("Apply new opts:", "opts", opts)
-		return nil
-	}
-	return err
+	// Shall we sanity check the opts?
+	return tv.repo.ConfigureKey(ctx, deviceID, opts)
 }
 
 var (

--- a/src/go/cmd/token-vendor/app/tokenvendor_test.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor_test.go
@@ -1,6 +1,10 @@
 package app
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/googlecloudrobotics/core/src/go/cmd/token-vendor/repository"
+)
 
 type isValidDeviceIDTest struct {
 	deviceId string
@@ -118,6 +122,52 @@ func TestServiceAccountName(t *testing.T) {
 			} else if saName != test.wantSA {
 				t.Fatalf("serviceAccountName(%q, %q, %q): got err %v, want %v",
 					defaultSA, test.cfgSA, test.reqSA, err, test.wantError)
+			}
+		})
+	}
+}
+
+type keyOptionsTest struct {
+	desc      string
+	opts      repository.KeyOptions
+	wantError bool
+}
+
+func TestKeyOptions(t *testing.T) {
+	var cases = []keyOptionsTest{
+		{
+			desc: "empty opts are good",
+			opts: repository.KeyOptions{},
+		},
+		{
+			desc: "one good email, one empty",
+			opts: repository.KeyOptions{ServiceAccount: "svc@example.com"},
+		},
+		{
+			desc: "two good emails",
+			opts: repository.KeyOptions{ServiceAccount: "svc@example.com", ServiceAccountDelegate: "del@example.com"},
+		},
+		{
+			desc:      "bad email #1",
+			opts:      repository.KeyOptions{ServiceAccount: "svc"},
+			wantError: true,
+		},
+		{
+			desc:      "bad email #2",
+			opts:      repository.KeyOptions{ServiceAccount: "svc@"},
+			wantError: true,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.desc, func(t *testing.T) {
+			err := validateKeyOptions(test.opts)
+			haveError := err != nil
+			if haveError != test.wantError {
+				if test.wantError {
+					t.Fatalf("validateKeyOptions returned %v, but wanted error", err)
+				} else {
+					t.Fatalf("validateKeyOptions returned %v, but wanted no error", err)
+				}
 			}
 		})
 	}

--- a/src/go/cmd/token-vendor/repository/k8s/k8s.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s.go
@@ -173,8 +173,8 @@ func (k *K8sRepository) ConfigureKey(ctx context.Context, deviceID string, opts 
 	if cm.ObjectMeta.Annotations == nil {
 		cm.ObjectMeta.Annotations = make(map[string]string)
 	}
-	cm.ObjectMeta.Annotations[serviceAccountAnnotation] = opts.ServiceAccount
-	cm.ObjectMeta.Annotations[serviceAccountDelegateAnnotation] = opts.ServiceAccountDelegate
+	mapSetOrDelete(cm.ObjectMeta.Annotations, serviceAccountAnnotation, opts.ServiceAccount)
+	mapSetOrDelete(cm.ObjectMeta.Annotations, serviceAccountDelegateAnnotation, opts.ServiceAccountDelegate)
 	if _, err := k.kcl.CoreV1().ConfigMaps(k.ns).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return errors.Wrapf(err, "failed to update configmap %q/%q", k.ns, deviceID)
 	}
@@ -204,4 +204,12 @@ func createPubKeyDeviceConfig(name, namespace, pk string) (*corev1.ConfigMap, er
 		},
 		Data: map[string]string{pubKey: pk},
 	}, nil
+}
+
+func mapSetOrDelete(m map[string]string, k, v string) {
+	if v != "" {
+		m[k] = v
+	} else {
+		delete(m, k)
+	}
 }

--- a/src/go/cmd/token-vendor/repository/k8s/k8s.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s.go
@@ -159,16 +159,12 @@ func (k *K8sRepository) PublishKey(ctx context.Context, deviceID, publicKey stri
 }
 
 func (k *K8sRepository) ConfigureKey(ctx context.Context, deviceID string, opts repository.KeyOptions) error {
-	obj, exists, err := k.cmInformer.GetStore().GetByKey(k.ns + "/" + deviceID)
+	cm, err := k.kcl.CoreV1().ConfigMaps(k.ns).Get(ctx, deviceID, metav1.GetOptions{})
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return errors.Wrapf(repository.ErrNotFound, "failed to retrieve configmap %q/%q", k.ns, deviceID)
+		}
 		return errors.Wrapf(err, "failed to retrieve configmap %q/%q from cache", k.ns, deviceID)
-	}
-	if !exists {
-		return errors.Wrapf(repository.ErrNotFound, "failed to retrieve configmap %q/%q", k.ns, deviceID)
-	}
-	cm, ok := obj.(*corev1.ConfigMap)
-	if !ok {
-		return fmt.Errorf("unexpected object type: %T", obj)
 	}
 	if cm.ObjectMeta.Annotations == nil {
 		cm.ObjectMeta.Annotations = make(map[string]string)

--- a/src/go/cmd/token-vendor/repository/k8s/k8s_test.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s_test.go
@@ -114,3 +114,33 @@ func TestConfigure(t *testing.T) {
 		t.Fatalf("LookupKey: got %q, expected %q", k.SAName, "svc@example.com")
 	}
 }
+
+func TestReConfigure(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	kcl, err := NewK8sRepository(ctx, cs, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const id = "testdevice"
+	const key = "testkey"
+	if err = kcl.PublishKey(ctx, id, key); err != nil {
+		t.Fatal(err)
+	}
+	opts := repository.KeyOptions{"svc@example.com", ""}
+	if err := kcl.ConfigureKey(ctx, id, opts); err != nil {
+		t.Fatal(err)
+	}
+	// remove the config again
+	opts = repository.KeyOptions{"", ""}
+	if err := kcl.ConfigureKey(ctx, id, opts); err != nil {
+		t.Fatal(err)
+	}
+	k, err := kcl.LookupKey(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.SAName != "" {
+		t.Fatalf("LookupKey: got %q, expected %q", k.SAName, "svc@example.com")
+	}
+}

--- a/src/go/cmd/token-vendor/repository/memory/memory.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory.go
@@ -25,10 +25,14 @@ import (
 // Used only for integration tests.
 type MemoryRepository struct {
 	keys map[string]string
+	opts map[string]repository.KeyOptions
 }
 
 func NewMemoryRepository(ctx context.Context) (*MemoryRepository, error) {
-	return &MemoryRepository{keys: map[string]string{}}, nil
+	return &MemoryRepository{
+		keys: map[string]string{},
+		opts: map[string]repository.KeyOptions{},
+	}, nil
 }
 
 func (m *MemoryRepository) PublishKey(ctx context.Context, deviceID, publicKey string) error {
@@ -44,5 +48,14 @@ func (m *MemoryRepository) LookupKey(ctx context.Context, deviceID string) (*rep
 	if !found {
 		return nil, repository.ErrNotFound
 	}
-	return &repository.Key{k, "", ""}, nil
+	opts, found := m.opts[deviceID]
+	if !found {
+		opts = repository.KeyOptions{}
+	}
+	return &repository.Key{k, opts.ServiceAccount, opts.ServiceAccountDelegate}, nil
+}
+
+func (m *MemoryRepository) ConfigureKey(ctx context.Context, deviceID string, opts repository.KeyOptions) error {
+	m.opts[deviceID] = opts
+	return nil
 }

--- a/src/go/cmd/token-vendor/repository/memory/memory_test.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Test publish and lookup key
-func TestMemoryBackend(t *testing.T) {
+func TestMemoryPublishAndLookup(t *testing.T) {
 	m, err := NewMemoryRepository(context.TODO())
 	if err != nil {
 		t.Fatal(err)
@@ -61,5 +61,28 @@ func TestMemoryNotFound(t *testing.T) {
 	}
 	if k != nil {
 		t.Fatalf("LookupKey: got %q, expected empty response", k)
+	}
+}
+
+// Test publish and lookup key
+func TestMemoryConfigure(t *testing.T) {
+	ctx := context.Background()
+	m, err := NewMemoryRepository(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.PublishKey(ctx, "a", "akey"); err != nil {
+		t.Fatal(err)
+	}
+	opts := repository.KeyOptions{"svc@example.com", ""}
+	if err := m.ConfigureKey(ctx, "a", opts); err != nil {
+		t.Fatal(err)
+	}
+	k, err := m.LookupKey(ctx, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.SAName != "svc@example.com" {
+		t.Fatalf("LookupKey: got %q, expected %q", k.SAName, "svc@example.com")
 	}
 }

--- a/src/go/cmd/token-vendor/repository/memory/memory_test.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory_test.go
@@ -23,25 +23,26 @@ import (
 )
 
 // Test publish and lookup key
-func TestMemoryPublishAndLookup(t *testing.T) {
-	m, err := NewMemoryRepository(context.TODO())
+func TestPublishAndLookup(t *testing.T) {
+	ctx := context.Background()
+	m, err := NewMemoryRepository(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := m.PublishKey(context.TODO(), "a", "akey"); err != nil {
+	if err := m.PublishKey(ctx, "a", "akey"); err != nil {
 		t.Fatal(err)
 	}
-	if err := m.PublishKey(context.TODO(), "b", "bkey"); err != nil {
+	if err := m.PublishKey(ctx, "b", "bkey"); err != nil {
 		t.Fatal(err)
 	}
-	k, err := m.LookupKey(context.TODO(), "a")
+	k, err := m.LookupKey(ctx, "a")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if k.PublicKey != "akey" {
 		t.Fatalf("Key for a: got %q, want %q", k, "akey")
 	}
-	k, err = m.LookupKey(context.TODO(), "b")
+	k, err = m.LookupKey(ctx, "b")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,12 +51,13 @@ func TestMemoryPublishAndLookup(t *testing.T) {
 	}
 }
 
-func TestMemoryNotFound(t *testing.T) {
-	m, err := NewMemoryRepository(context.TODO())
+func TestLookupNotFound(t *testing.T) {
+	ctx := context.Background()
+	m, err := NewMemoryRepository(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	k, err := m.LookupKey(context.TODO(), "a")
+	k, err := m.LookupKey(ctx, "a")
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Fatalf("LookupKey produced wrong error: got %v, want %v", err, repository.ErrNotFound)
 	}
@@ -64,8 +66,7 @@ func TestMemoryNotFound(t *testing.T) {
 	}
 }
 
-// Test publish and lookup key
-func TestMemoryConfigure(t *testing.T) {
+func TestConfigure(t *testing.T) {
 	ctx := context.Background()
 	m, err := NewMemoryRepository(ctx)
 	if err != nil {

--- a/src/go/cmd/token-vendor/repository/repository.go
+++ b/src/go/cmd/token-vendor/repository/repository.go
@@ -48,4 +48,6 @@ type PubKeyRepository interface {
 	// that the device is blocked.
 	LookupKey(ctx context.Context, deviceID string) (*Key, error)
 	PublishKey(ctx context.Context, deviceID, publicKey string) error
+	// ConfigureKey applies the given opts to the key store.
+	ConfigureKey(ctx context.Context, deviceID string, opts KeyOptions) error
 }

--- a/src/go/cmd/token-vendor/repository/repository.go
+++ b/src/go/cmd/token-vendor/repository/repository.go
@@ -35,6 +35,12 @@ type Key struct {
 	SADelegateName string
 }
 
+// KeyOptions contain optional settings for a key
+type KeyOptions struct {
+	ServiceAccount         string `json:"service-account"`
+	ServiceAccountDelegate string `json:"service-account-delegate"`
+}
+
 // PubKeyRepository defines the api for the pub key stores
 type PubKeyRepository interface {
 	// LookupKey retrieves the public key of a device from the repository.


### PR DESCRIPTION
This endpoint allows to configure optional settings for a specific key, such as additional serviceacount that can be impersonated.