### PR TITLE
Replace auth-gateway catchall NGINX using HTTP status echo server

### DIFF
--- a/src/app_charts/base/BUILD.bazel
+++ b/src/app_charts/base/BUILD.bazel
@@ -108,6 +108,7 @@ app_chart(
         "app-rollout-controller": "//src/go/cmd/app-rollout-controller:app-rollout-controller-image",
         "chart-assignment-controller": "//src/go/cmd/chart-assignment-controller:chart-assignment-controller-image",
         "cr-syncer-auth-webhook": "//src/go/cmd/cr-syncer-auth-webhook:cr-syncer-auth-webhook-image",
+        "status-echo-server": "//src/go/cmd/status-echo-server:status-echo-server-image",
     },
     values = "values-cloud.yaml",
     visibility = ["//visibility:public"],

--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -120,20 +120,19 @@ spec:
         app: crc-auth-gateway-catchall-svc
     spec:
       containers:
-      - name: nginx
-        image: nginxinc/nginx-unprivileged:1.31.1-alpine
+      - name: catchall
+        image: {{ .Values.registry }}{{ .Values.images.status_echo_server }}
         ports:
         - containerPort: 8080
-        command: ["/bin/sh", "-c"]
         args:
-        - |
-          echo 'server {
-              listen 8080;
-              location / {
-                  add_header Content-Type text/plain;
-                  return 404 "Not Found\n";
-              }
-          }' > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'
+        - --port=8080
+        - --http_status=404
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+        livenessProbe:
+          tcpSocket:
+            port: 8080
 ---
 apiVersion: v1
 kind: Service

--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -123,7 +123,9 @@ spec:
       - name: catchall
         image: {{ .Values.registry }}{{ .Values.images.status_echo_server }}
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
+          protocol: TCP
         args:
         - --port=8080
         - --http_status=404
@@ -133,6 +135,19 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          privileged: false
+          capabilities:
+              drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Replace auth-gateway catchall NGINX using the newly implemented HTTP status echo server.