### PR TITLE
Allow setting default service account for robot

### DIFF
--- a/src/app_charts/base/robot/gcr-credential-refresher.yaml
+++ b/src/app_charts/base/robot/gcr-credential-refresher.yaml
@@ -17,7 +17,7 @@ spec:
       - image: {{ .Values.registry }}{{ .Values.images.gcr_credential_refresher }}
         args:
         - --robot_id_file=/credentials/robot-id.json
-        - --sa_name={{ .Values.robot.defaultSAName }}
+        - --service_account={{ .Values.robot.defaultSAName }}
         name: gcr-credential-refresher
         resources:
           requests:

--- a/src/app_charts/base/robot/gcr-credential-refresher.yaml
+++ b/src/app_charts/base/robot/gcr-credential-refresher.yaml
@@ -17,6 +17,7 @@ spec:
       - image: {{ .Values.registry }}{{ .Values.images.gcr_credential_refresher }}
         args:
         - --robot_id_file=/credentials/robot-id.json
+        - --sa_name={{ .Values.robot.defaultSAName }}
         name: gcr-credential-refresher
         resources:
           requests:
@@ -27,7 +28,7 @@ spec:
             memory: "200Mi"
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true  
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /credentials
           name: robot-id

--- a/src/app_charts/base/robot/metadata-server.yaml
+++ b/src/app_charts/base/robot/metadata-server.yaml
@@ -33,8 +33,9 @@ spec:
         - --robot_id_file=/credentials/robot-id.json
         - --source_cidr={{ .Values.pod_cidr }}
         - --running_on_gke={{ .Values.running_on_gke }}
+        - --sa_name={{ .Values.robot.defaultSAName }}
         securityContext:
-          readOnlyRootFilesystem: true  
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - all

--- a/src/app_charts/base/robot/metadata-server.yaml
+++ b/src/app_charts/base/robot/metadata-server.yaml
@@ -33,7 +33,7 @@ spec:
         - --robot_id_file=/credentials/robot-id.json
         - --source_cidr={{ .Values.pod_cidr }}
         - --running_on_gke={{ .Values.running_on_gke }}
-        - --sa_name={{ .Values.robot.defaultSAName }}
+        - --service_account={{ .Values.robot.defaultSAName }}
         securityContext:
           readOnlyRootFilesystem: true
           capabilities:

--- a/src/app_charts/base/values-robot.yaml
+++ b/src/app_charts/base/values-robot.yaml
@@ -32,6 +32,8 @@ running_on_gke: "false"
 
 robot:
   name: ""
+  # Name of the default GCP Service Account used by robot when connecting to cloud.
+  defaultSAName: "robot-service"
 
 webhook:
   enabled: "true"

--- a/src/go/cmd/gcr-credential-refresher/main.go
+++ b/src/go/cmd/gcr-credential-refresher/main.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	robotIdFile = flag.String("robot_id_file", "", "robot-id.json file")
-	robotSAName = flag.String("sa_name", "robot-service", "Robot default service account name, default: robot-service")
+	robotSAName = flag.String("service_account", "robot-service", "Robot default service account name, default: robot-service")
 )
 
 const updateInterval = 10 * time.Minute

--- a/src/go/cmd/gcr-credential-refresher/main.go
+++ b/src/go/cmd/gcr-credential-refresher/main.go
@@ -17,9 +17,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/googlecloudrobotics/core/src/go/pkg/gcr"
@@ -51,12 +49,9 @@ func updateCredentials(ctx context.Context) error {
 		log.Fatalf("failed to read robot id file %s: %v", *robotIdFile, err)
 	}
 
-	effectiveSA := *robotSAName
-	if effectiveSA == "" {
-		effectiveSA = "robot-service"
-	}
-	if !strings.Contains(effectiveSA, "@") {
-		effectiveSA = fmt.Sprintf("%s@%s.iam.gserviceaccount.com", effectiveSA, robotAuth.ProjectId)
+	effectiveSA, err := robotAuth.ServiceAccountEmail(*robotSAName)
+	if err != nil {
+		log.Fatalf("failed to construct service account from '%s': %v", *robotSAName, err)
 	}
 
 	// Perform a token exchange with the TokenVendor in the cloud cluster and update the

--- a/src/go/cmd/metadata-server/main.go
+++ b/src/go/cmd/metadata-server/main.go
@@ -16,7 +16,7 @@
 // cloud project.
 //
 // This metadata server replicates a subset of the GKE metadata server
-// functionality to provide applcation default creadentials for local services.
+// functionality to provide application default credentials for local services.
 package main
 
 import (
@@ -51,6 +51,7 @@ var (
 	logPeerDetails = flag.Bool("log_peer_details", false, "When enabled details about the peer that requests ADC are logged on the expense of some extra latency")
 	logLevel       = flag.Int("log_level", int(slog.LevelInfo), "the log message level required to be logged")
 	runningOnGKE   = flag.Bool("running_on_gke", false, "If running on GKE, skip setup steps that are unnecessary and will fail.")
+	robotSAName    = flag.String("sa_name", "robot-service", "Robot default service account name, default: robot-service")
 )
 
 func detectChangesToFile(filename string) <-chan struct{} {
@@ -144,7 +145,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	tokenHandler, err := NewTokenHandler(ctx, k8s)
+	tokenHandler, err := NewTokenHandler(ctx, k8s, *robotSAName)
 	if err != nil {
 		slog.Error("NewTokenHandler", slog.Any("Error", err))
 		os.Exit(1)

--- a/src/go/cmd/metadata-server/main.go
+++ b/src/go/cmd/metadata-server/main.go
@@ -51,7 +51,7 @@ var (
 	logPeerDetails = flag.Bool("log_peer_details", false, "When enabled details about the peer that requests ADC are logged on the expense of some extra latency")
 	logLevel       = flag.Int("log_level", int(slog.LevelInfo), "the log message level required to be logged")
 	runningOnGKE   = flag.Bool("running_on_gke", false, "If running on GKE, skip setup steps that are unnecessary and will fail.")
-	robotSAName    = flag.String("sa_name", "robot-service", "Robot default service account name, default: robot-service")
+	robotSAName    = flag.String("service_account", "robot-service", "Robot default service account name, default: robot-service")
 )
 
 func detectChangesToFile(filename string) <-chan struct{} {


### PR DESCRIPTION
Allows setting default service account used by metadata server and gcr-credentials-refresher in order to enable token vendor to consider alternatives for creating new tokens overriding default behavior for annotated device registration.