### PR TITLE
Fix 2 calls for "gcloud storage cp"

### DIFF
--- a/.github/ci/common.sh
+++ b/.github/ci/common.sh
@@ -62,7 +62,7 @@ function release_binary {
   # right away.
   gcloud storage cp \
       --predefined-acl=publicRead \
-      --header="Cache-Control:private, max-age=0, no-transform" \
+      --cache-control="private, max-age=0, no-transform" \
       src/bootstrap/cloud/run-install.sh \
       "gs://${bucket}/"
 
@@ -76,7 +76,7 @@ function release_binary {
   for label; do
     gcloud storage cp \
         --predefined-acl=publicRead \
-        --header="Cache-Control:private, max-age=0, no-transform" \
+        --cache-control="private, max-age=0, no-transform" \
         ${vfile} "gs://${bucket}/${label}"
   done
 }


### PR DESCRIPTION
There is no --header, but dedicated flag for cache control. It is not docuemnted though:
https://docs.cloud.google.com/sdk/gcloud/reference/storage/cp#--cache-control