### PR TITLE
Allow to configure metricsRelabelings

### DIFF
--- a/src/app_charts/k8s-relay/cloud/service-monitor.yaml
+++ b/src/app_charts/k8s-relay/cloud/service-monitor.yaml
@@ -10,6 +10,9 @@ spec:
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_node_name]
       targetLabel: instance
+    {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- tpl (toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 6) . }}
+    {{- end }}
   selector:
     matchLabels:
       app: kubernetes-relay-server

--- a/src/app_charts/prometheus/cloud/prometheus-relay.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-relay.yaml
@@ -96,6 +96,9 @@ spec:
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_node_name]
       targetLabel: instance
+    {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- tpl (toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 6) . }}
+    {{- end }}
   selector:
     matchLabels:
       app: prometheus-relay-server


### PR DESCRIPTION
When using a lot of clients on a relay, these configs can be used to e.g. group the metrics.

See b/431135959#comment6