### PR TITLE
Set the release-channel for GKE clusters to STABLE for consistency

### DIFF
--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -38,6 +38,9 @@ resource "google_container_cluster" "cloud-robotics" {
       recurrence = "FREQ=WEEKLY;BYDAY=SA,SU"
     }
   }
+  release_channel {
+    channel = "STABLE"
+  }
   secret_manager_config {
     enabled = var.secret_manager_plugin
   }


### PR DESCRIPTION
This only sets the channel to be used when applying the next update given the configured maintenance window.

Tested manually.