### PR TITLE
🧱 terraform: natively deploy GRPCRoute CRD on GKE bootstrap

### DIFF
--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -190,3 +190,34 @@ resource "google_project_iam_member" "gke_node_roles" {
   ])
   role = each.key
 }
+
+# Download the official standard grpcroutes.yaml directly from Kubernetes Gateway API repository
+data "http" "grpcroutes_crd" {
+  url = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml"
+}
+
+locals {
+  # Decode multi-document YAML file
+  raw_manifests = provider::kubernetes::manifest_decode_multi(data.http.grpcroutes_crd.response_body)
+
+  # Filter out 'status' field since it is forbidden in kubernetes_manifest input configuration
+  clean_manifests = [
+    for manifest in local.raw_manifests : {
+      for key, value in manifest : key => value if key != "status"
+    }
+  ]
+}
+
+# Deploy the GRPCRoute CRD natively
+resource "kubernetes_manifest" "grpcroutes_crd" {
+  # Ensure CRD is only applied after GKE nodes and base pool are fully provisioned
+  depends_on = [google_container_node_pool.cloud_robotics_base_pool]
+
+  for_each = {
+    for manifest in local.clean_manifests : 
+    "${manifest.kind}--${manifest.metadata.name}" => manifest
+  }
+  
+  manifest = each.value
+}
+

--- a/src/bootstrap/cloud/terraform/provider.tf
+++ b/src/bootstrap/cloud/terraform/provider.tf
@@ -2,3 +2,12 @@ provider "google" {
   project = var.id
   region  = var.region
 }
+
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.cloud-robotics.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.cloud-robotics.master_auth[0].cluster_ca_certificate)
+}
+

--- a/src/bootstrap/cloud/terraform/versions.tf
+++ b/src/bootstrap/cloud/terraform/versions.tf
@@ -3,6 +3,11 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.28.0"
+    }
   }
   required_version = ">= 1.11.4"
 }
+


### PR DESCRIPTION
This change enables native deployment of the Gateway API GRPCRoute CRD during GKE bootstrap.

#### Why

The standard GKE Gateway API addon only installs stable channel resources (excluding GRPCRoute). To route gRPC traffic using Istio Gateway, the GRPCRoute CRD is required in the cluster. Managing it natively in Terraform prevents bootstrapping race conditions and version conflicts.

#### The code changes include:

- Add kubernetes provider requirement to versions.tf.
- Configure the kubernetes provider in provider.tf using data.google_client_config.
- Add http data download, status-field stripping, and kubernetes_manifest deployment for GRPCRoute CRD in cluster.tf.

RELNOTES=NONE
SDK_CHANGES=No changes
TESTED=on xfa-awesome-alpha