### PR TITLE
Upgrade NGINX version to remediate CVE-2026-9256

### DIFF
--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -121,7 +121,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged:1.30.1-alpine
+        image: nginxinc/nginx-unprivileged:1.31.1-alpine
         ports:
         - containerPort: 8080
         command: ["/bin/sh", "-c"]


### PR DESCRIPTION
Upgrade NGINX version to remediate [CVE-2026-9256](https://www.cve.org/CVERecord?id=CVE-2026-9256)