### PR TITLE
Re-enable connection reuse

### DIFF
--- a/src/app_charts/base/cloud/nginx-ingress-controller.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller.yaml
@@ -13,11 +13,6 @@ data:
   # The token-vendor checks the Original-URI header to accept tokens from query
   # parameters.
   proxy-add-original-uri-header: "true"
-  # NGINX uses a single connection pool for all kind of connection, including grpc,
-  # which leads to sporadic errors:
-  #   "no connection data found for keepalive http2 connection while sending request to upstream,"
-  # https://github.com/kubernetes/ingress-nginx/issues/4836
-  upstream-keepalive-requests: "1"
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
There's now a better workaround on the upstream issue: using two
separate k8s Services with different IPs for different traffic types.

This avoids ephemeral port exhaustion when handling many requests 100s
of RPS per pod.
