### PR TITLE
Allow cross-ns deployments to "default" as well.

### DIFF
--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -413,7 +413,7 @@ func (s *Synk) applyAll(
 
 func validateNamespace(r *unstructured.Unstructured, optsNs string) error {
 	ns := r.GetNamespace()
-	allowed := []string{"", "kube-system", optsNs}
+	allowed := []string{"", "kube-system", "default", optsNs}
 	if slices.Contains(allowed, ns) {
 		return nil
 	}


### PR DESCRIPTION
We do need this for httproutes to reference the gateways that we have placed into the default ns.

Extracted from: https://github.com/googlecloudrobotics/core/pull/676/changes#diff-595eb1a44092ba5f25963e2e30fc6516cffc95eba582c03e657416908ae88aaa