### PR TITLE
Add a priorityClassName to the metadata server.

### DIFF
--- a/src/app_charts/base/robot/metadata-server.yaml
+++ b/src/app_charts/base/robot/metadata-server.yaml
@@ -51,4 +51,5 @@ spec:
       tolerations:
       - operator: "Exists"
         effect: "NoSchedule"
+      priorityClassName: system-cluster-critical
 {{ end }}


### PR DESCRIPTION
According to [1] this should help with the cluster startup, as k8s will prioritize the metadatta server.
This should reduce pod restart of services that need ADCs.

[1]: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#effect-of-pod-priority-on-scheduling-order