### PR TITLE
fail app_chart build when there is lint error

### DIFF
--- a/bazel/build_rules/helm_chart.bzl
+++ b/bazel/build_rules/helm_chart.bzl
@@ -13,6 +13,7 @@ def helm_chart(ctx, name, chart, files, templates, values, version, helm, out):
     """
 
     cmd = """
+      set -e
       mkdir {name} {name}/templates
       cp {chart} {name}/Chart.yaml
       cp {values} {name}/values.yaml


### PR DESCRIPTION
Tested by removing https://github.com/googlecloudrobotics/core/blob/fc4553d7b8243cbe91a2b125c7434ba76e2bf26c/src/app_charts/k8s-relay/values-robot.yaml#L6-L7. Build fails with a lint error.