### PR TITLE
Enable gateway api in certmanager.

### DIFF
--- a/src/app_charts/base/cert-manager-cloud.values.yaml
+++ b/src/app_charts/base/cert-manager-cloud.values.yaml
@@ -1,6 +1,9 @@
 # Configuration for the cert-manager chart.
 # Reference: https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
 
+config:
+  enableGatewayAPI: true
+
 # Install CRDs by helm chart that webhook works in different namespace as cert-manager
 installCRDs: true
 

--- a/src/app_charts/base/cloud/cert-manager-issuers.yaml
+++ b/src/app_charts/base/cloud/cert-manager-issuers.yaml
@@ -31,8 +31,16 @@ spec:
     # We can't use dns01 since we don't control the dns-zone that endpoints uses.
     solvers:
       - http01:
+{{- if eq .Values.use_istio "true" }}
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: crc-gateway
+                namespace: default
+                kind: Gateway
+{{- else }}
           ingress:
             class: nginx
+{{- end }}
 {{- else if eq .Values.certificate_provider "google-cas" }}
 ---
 # Issuer for Google's Certificate Authority service (CAS) using the google-cas-issuer project.


### PR DESCRIPTION
Tested by created a 2nd cert. Verified that a temp http route has been created and we got a cert.

See #668