### PR TITLE
W.I.P. configure external authorization policy

### DIFF
--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -3,6 +3,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: crc-gateway
+  labels:
+    gateway.networking.k8s.io/gateway-name: crc-gateway
   annotations:
     # Use standard K8s annotations for cloud-specific LB settings
     networking.istio.io/service-type: LoadBalancer 
@@ -47,4 +49,34 @@ spec:
       requestRedirect:
         scheme: https
         statusCode: 301
+# ---
+# apiVersion: networking.istio.io/v1
+# kind: ServiceEntry
+# metadata:
+#   name: token-vendor-robot-and-human-auth
+# spec:
+#   hosts:
+#   - "token-vendor-robot-and-human-auth.local" # The service name to be used in the extension provider in the mesh config.
+#   endpoints:
+#   - address: "127.0.0.1"
+#   ports:
+#   - name: http
+#     number: 80 # The port number to be used in the extension provider in the mesh config.
+#     protocol: HTTP
+#   resolution: STATIC
+# ---
+# apiVersion: networking.istio.io/v1
+# kind: ServiceEntry
+# metadata:
+#   name: token-vendor-human-only-auth
+# spec:
+#   hosts:
+#   - "token-vendor-human-only-auth.local" # The service name to be used in the extension provider in the mesh config.
+#   endpoints:
+#   - address: "127.0.0.1"
+#   ports:
+#   - name: http
+#     number: 80 # The port number to be used in the extension provider in the mesh config.
+#     protocol: HTTP
+#   resolution: STATIC
 {{- end}}

--- a/src/app_charts/token-vendor/cloud/auth-policy.yaml
+++ b/src/app_charts/token-vendor/cloud/auth-policy.yaml
@@ -1,0 +1,43 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: tokenvendor-public-key-access-auth
+  namespace: default  # the policy can only target gateways in the same namespace
+spec:
+  # Single baseline policy.
+  # Finding: PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS did not resolve 
+  # the '1 provider per workload' error in this environment when using multiple CUSTOM actions.
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: crc-gateway
+  action: CUSTOM
+  provider:
+    # Must match name in meshConfig.extensionProviders exactly.
+    name: "token-vendor-robot-and-human-auth"
+  rules:
+  - to:
+    - operation:
+        paths:
+        - "/apis/core.token-vendor/v1/public-key.read"
+        - "/apis/core.token-vendor/v1/public-key.read*"
+# ---
+# apiVersion: security.istio.io/v1
+# kind: AuthorizationPolicy
+# metadata:
+#   name: tokenvendor-public-key-manager-auth
+#   namespace: default  # the policy can only target gateways in the same namespace
+# spec:
+#   selector:
+#     matchLabels:
+#       gateway.networking.k8s.io/gateway-name: crc-gateway
+#   action: CUSTOM
+#   provider:
+#     name: "token-vendor-human-auth"
+#   rules:
+#   - to:
+#     - operation:
+#         paths:
+#         - "/apis/core.token-vendor/v1/public-key.configure"
+#         - "/apis/core.token-vendor/v1/public-key.configure*"
+#         - "/apis/core.token-vendor/v1/public-key.publish"
+#         - "/apis/core.token-vendor/v1/public-key.publish*"

