### PR TITLE
bazel: Add oci_load target for chart-assignment-controller

### DIFF
--- a/src/go/cmd/chart-assignment-controller/BUILD.bazel
+++ b/src/go/cmd/chart-assignment-controller/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
@@ -71,4 +71,16 @@ oci_image(
     base = ":helm-image",
     entrypoint = ["/chart-assignment-controller-app"],
     tars = [":chart-assignment-controller-layer"],
+)
+
+oci_load(
+    name = "chart-assignment-controller-tarball",
+    image = ":chart-assignment-controller-image",
+    repo_tags = ["chart-assignment-controller:latest"],
+)
+
+filegroup(
+    name = "chart-assignment-controller-tarball.tar",
+    srcs = [":chart-assignment-controller-tarball"],
+    output_group = "tarball",
 )


### PR DESCRIPTION
This PR adds an `oci_load` target to build a Docker-loadable tarball of the `chart-assignment-controller`.
It also adds a helper `filegroup` target to make building the tarball easy without needing to specify `--output_groups=tarball`.

This can be used as a workaround if you need to install just the chart-assignment-controller to a k8s cluster without any of the cloud connection parts that setup_robot.sh does (by providing your own YAML and using docker load). Longer-term it would be nicer to publish the chart-assignment-controller to a Helm repo where it can be installed from, but this is just a quick change to unblock it.

Tested with:

```bash
bazel build //src/go/cmd/chart-assignment-controller:chart-assignment-controller-tarball.tar
docker load -i bazel-bin/src/go/cmd/chart-assignment-controller/chart-assignment-controller-tarball/tarball.tar
[...]
Loaded image: chart-assignment-controller:latest
```