### PR TITLE
⏪️ Revert "🛂 istio: whitelist cookie header in crc-auth-gateway provider"

### DIFF
--- a/third_party/istio/istio_operator.yaml
+++ b/third_party/istio/istio_operator.yaml
@@ -35,7 +35,6 @@ spec:
           port: "8080"
           includeRequestHeadersInCheck: 
           - "authorization"
-          - "cookie"
           - "x-forwarded-access-token"
           - "x-auth-url"
           headersToUpstreamOnAllow: 


### PR DESCRIPTION
Reverts googlecloudrobotics/core#699

This is intrinsic specific and not fitting for the opensource community. I will add this as a post processing to the deployment scripts on intrinsic side