--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -1,5 +1,3 @@
-# TODO: need auth
-# "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -19,9 +17,13 @@ spec:
     - path:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/public-key.read
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+          - name: "x-auth-url"
+            value: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 ---
-# TODO: need auth
-# nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=false"
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -44,6 +46,12 @@ spec:
     - path:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/public-key.publish
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+          - name: "x-auth-url"
+            value: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=false"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/src/go/cmd/synk/README.md
+++ b/src/go/cmd/synk/README.md
@@ -6,7 +6,7 @@ It takes set of fully populated Kubernetes resources (files or in-process object
 
 It has a similar intent to [Mortar](https://github.com/kontena/mortar), but synk is usable as a Golang library and has first-class support for CRDs.
 
-To be compatible with some of the existing charts, we allow charts to install resources to "kube-system" as the only allowed namespace outside of the chart namespace.
+To be compatible with some of the existing charts, we allow charts to install resources to "default" & "kube-system" as the only allowed namespaces outside of the chart namespace.
 
 ## Examples
 

--- a/src/go/cmd/token-vendor/api/v1/v1.go
+++ b/src/go/cmd/token-vendor/api/v1/v1.go
@@ -362,6 +362,13 @@ func (h *HandlerContext) verifyJWTHandler(w http.ResponseWriter, r *http.Request
 // Headers (optional): X_FORWARDED_ACCESS_TOKEN or AUTHORIZATION
 // See function `tokenFromRequest` for details on how to supply the token.
 func (h *HandlerContext) verifyTokenHandler(w http.ResponseWriter, r *http.Request) {
+	// for testing: dump request infor to see what we get as an auth plugin
+	slog.Warn("v1/token.verify",
+		slog.String("RemoteAddr", r.RemoteAddr),
+		slog.String("Method", r.Method),
+		slog.String("URL", r.URL.String()),
+		slog.String("Headers", fmt.Sprintf("%v", r.Header)))
+
 	if r.Method != http.MethodGet {
 		api.ErrResponse(r.Context(), w, http.StatusBadRequest,
 			fmt.Sprintf("method %s not allowed, only %s", r.Method, http.MethodGet))

--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -413,7 +413,7 @@ func (s *Synk) applyAll(
 
 func validateNamespace(r *unstructured.Unstructured, optsNs string) error {
 	ns := r.GetNamespace()
-	allowed := []string{"", "kube-system", optsNs}
+	allowed := []string{"", "kube-system", "default", optsNs}
 	if slices.Contains(allowed, ns) {
 		return nil
 	}

--- a/third_party/istio/istio-generated.yaml
+++ b/third_party/istio/istio-generated.yaml
@@ -18752,7 +18752,7 @@ webhooks:
 ---
 apiVersion: v1
 data:
-  mesh: "accessLogFile: \"\"\naccessLogFormat: |\n  {\"authority\": \"%REQ(:AUTHORITY)%\"\
+  mesh: "accessLogFile: /dev/stdout\naccessLogFormat: |\n  {\"authority\": \"%REQ(:AUTHORITY)%\"\
     , \"start_time\": \"%START_TIME%\", \"bytes_received\": \"%BYTES_RECEIVED%\",\
     \ \"bytes_sent\": \"%BYTES_SENT%\", \"downstream_local_address\": \"%DOWNSTREAM_LOCAL_ADDRESS%\"\
     , \"downstream_remote_address\": \"%DOWNSTREAM_REMOTE_ADDRESS%\", \"duration\"\
@@ -18769,7 +18769,12 @@ data:
     %REQ(x-icon-instance-name)%\", \"x_resource_instance_name\": \"%REQ(x-resource-instance-name)%\"\
     }\ndefaultConfig:\n  discoveryAddress: istiod.default.svc:15012\n  proxyMetadata:\
     \ {}\ndefaultProviders:\n  metrics:\n  - prometheus\nenablePrometheusMerge: true\n\
-    rootNamespace: default\ntrustDomain: cluster.local"
+    extensionProviders:\n- envoyExtAuthzHttp:\n    headersToUpstreamOnAllow:\n   \
+    \ - authorization\n    includeRequestHeadersInCheck:\n    - authorization\n  \
+    \  - x-forwarded-access-token\n    - x-auth-url\n    pathPrefix: /apis/core.token-vendor/v1/token.verify?robots=true;origin=\n\
+    \    port: \"80\"\n    service: token-vendor.app-token-vendor.svc.cluster.local\n\
+    \    withRequestBody:\n      maxRequestBytes: 0\n      packAsBytes: false\n  name:\
+    \ token-vendor-robot-and-human-auth\nrootNamespace: default\ntrustDomain: cluster.local"
   meshNetworks: 'networks: {}'
 kind: ConfigMap
 metadata:
@@ -18818,9 +18823,10 @@ data:
     : {\n      \"enabled\": false\n    }\n  },\n  \"configMap\": true,\n  \"cpu\"\
     : {\n    \"targetAverageUtilization\": 80\n  },\n  \"defaultRevision\": \"\",\n\
     \  \"deploymentAnnotations\": {},\n  \"deploymentLabels\": {},\n  \"enabled\"\
-    : true,\n  \"env\": {},\n  \"envVarFrom\": [],\n  \"experimental\": {\n    \"\
-    stableValidationPolicy\": false\n  },\n  \"extraContainerArgs\": [],\n  \"gatewayClasses\"\
-    : {},\n  \"gateways\": {\n    \"istio-egressgateway\": {},\n    \"istio-ingressgateway\"\
+    : true,\n  \"env\": {\n    \"PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS\": \"\
+    true\"\n  },\n  \"envVarFrom\": [],\n  \"experimental\": {\n    \"stableValidationPolicy\"\
+    : false\n  },\n  \"extraContainerArgs\": [],\n  \"gatewayClasses\": {},\n  \"\
+    gateways\": {\n    \"istio-egressgateway\": {},\n    \"istio-ingressgateway\"\
     : {},\n    \"seccompProfile\": {},\n    \"securityContext\": {}\n  },\n  \"global\"\
     : {\n    \"caAddress\": \"\",\n    \"caName\": \"\",\n    \"certSigners\": [],\n\
     \    \"configCluster\": false,\n    \"configValidation\": true,\n    \"defaultPodDisruptionBudget\"\
@@ -18862,9 +18868,9 @@ data:
     : {\n    \"enabled\": false,\n    \"enabledLocalInjectorIstiod\": false,\n   \
     \ \"injectionCABundle\": \"\",\n    \"injectionPath\": \"/inject\",\n    \"injectionURL\"\
     : \"\"\n  },\n  \"jwksResolverExtraRootCA\": \"\",\n  \"keepaliveMaxServerConnectionAge\"\
-    : \"30m\",\n  \"memory\": {},\n  \"meshConfig\": {\n    \"accessLogFile\": \"\"\
-    ,\n    \"accessLogFormat\": \"{\\\"authority\\\": \\\"%REQ(:AUTHORITY)%\\\", \\\
-    \"start_time\\\": \\\"%START_TIME%\\\", \\\"bytes_received\\\": \\\"%BYTES_RECEIVED%\\\
+    : \"30m\",\n  \"memory\": {},\n  \"meshConfig\": {\n    \"accessLogFile\": \"\
+    /dev/stdout\",\n    \"accessLogFormat\": \"{\\\"authority\\\": \\\"%REQ(:AUTHORITY)%\\\
+    \", \\\"start_time\\\": \\\"%START_TIME%\\\", \\\"bytes_received\\\": \\\"%BYTES_RECEIVED%\\\
     \", \\\"bytes_sent\\\": \\\"%BYTES_SENT%\\\", \\\"downstream_local_address\\\"\
     : \\\"%DOWNSTREAM_LOCAL_ADDRESS%\\\", \\\"downstream_remote_address\\\": \\\"\
     %DOWNSTREAM_REMOTE_ADDRESS%\\\", \\\"duration\\\": \\\"%DURATION%\\\", \\\"istio_policy_status\\\
@@ -18881,14 +18887,23 @@ data:
     \", \\\"x_forwarded_for\\\": \\\"%REQ(X-FORWARDED-FOR)%\\\", \\\"x_icon_instance_name\\\
     \": \\\"%REQ(x-icon-instance-name)%\\\", \\\"x_resource_instance_name\\\": \\\"\
     %REQ(x-resource-instance-name)%\\\"}\\n\",\n    \"defaultConfig\": {\n      \"\
-    proxyMetadata\": {}\n    },\n    \"enablePrometheusMerge\": true\n  },\n  \"nodeSelector\"\
+    proxyMetadata\": {}\n    },\n    \"enablePrometheusMerge\": true,\n    \"extensionProviders\"\
+    : [\n      {\n        \"envoyExtAuthzHttp\": {\n          \"headersToUpstreamOnAllow\"\
+    : [\n            \"authorization\"\n          ],\n          \"includeRequestHeadersInCheck\"\
+    : [\n            \"authorization\",\n            \"x-forwarded-access-token\"\
+    ,\n            \"x-auth-url\"\n          ],\n          \"pathPrefix\": \"/apis/core.token-vendor/v1/token.verify?robots=true;origin=\"\
+    ,\n          \"port\": \"80\",\n          \"service\": \"token-vendor.app-token-vendor.svc.cluster.local\"\
+    ,\n          \"withRequestBody\": {\n            \"maxRequestBytes\": 0,\n   \
+    \         \"packAsBytes\": false\n          }\n        },\n        \"name\": \"\
+    token-vendor-robot-and-human-auth\"\n      }\n    ]\n  },\n  \"nodeSelector\"\
     : {},\n  \"ownerName\": \"\",\n  \"pdb\": {\n    \"minAvailable\": 1,\n    \"\
     unhealthyPodEvictionPolicy\": \"\"\n  },\n  \"pilot\": {\n    \"cni\": {\n   \
-    \   \"enabled\": false\n    },\n    \"enabled\": true\n  },\n  \"podAnnotations\"\
-    : {},\n  \"podLabels\": {},\n  \"replicaCount\": 1,\n  \"resourceQuotas\": {\n\
-    \    \"enabled\": true\n  },\n  \"resources\": {\n    \"requests\": {\n      \"\
-    cpu\": \"500m\",\n      \"memory\": \"2048Mi\"\n    }\n  },\n  \"revision\": \"\
-    \",\n  \"revisionTags\": [],\n  \"rollingMaxSurge\": \"100%\",\n  \"rollingMaxUnavailable\"\
+    \   \"enabled\": false\n    },\n    \"enabled\": true,\n    \"env\": {\n     \
+    \ \"PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS\": \"true\"\n    }\n  },\n  \"\
+    podAnnotations\": {},\n  \"podLabels\": {},\n  \"replicaCount\": 1,\n  \"resourceQuotas\"\
+    : {\n    \"enabled\": true\n  },\n  \"resources\": {\n    \"requests\": {\n  \
+    \    \"cpu\": \"500m\",\n      \"memory\": \"2048Mi\"\n    }\n  },\n  \"revision\"\
+    : \"\",\n  \"revisionTags\": [],\n  \"rollingMaxSurge\": \"100%\",\n  \"rollingMaxUnavailable\"\
     : \"25%\",\n  \"seccompProfile\": {},\n  \"serviceAccountAnnotations\": {},\n\
     \  \"serviceAnnotations\": {},\n  \"sidecarInjectorWebhook\": {\n    \"alwaysInjectSelector\"\
     : [],\n    \"defaultTemplates\": [],\n    \"enableNamespacesByDefault\": false,\n\
@@ -18909,12 +18924,12 @@ data:
     : {\n    \"configValidation\": true,\n    \"hub\": \"docker.io/istio\",\n    \"\
     istioNamespace\": \"default\",\n    \"logging\": {\n      \"level\": \"all:warn\"\
     \n    },\n    \"platform\": \"gke\",\n    \"tag\": \"1.29.2\"\n  },\n  \"meshConfig\"\
-    : {\n    \"accessLogFile\": \"\",\n    \"accessLogFormat\": \"{\\\"authority\\\
-    \": \\\"%REQ(:AUTHORITY)%\\\", \\\"start_time\\\": \\\"%START_TIME%\\\", \\\"\
-    bytes_received\\\": \\\"%BYTES_RECEIVED%\\\", \\\"bytes_sent\\\": \\\"%BYTES_SENT%\\\
-    \", \\\"downstream_local_address\\\": \\\"%DOWNSTREAM_LOCAL_ADDRESS%\\\", \\\"\
-    downstream_remote_address\\\": \\\"%DOWNSTREAM_REMOTE_ADDRESS%\\\", \\\"duration\\\
-    \": \\\"%DURATION%\\\", \\\"istio_policy_status\\\": \\\"%DYNAMIC_METADATA(istio.mixer:status)%\\\
+    : {\n    \"accessLogFile\": \"/dev/stdout\",\n    \"accessLogFormat\": \"{\\\"\
+    authority\\\": \\\"%REQ(:AUTHORITY)%\\\", \\\"start_time\\\": \\\"%START_TIME%\\\
+    \", \\\"bytes_received\\\": \\\"%BYTES_RECEIVED%\\\", \\\"bytes_sent\\\": \\\"\
+    %BYTES_SENT%\\\", \\\"downstream_local_address\\\": \\\"%DOWNSTREAM_LOCAL_ADDRESS%\\\
+    \", \\\"downstream_remote_address\\\": \\\"%DOWNSTREAM_REMOTE_ADDRESS%\\\", \\\
+    \"duration\\\": \\\"%DURATION%\\\", \\\"istio_policy_status\\\": \\\"%DYNAMIC_METADATA(istio.mixer:status)%\\\
     \", \\\"method\\\": \\\"%REQ(:METHOD)%\\\", \\\"path\\\": \\\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\\\
     \", \\\"protocol\\\": \\\"%PROTOCOL%\\\", \\\"request_id\\\": \\\"%REQ(X-REQUEST-ID)%\\\
     \", \\\"requested_server_name\\\": \\\"%REQUESTED_SERVER_NAME%\\\", \\\"response_code\\\
@@ -18928,9 +18943,18 @@ data:
     \"%REQ(X-FORWARDED-FOR)%\\\", \\\"x_icon_instance_name\\\": \\\"%REQ(x-icon-instance-name)%\\\
     \", \\\"x_resource_instance_name\\\": \\\"%REQ(x-resource-instance-name)%\\\"\
     }\\n\",\n    \"defaultConfig\": {\n      \"proxyMetadata\": {}\n    },\n    \"\
-    enablePrometheusMerge\": true\n  },\n  \"pilot\": {\n    \"cni\": {\n      \"\
-    enabled\": false\n    },\n    \"enabled\": true\n  },\n  \"ztunnel\": {\n    \"\
-    resourceName\": \"ztunnel\"\n  }\n}"
+    enablePrometheusMerge\": true,\n    \"extensionProviders\": [\n      {\n     \
+    \   \"envoyExtAuthzHttp\": {\n          \"headersToUpstreamOnAllow\": [\n    \
+    \        \"authorization\"\n          ],\n          \"includeRequestHeadersInCheck\"\
+    : [\n            \"authorization\",\n            \"x-forwarded-access-token\"\
+    ,\n            \"x-auth-url\"\n          ],\n          \"pathPrefix\": \"/apis/core.token-vendor/v1/token.verify?robots=true;origin=\"\
+    ,\n          \"port\": \"80\",\n          \"service\": \"token-vendor.app-token-vendor.svc.cluster.local\"\
+    ,\n          \"withRequestBody\": {\n            \"maxRequestBytes\": 0,\n   \
+    \         \"packAsBytes\": false\n          }\n        },\n        \"name\": \"\
+    token-vendor-robot-and-human-auth\"\n      }\n    ]\n  },\n  \"pilot\": {\n  \
+    \  \"cni\": {\n      \"enabled\": false\n    },\n    \"enabled\": true,\n    \"\
+    env\": {\n      \"PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS\": \"true\"\n \
+    \   }\n  },\n  \"ztunnel\": {\n    \"resourceName\": \"ztunnel\"\n  }\n}"
 kind: ConfigMap
 metadata:
   annotations:
@@ -19189,6 +19213,8 @@ spec:
               value: /var/run/secrets/remote/config
             - name: CA_TRUSTED_NODE_ACCOUNTS
               value: default/ztunnel
+            - name: PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS
+              value: 'true'
             - name: PILOT_TRACE_SAMPLING
               value: '1'
             - name: PILOT_ENABLE_ANALYSIS

--- a/third_party/istio/istio-values.json
+++ b/third_party/istio/istio-values.json
@@ -122,7 +122,9 @@
         "enabled": false
       }
     },
-    "env": {}
+    "env": {
+      "PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS": "true"
+    }
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/third_party/istio/istio_operator.yaml
+++ b/third_party/istio/istio_operator.yaml
@@ -16,17 +16,48 @@ spec:
       # Override the default namespace (istio-system) because we will wrap this YAML in a
       # ChartAssignment, and the controller will install to the default namespace.
       istioNamespace: default
+    pilot:
+      env:
+        PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS: "true"
 
   meshConfig:
-    # from default
     defaultConfig:
       proxyMetadata: {}
     enablePrometheusMerge: true
 
-    # Set this to "/dev/stdout" to enable access logging.
-    accessLogFile: ""
+    accessLogFile: "/dev/stdout"
     accessLogFormat: |
       {"authority": "%REQ(:AUTHORITY)%", "start_time": "%START_TIME%", "bytes_received": "%BYTES_RECEIVED%", "bytes_sent": "%BYTES_SENT%", "downstream_local_address": "%DOWNSTREAM_LOCAL_ADDRESS%", "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%", "duration": "%DURATION%", "istio_policy_status": "%DYNAMIC_METADATA(istio.mixer:status)%", "method": "%REQ(:METHOD)%", "path": "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%", "protocol": "%PROTOCOL%", "request_id": "%REQ(X-REQUEST-ID)%", "requested_server_name": "%REQUESTED_SERVER_NAME%", "response_code": "%RESPONSE_CODE%", "response_flags": "%RESPONSE_FLAGS%", "route_name": "%ROUTE_NAME%", "start_time": "%START_TIME%", "upstream_cluster": "%UPSTREAM_CLUSTER%", "upstream_host": "%UPSTREAM_HOST%", "upstream_local_address": "%UPSTREAM_LOCAL_ADDRESS%", "upstream_service_time": "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%", "upstream_transport_failure_reason": "%UPSTREAM_TRANSPORT_FAILURE_REASON%", "user_agent": "%REQ(USER-AGENT)%", "x_forwarded_for": "%REQ(X-FORWARDED-FOR)%", "x_icon_instance_name": "%REQ(x-icon-instance-name)%", "x_resource_instance_name": "%REQ(x-resource-instance-name)%"}
+    # Baseline Debugging for ensonic/istio:
+    # The PILOT_ENABLE_MULTIPLE_CUSTOM_AUTHZ_PROVIDERS flag is applied to Istiod.
+    # However, Istiod still reports 'only 1 provider can be used per workload'.
+    # This suggests a possible version limitation or a requirement that providers 
+    # be referenced in a specific way when multiple are used.
+    extensionProviders:
+    - name: "token-vendor-robot-and-human-auth"
+      envoyExtAuthzHttp:
+        service: "token-vendor.app-token-vendor.svc.cluster.local"
+        port: "80"
+        pathPrefix: "/apis/core.token-vendor/v1/token.verify?robots=true;origin="
+        # Force Envoy to use GET instead of POST for the verification check
+        withRequestBody:
+          maxRequestBytes: 0
+          packAsBytes: false
+        includeRequestHeadersInCheck: 
+        - "authorization"
+        - "x-forwarded-access-token"
+        - "x-auth-url"
+        headersToUpstreamOnAllow:
+        - "authorization"
+    # - name: "token-vendor-human-auth"
+    #   envoyExtAuthzHttp:
+    #     service: "token-vendor.app-token-vendor.svc.cluster.local"
+    #     port: "80"
+    #     pathPrefix: "/apis/core.token-vendor/v1/token.verify?robots=false"
+    #     headersToUpstreamOnAllow: ["authorization"]
+    #     includeRequestHeadersInCheck: 
+    #       - "authorization"
+    #       - "x-forwarded-access-token"
 
   components:
     base:


### PR DESCRIPTION
Try to configure the AuthorizationPolicy for token vendor.

This requires us to lift the constraint on chart assignments and we
need to allow to deploy into the "defaul"t namespec as well.

Tested:
```shell
istioctl x authz check $(kubectl get pods -n default -l gateway.networking.k8s.io/gateway-name=crc-gateway -o name | cut -d'/' -f2) -n default
istioctl proxy-config listener $(kubectl get pods -n default -l gateway.networking.k8s.io/gateway-name=crc-gateway -o name | cut -d'/' -f2) -n default --port 443 -o json | more
```