### PR TITLE
Use helm templating to hide the HTTPRoute duplication

### DIFF
--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -1,16 +1,16 @@
-# TODO: need auth
-# "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+{{- range list "" "-auth" }}
+{{- $sectionName := "https" }}{{ if eq . "-auth" }}{{ $sectionName = "http" }}{{ end -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: public-key-access
+  name: public-key-access{{.}}
 spec:
   hostnames:
-  - {{ .Values.domain }}
+  - {{ $.Values.domain }}
   parentRefs:
-  - name: crc-gateway
+  - name: crc{{.}}-gateway
     namespace: default
-    sectionName: https
+    sectionName: {{ $sectionName }}
   rules:
   - backendRefs:
     - name: token-vendor
@@ -19,20 +19,26 @@ spec:
     - path:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/public-key.read
+{{- if eq . "-auth" }}
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /apis/core.token-vendor/v1/token.verify?robots=true
+{{- end }}
 ---
-# TODO: need auth
-# nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=false"
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: public-key-manager
+  name: public-key-manager{{.}}
 spec:
   hostnames:
-  - {{ .Values.domain }}
+  - {{ $.Values.domain }}
   parentRefs:
-  - name: crc-gateway
+  - name: crc{{.}}-gateway
     namespace: default
-    sectionName: https
+    sectionName: {{ $sectionName }}
   rules:
   - backendRefs:
     - name: token-vendor
@@ -44,7 +50,16 @@ spec:
     - path:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/public-key.publish
+{{- if eq . "-auth" }}
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /apis/core.token-vendor/v1/token.verify?robots=false
+{{- end }}
 ---
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -71,61 +86,3 @@ spec:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/token.oauth2
 ---
-# NOTE: ReferenceGrant not needed if we deploy this HTTPRoutes
-# in the same namespace as the token-vendor service (backendRef)
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: public-key-access-auth
-spec:
-  hostnames:
-  - {{ .Values.domain }}
-  parentRefs:
-  - name: crc-auth-gateway
-    namespace: default
-    sectionName: http
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /apis/core.token-vendor/v1/public-key.read
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplaceFullPath
-          replaceFullPath: /apis/core.token-vendor/v1/token.verify?robots=true
-    backendRefs:
-    - name: token-vendor
-      namespace: app-token-vendor
-      port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: public-key-manager-auth
-spec:
-  hostnames:
-  - {{ .Values.domain }}
-  parentRefs:
-  - name: crc-auth-gateway
-    namespace: default
-    sectionName: http
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /apis/core.token-vendor/v1/public-key.configure
-    - path:
-        type: PathPrefix
-        value: /apis/core.token-vendor/v1/public-key.publish
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplaceFullPath
-          replaceFullPath: /apis/core.token-vendor/v1/token.verify?robots=false
-    backendRefs:
-    - name: token-vendor
-      namespace: app-token-vendor
-      port: 80


### PR DESCRIPTION
Use a range loop to produce both the traffic and the auth routes in-place. This will avoid having to specify all path matches twice.

```shell
$ kubectl get httproute -n app-token-vendor
NAME                      HOSTNAMES                                    AGE
public-key-access         ["www.endpoints.XXX.cloud.goog"]   9d
public-key-access-auth    ["www.endpoints.XXX.cloud.goog"]   6h6m
public-key-manager        ["www.endpoints.XXX.cloud.goog"]   9d
public-key-manager-auth   ["www.endpoints.XXX.cloud.goog"]   6h6m
token-vendor              ["www.endpoints.XXX.cloud.goog"]   9d
```