### PR TITLE
Use typed client for ResourceSets

### DIFF
--- a/src/go/pkg/synk/BUILD.bazel
+++ b/src/go/pkg/synk/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
+        "//src/go/pkg/client/versioned:go_default_library",
         "@com_github_cenkalti_backoff//:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
@@ -45,6 +46,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
+        "//src/go/pkg/client/versioned/fake:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",


### PR DESCRIPTION
This complicates the tests a little but avoids marshalling to/from JSON.
