### PR TITLE
Allow switching off the cr-syncer-auth-webhook

### DIFF
--- a/src/app_charts/base/cloud/cr-syncer-auth-webhook.yaml
+++ b/src/app_charts/base/cloud/cr-syncer-auth-webhook.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.onprem_federation }}
+{{ if eq .Values.onprem_federation "true" }}
 # The cr-syncer-auth-webhook verifies that requests from the cr-syncer are
 # limited to the robot named in the credentials.
 apiVersion: apps/v1

--- a/src/app_charts/base/cloud/cr-syncer-policy.yaml
+++ b/src/app_charts/base/cloud/cr-syncer-policy.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.onprem_federation "true" }}
 # This policy lets the cr-syncer operate on the apps & registry CRDs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -74,3 +75,4 @@ subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
   name: cr-syncer-auth-webhook
+{{ end }}

--- a/src/app_charts/base/cloud/kubernetes-api.yaml
+++ b/src/app_charts/base/cloud/kubernetes-api.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.onprem_federation }}
+{{ if eq .Values.onprem_federation "true" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/src/app_charts/base/values-cloud.yaml
+++ b/src/app_charts/base/values-cloud.yaml
@@ -8,6 +8,8 @@ owner_email: "info@example.com"
 
 # Setting app_management to "false" will remove layer 2 (app-rollout/chart-assignment-controller, etc).
 app_management: "true"
+# Setting onprem_federation to "false" will remove cloud policy for the cr-syncer (part of layer 1).
+onprem_federation: "true"
 
 oauth2_proxy:
   cookie_secret: ""


### PR DESCRIPTION
We previously mistakenly assumed .Values.onprem_federation was a
boolean, but it seems that deploy.sh passes all values through as
strings. I don't remember if there is a good reason for this...

To align with other switches like .Values.app_management, let's
stringly-type this too.

Tested by setting ONPREM_FEDERATION=true/false in config.sh, deploying,
and checking for the deployment in GKE.
