### PR TITLE
Upgrade terraform to 1.11.4

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -154,7 +154,7 @@
   "moduleExtensions": {
     "//:non_module_deps.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "o0sirQuZL1+0joXZIy8BeTUhX1eDDtIeuo5Cu2r0nVk=",
+        "bzlTransitiveDigest": "SyCvkKME3OWHXx/+/KVdfAsMia7FtzfJMAz6VWPWGyA=",
         "usagesDigest": "zfnL/SmA7XDGXo53LgkU5djkne78t1HNugCpAtbfc84=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -211,9 +211,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "urls": [
-                "https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip"
+                "https://releases.hashicorp.com/terraform/1.11.4/terraform_1.11.4_linux_amd64.zip"
               ],
-              "sha256": "3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d",
+              "sha256": "1ce994251c00281d6845f0f268637ba50c0005657eb3cf096b92f753b42ef4dc",
               "build_file": "@@//third_party:terraform.BUILD"
             }
           },

--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -47,9 +47,9 @@ def _non_module_deps_impl(ctx):
     http_archive(
         name = "hashicorp_terraform",
         urls = [
-            "https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip",
+            "https://releases.hashicorp.com/terraform/1.11.4/terraform_1.11.4_linux_amd64.zip",
         ],
-        sha256 = "3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d",
+        sha256 = "1ce994251c00281d6845f0f268637ba50c0005657eb3cf096b92f753b42ef4dc",
         build_file = "//third_party:terraform.BUILD",
     )
     http_archive(

--- a/src/bootstrap/cloud/terraform/versions.tf
+++ b/src/bootstrap/cloud/terraform/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "hashicorp/google"
     }
   }
-  required_version = ">= 0.15"
+  required_version = ">= 1.11.4"
 }


### PR DESCRIPTION
I've checked all major versions inbetween to ensure that no tf file updates are required. These are the versions I checked: 1.0.11, 1.1.9, 1.2.9, 1.3.10, 1.4.7, 1.5.7, 1.6.6, 1.7.5, 1.8.5, 1.9.8, 1.10.5.

I've deployed this to my personal testing project with no issues.

See b/409492452