### PR TITLE
disable grafana test framework so postsubmit does not wait for it to be ready

### DIFF
--- a/src/app_charts/prometheus/prometheus-cloud.values.yaml
+++ b/src/app_charts/prometheus/prometheus-cloud.values.yaml
@@ -169,6 +169,8 @@ nodeExporter:
       targetLabel: instance
 
 grafana:
+  testFramework:
+    enabled: false
   env:
     GF_SERVER_DOMAIN: "${CR_GF_SERVER_DOMAIN}"
     GF_SERVER_ROOT_URL: "${CR_GF_SERVER_ROOT_URL}"

--- a/src/app_charts/prometheus/prometheus-robot.values.yaml
+++ b/src/app_charts/prometheus/prometheus-robot.values.yaml
@@ -200,4 +200,6 @@ prometheus-node-exporter:
     - --collector.netclass.ignored-devices=^(bond|cilium|ip6tnl0|lo|lxc|tunl)
 
 grafana:
+  testFramework:
+    enabled: false
   enabled: false


### PR DESCRIPTION
The test cluster is updated recently and it does not include `prom-grafana-test`, it causes postsubmit CI to fail as it tries to wait for the pod to be ready.