### PR TITLE
Improve error message for recently-disappeared client

### DIFF
--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -173,7 +173,7 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 	case <-time.After(10 * time.Second):
 		// This branch is triggered if the channel is not ready to consume the request
 		// since it is still busy with handling a different request.
-		return nil, fmt.Errorf("Cannot reach the client %q. Check that it's turned on, set up, and connected to the internet. (timeout waiting for relay client to accept request)", server)
+		return nil, fmt.Errorf("Cannot reach the client %q. Check that it's turned on, set up, and connected to the internet. If the network config recently changed, try again in 1-2 minutes. (timeout waiting for relay client to accept request)", server)
 	}
 }
 


### PR DESCRIPTION
We normally see "unknown client" when the client is completely offline. However, when the client recently went offline (eg due to a change in network configuration) there is a brief network outage, so we can highlight this in the error as it's a different code path.