### PR TITLE
🛂 istio: whitelist cookie header in crc-auth-gateway provider

### DIFF
--- a/third_party/istio/istio_operator.yaml
+++ b/third_party/istio/istio_operator.yaml
@@ -35,6 +35,7 @@ spec:
           port: "8080"
           includeRequestHeadersInCheck: 
           - "authorization"
+          - "cookie"
           - "x-forwarded-access-token"
           - "x-auth-url"
           headersToUpstreamOnAllow: 


### PR DESCRIPTION
Whitelist the Cookie request header in the includeRequestHeadersInCheck list of the crc-auth-gateway EnvoyExtAuthzHttp provider.

#### Why

For initial migration to istio we are using cookies as headers and need those to be allowed to be passed downstream to our auth handlers. This is crc unspecific and we will need to remove this in the future.

#### The code changes include:

- Add "cookie" to includeRequestHeadersInCheck list in third_party/istio/istio_operator.yaml.

TESTED=NOTYET
go/traj/700fe5a1-d69b-436e-a7cf-7addcef36fca
TAG=agy