### PR TITLE
crd: restrict nested fields in info robot crd

### DIFF
--- a/src/app_charts/base/cloud/registry-crd.yaml
+++ b/src/app_charts/base/cloud/registry-crd.yaml
@@ -75,7 +75,8 @@ spec:
                   properties:
                     info:
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                     updateTime:
                       type: string
                     state:


### PR DESCRIPTION
This restricts the `info` property in the Robot CRD to contain only string values. This reflects the Go type added in #654.

Additionally, the `x-kubernetes-preserve-unknown-fields` has been removed as it is now redundant, `additionalProperties` already explicitly allows any fields.