### PR TITLE
Revert "Allows TokenVendor to read SA from JWT.SUB (#539)"

### DIFF
--- a/src/go/cmd/metadata-server/metadata.go
+++ b/src/go/cmd/metadata-server/metadata.go
@@ -181,7 +181,7 @@ type TokenHandler struct {
 }
 
 type auth interface {
-	CreateRobotTokenSource(context.Context, ...string) oauth2.TokenSource
+	CreateRobotTokenSource(context.Context) oauth2.TokenSource
 	projectID() string
 	robotName() string
 }

--- a/src/go/cmd/metadata-server/metadata_test.go
+++ b/src/go/cmd/metadata-server/metadata_test.go
@@ -126,7 +126,7 @@ type fakeRobotAuth struct {
 	name string
 }
 
-func (a *fakeRobotAuth) CreateRobotTokenSource(context.Context, ...string) oauth2.TokenSource {
+func (a *fakeRobotAuth) CreateRobotTokenSource(context.Context) oauth2.TokenSource {
 	return a.ts
 }
 

--- a/src/go/cmd/token-vendor/README.md
+++ b/src/go/cmd/token-vendor/README.md
@@ -86,11 +86,13 @@ Robots sign JWTs with their local private keys. These get verified against the
 public keys from the keystore. If the key is present and enabled, the token
 vendor will hand out an OAuth access token for requested service account.
 The service account must be either the default one (robot-service@) or the
-account configured during registration (see /public-key.configure). To specify
-custom service account use Subject claim.
+account configured during registration (see /public-key.configure).
 
 * URL: /apis/core.token-vendor/v1/token.oauth2
 * Method: POST
+* URL Params:
+  * service-account: for which service account to return the access token,
+    (robot-service@<gcp-project>.iam.gserviceaccount.com" by default)
 * Body: JWT query (TokenSource)
 * Response: application/json
 

--- a/src/go/cmd/token-vendor/api/v1/v1.go
+++ b/src/go/cmd/token-vendor/api/v1/v1.go
@@ -294,7 +294,9 @@ func (h *HandlerContext) tokenOAuth2Handler(w http.ResponseWriter, r *http.Reque
 			fmt.Sprintf(`expected "%s=<jwt>" in body, invalid token format: %v`, paramAssert, err))
 		return
 	}
-	token, err := h.tv.GetOAuth2Token(r.Context(), assertion)
+	const paramServiceAccount = "service-account"
+	serviceAccount := values.Get(paramServiceAccount)
+	token, err := h.tv.GetOAuth2Token(r.Context(), assertion, serviceAccount)
 	if err != nil {
 		api.ErrResponse(w, http.StatusForbidden, "unable to retrieve cloud access token with given JWT")
 		slog.Error("unable to retrieve cloud access token with given JWT", ilog.Err(err))
@@ -348,7 +350,7 @@ func (h *HandlerContext) verifyJWTHandler(w http.ResponseWriter, r *http.Request
 	// Authorization: ...
 	jwtString := strings.TrimPrefix(authHeader[0], "Bearer ")
 
-	if _, err := h.tv.ValidateJWT(r.Context(), jwtString); err != nil {
+	if _, _, err := h.tv.ValidateJWT(r.Context(), jwtString); err != nil {
 		slog.WarnContext(r.Context(), "JWT failed validation", ilog.Err(err))
 		api.ErrResponse(w, http.StatusForbidden, "JWT not valid")
 		return

--- a/src/go/cmd/token-vendor/app/tokenvendor.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor.go
@@ -50,12 +50,12 @@ func NewTokenVendor(ctx context.Context, repo repository.PubKeyRepository, v *oa
 }
 
 func (tv *TokenVendor) PublishPublicKey(ctx context.Context, deviceID, publicKey string) error {
-	slog.Info("Publishing public Key", slog.String("DeviceID", deviceID))
+	slog.Info("Publishing public key", slog.String("DeviceID", deviceID))
 	return tv.repo.PublishKey(ctx, deviceID, publicKey)
 }
 
 func (tv *TokenVendor) ReadPublicKey(ctx context.Context, deviceID string) (string, error) {
-	slog.Debug("Returning public Key", slog.String("DeviceID", deviceID))
+	slog.Debug("Returning public key", slog.String("DeviceID", deviceID))
 	key, err := tv.repo.LookupKey(ctx, deviceID)
 	if key != nil {
 		return key.PublicKey, nil
@@ -65,10 +65,10 @@ func (tv *TokenVendor) ReadPublicKey(ctx context.Context, deviceID string) (stri
 
 func (tv *TokenVendor) ConfigurePublicKey(ctx context.Context, deviceID string, opts repository.KeyOptions) error {
 	if err := validateKeyOptions(opts); err != nil {
-		slog.Error("Configuring public Key", ilog.Err(err))
+		slog.Error("Configuring public key", ilog.Err(err))
 		return err
 	}
-	slog.Debug("Configuring public Key", slog.String("DeviceID", deviceID))
+	slog.Debug("Configuring public key", slog.String("DeviceID", deviceID))
 	return tv.repo.ConfigureKey(ctx, deviceID, opts)
 }
 
@@ -109,9 +109,9 @@ var (
 	)
 )
 
-func (tv *TokenVendor) GetOAuth2Token(ctx context.Context, jwtk string) (*tokensource.TokenResponse, error) {
+func (tv *TokenVendor) GetOAuth2Token(ctx context.Context, jwtk, requestedSA string) (*tokensource.TokenResponse, error) {
 	ts := time.Now()
-	r, err := tv.getOAuth2Token(ctx, jwtk)
+	r, err := tv.getOAuth2Token(ctx, jwtk, requestedSA)
 	var state string
 	if err != nil {
 		state = "failed"
@@ -123,63 +123,51 @@ func (tv *TokenVendor) GetOAuth2Token(ctx context.Context, jwtk string) (*tokens
 	return r, err
 }
 
-// DeviceAuth contains authorization information for device with DeviceID.
-// Information is extracted from request's OAuth2 JWT Payload
-type DeviceAuth struct {
-	DeviceID   string
-	Key        *repository.Key
-	ServiceAcc string
-}
-
-func (tv *TokenVendor) ValidateJWT(ctx context.Context, jwtk string) (*DeviceAuth, error) {
+func (tv *TokenVendor) ValidateJWT(ctx context.Context, jwtk string) (string, *repository.Key, error) {
 	p, err := jwt.PayloadUnsafe(jwtk)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to extract JWT payload")
+		return "", nil, errors.Wrap(err, "failed to extract JWT payload")
 	}
 	exp := time.Unix(p.Exp, 0)
 	if exp.Before(time.Now()) {
-		return nil, fmt.Errorf("JWT has expired %v, %v ago (iss: %q)",
+		return "", nil, fmt.Errorf("JWT has expired %v, %v ago (iss: %q)",
 			exp, time.Since(exp), p.Iss)
 	}
 	if err := acceptedAudience(p.Aud, tv.accAud); err != nil {
-		return nil, errors.Wrapf(err, "validation of JWT audience failed (iss: %q)", p.Iss)
+		return "", nil, errors.Wrapf(err, "validation of JWT audience failed (iss: %q)", p.Iss)
 	}
 	if !IsValidDeviceID(p.Iss) {
-		return nil, fmt.Errorf("missing or invalid device identifier (`iss`: %q)", p.Iss)
+		return "", nil, fmt.Errorf("missing or invalid device identifier (`iss`: %q)", p.Iss)
 	}
 	deviceID := p.Iss
 	k, err := tv.repo.LookupKey(ctx, deviceID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve public Key for device %q", deviceID)
+		return "", nil, errors.Wrapf(err, "failed to retrieve public key for device %q", deviceID)
 	}
 	if k.PublicKey == "" {
-		return nil, errors.Errorf("no public Key found for device %q", deviceID)
+		return "", nil, errors.Errorf("no public key found for device %q", deviceID)
 	}
 	err = jwt.VerifySignature(jwtk, k.PublicKey)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to verify signature for device %q", deviceID)
+		return "", nil, errors.Wrapf(err, "failed to verify signature for device %q", deviceID)
 	}
-	return &DeviceAuth{
-		DeviceID:   deviceID,
-		Key:        k,
-		ServiceAcc: p.Sub,
-	}, nil
+	return deviceID, k, nil
 }
 
-func (tv *TokenVendor) getOAuth2Token(ctx context.Context, jwtk string) (*tokensource.TokenResponse, error) {
-	authInfo, err := tv.ValidateJWT(ctx, jwtk)
+func (tv *TokenVendor) getOAuth2Token(ctx context.Context, jwtk, requestedSA string) (*tokensource.TokenResponse, error) {
+	deviceID, k, err := tv.ValidateJWT(ctx, jwtk)
 	if err != nil {
 		return nil, err
 	}
-	saName, err := serviceAccountName(tv.defaultSAName, authInfo.Key.SAName, authInfo.ServiceAcc)
+	saName, err := serviceAccountName(tv.defaultSAName, k.SAName, requestedSA)
 	if err != nil {
 		return nil, err
 	}
-	cloudToken, err := tv.ts.Token(ctx, saName, authInfo.Key.SADelegateName)
+	cloudToken, err := tv.ts.Token(ctx, saName, k.SADelegateName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve a cloud token for device %q", authInfo.DeviceID)
+		return nil, errors.Wrapf(err, "failed to retrieve a cloud token for device %q", deviceID)
 	}
-	slog.Info("Handing out cloud token", slog.String("DeviceID", authInfo.DeviceID), slog.String("ServiceAccount", authInfo.Key.SAName))
+	slog.Info("Handing out cloud token", slog.String("DeviceID", deviceID), slog.String("ServiceAccount", k.SAName))
 	return cloudToken, nil
 }
 
@@ -199,7 +187,7 @@ func serviceAccountName(saDef, saCfg, saReq string) (string, error) {
 
 // acceptedAudience validates JWT audience as defined by the token vendor
 //
-// `aud` is the value of the audience Key from the JWT and `accAud` the configured
+// `aud` is the value of the audience key from the JWT and `accAud` the configured
 // accepted audience of the token vendor.
 func acceptedAudience(aud, accAud string) error {
 	qualified := accAud + "?token_type=access_token"

--- a/src/go/cmd/token-vendor/oauth/jwt/jwt.go
+++ b/src/go/cmd/token-vendor/oauth/jwt/jwt.go
@@ -13,7 +13,6 @@ type payload struct {
 	Aud    string
 	Iss    string
 	Exp    int64
-	Sub    string
 	Scopes string
 	Claims string
 }

--- a/src/go/pkg/gcr/update_gcr_credentials.go
+++ b/src/go/pkg/gcr/update_gcr_credentials.go
@@ -88,8 +88,8 @@ func patchServiceAccount(ctx context.Context, k8s *kubernetes.Clientset, name st
 
 // UpdateGcrCredentials authenticates to the cloud cluster using the auth config given and updates
 // the credentials used to pull images from GCR.
-func UpdateGcrCredentials(ctx context.Context, k8s *kubernetes.Clientset, auth *robotauth.RobotAuth, gcpSaChain ...string) error {
-	tokenSource := auth.CreateRobotTokenSource(ctx, gcpSaChain...)
+func UpdateGcrCredentials(ctx context.Context, k8s *kubernetes.Clientset, auth *robotauth.RobotAuth) error {
+	tokenSource := auth.CreateRobotTokenSource(ctx)
 	token, err := tokenSource.Token()
 	if err != nil {
 		return fmt.Errorf("failed to get token: %v", err)

--- a/src/go/pkg/robotauth/robotauth.go
+++ b/src/go/pkg/robotauth/robotauth.go
@@ -158,27 +158,24 @@ func (r *RobotAuth) getTokenEndpoint() string {
 }
 
 // CreateRobotTokenSource creates an OAuth2 token source for the token vendor.
-// This token source returns Google Cloud access token minted for either
-// the robot-service@ service account or impersonated via provided gcpSaChain.
-func (r *RobotAuth) CreateRobotTokenSource(ctx context.Context, gcpSaChain ...string) oauth2.TokenSource {
+// This token source returns Google Cloud access token minted for the robot-service@
+// service account.
+func (r *RobotAuth) CreateRobotTokenSource(ctx context.Context) oauth2.TokenSource {
 	c := jwt.Config{
 		// Will be used as "issuer" of the outgoing JWT. Is not formatted as an email though
 		Email:      r.PublicKeyRegistryId,
 		Expires:    time.Minute * 30,
 		PrivateKey: r.PrivateKey,
 		Scopes:     []string{},
-		TokenURL:   r.getTokenEndpoint(),
-	}
-	if len(gcpSaChain) > 0 {
-		// TokenVendor expects single service-account email.
-		// todo: consider allowing token-vendor to accept SA chain.
-		c.Subject = gcpSaChain[0]
+		// TODO: shouldn't this be the service-account name we want to get the token for?
+		Subject:  r.RobotName,
+		TokenURL: r.getTokenEndpoint(),
 	}
 	return c.TokenSource(ctx)
 }
 
 // CreateJWT allows to create a JWT for authentication against the token vendor.
-// This does not grant Google Cloud access, but can be used for explicit
+// This does not grant Google Cloud access, but can be used for for explicit
 // authentication with the token vendor.
 func (r *RobotAuth) CreateJWT(ctx context.Context, lifetime time.Duration) (string, error) {
 	p, _ := pem.Decode(r.PrivateKey)


### PR DESCRIPTION
This reverts commit 4d0c8f37913fe76400516c2c54dc059c67ca112f, https://cloudlogging.app.goo.gl/M1JMPrN1rMJf37Y68

See https://cloudlogging.app.goo.gl/4rL1Y3WxtwGJLmiT9
```
Error: "service account "dev-ensonic1-c-googlers-com" not allowed"
message: "unable to retrieve cloud access token with given JWT"
```

Rollback tested on robco-ensonic:
![image](https://github.com/user-attachments/assets/6d6fd89b-ae15-44fc-8553-69693ee804e6)
