### PR TITLE
ensure responseChannel is drained

### DIFF
--- a/src/go/cmd/http-relay-client/client/client.go
+++ b/src/go/cmd/http-relay-client/client/client.go
@@ -412,7 +412,6 @@ func (c *Client) postResponse(remote *http.Client, br *pb.HttpResponse) error {
 	}
 
 	resp, err := remote.Post(responseUrl.String(), "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse", bytes.NewReader(body))
-
 	if err != nil {
 		return fmt.Errorf("couldn't post response to relay server: %v", err)
 	}
@@ -576,7 +575,6 @@ func (c *Client) streamToBackend(remote *http.Client, id string, backendWriter i
 					slog.String("ID", id),
 					slog.String("Status", http.StatusText(resp.StatusCode)),
 					slog.String("Message", string(msg)))
-
 			}
 			return
 		}
@@ -708,6 +706,11 @@ func (c *Client) handleRequest(remote *http.Client, local *http.Client, pbreq *p
 		if err != nil {
 			slog.Error("Closing backend connection",
 				slog.String("ID", *resp.Id), ilog.Err(err))
+			// This is also closed in streamToBackend. In most cases this is safe but it depends on the transport.
+			hresp.Body.Close()
+			// Drain the response channel to avoid blocking buildResponses.
+			for range responseChannel {
+			}
 			break
 		}
 	}
@@ -747,7 +750,6 @@ func (c *Client) localProxy(remote, local *http.Client) error {
 			return
 		}
 	})
-
 	if err != nil {
 		return err
 	}

--- a/src/go/cmd/http-relay-client/client/client.go
+++ b/src/go/cmd/http-relay-client/client/client.go
@@ -706,7 +706,8 @@ func (c *Client) handleRequest(remote *http.Client, local *http.Client, pbreq *p
 		if err != nil {
 			slog.Error("Closing backend connection",
 				slog.String("ID", *resp.Id), ilog.Err(err))
-			// This is also closed in streamToBackend. In most cases this is safe but it depends on the transport.
+			// This is also closed in streamToBackend.
+			// Closing here too to ensure the disconnect propagates faster.
 			hresp.Body.Close()
 			// Drain the response channel to avoid blocking buildResponses.
 			for range responseChannel {


### PR DESCRIPTION
There is a potential for deadlocks

https://github.com/googlecloudrobotics/core/blob/f173d97ba2477bc9080af9fc2e1d364cc9017173/src/go/cmd/http-relay-client/client/client.go#L708-L712

if we exit the loop preemptively, we fail to fully consume `responseChannel` and https://github.com/googlecloudrobotics/core/blob/f173d97ba2477bc9080af9fc2e1d364cc9017173/src/go/cmd/http-relay-client/client/client.go#L487

might deadlock.

#222 fixes the error handling which may have caused the deadlock. Before, it checks for incorrect `backoff.PermanentError` which never happens so the `responseChannel` is always fully consumed.