### PR TITLE
Improve error handling in the relay

### DIFF
--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -26,6 +27,15 @@ import (
 	pb "github.com/googlecloudrobotics/core/src/proto/http-relay"
 
 	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ErrMultipleClients   = errors.New("multiple clients trying to handle request ID")
+	ErrRelayTimeout      = errors.New("timeout waiting for relay client to accept request")
+	ErrNoRequest         = errors.New("no request received within timeout")
+	ErrServerRestarting  = errors.New("server is restarting")
+	ErrInvalidRequestID  = errors.New("duplicate or invalid request ID")
+	ErrClosedInactivity  = errors.New("closed due to inactivity")
 )
 
 var (
@@ -149,7 +159,7 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 	}
 	if r.resp[id] != nil {
 		r.m.Unlock()
-		return nil, fmt.Errorf("multiple clients trying to handle request ID %s on server %s", id, server)
+		return nil, fmt.Errorf("%w %s on server %s", ErrMultipleClients, id, server)
 	}
 	ts := time.Now()
 	r.resp[id] = &pendingResponse{
@@ -173,7 +183,7 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 	case <-time.After(10 * time.Second):
 		// This branch is triggered if the channel is not ready to consume the request
 		// since it is still busy with handling a different request.
-		return nil, fmt.Errorf("cannot reach the client %q; check that it's turned on, set up, and connected to the internet; if the network config recently changed, try again in 1-2 minutes (timeout waiting for relay client to accept request)", server)
+		return nil, fmt.Errorf("cannot reach the client %q; check that it's turned on, set up, and connected to the internet; if the network config recently changed, try again in 1-2 minutes (%w)", server, ErrRelayTimeout)
 	}
 }
 
@@ -204,9 +214,9 @@ func (r *broker) GetRequest(ctx context.Context, server, path string) (*pb.HttpR
 		return req, nil
 	case <-time.After(time.Second * 30):
 		brokerResponses.WithLabelValues("server_request", "timeout", server).Inc()
-		return nil, fmt.Errorf("no request received within timeout")
+		return nil, ErrNoRequest
 	case <-ctx.Done():
-		return nil, fmt.Errorf("server is restarting")
+		return nil, ErrServerRestarting
 	}
 }
 
@@ -265,7 +275,7 @@ func (r *broker) SendResponse(resp *pb.HttpResponse) error {
 	if pr == nil {
 		r.m.Unlock()
 		brokerResponses.WithLabelValues("server_response", "not recognized or reaches the inactivity timeout", backendName).Inc()
-		return fmt.Errorf("duplicate or invalid request ID %s", id)
+		return fmt.Errorf("%w %s", ErrInvalidRequestID, id)
 	}
 	// hold `sendMutex` throughout the function to ensure that `responseStream` is not closed
 	// while we are writing to it. We must acquire the lock while we are holding `r.m` to
@@ -292,7 +302,7 @@ func (r *broker) SendResponse(resp *pb.HttpResponse) error {
 	case pr.responseStream <- resp:
 		break
 	case <-pr.markReap:
-		return fmt.Errorf("closed due to inactivity")
+		return ErrClosedInactivity
 	}
 
 	brokerRequests.WithLabelValues("server_response", backendName).Inc()

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -291,8 +292,8 @@ func TestReapWhileSendingResponse(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		reqErr = b.SendResponse(&pb.HttpResponse{Id: req.Id, Body: []byte(*req.Id), Eof: proto.Bool(false)})
-		if reqErr == nil || reqErr.Error() != "closed due to inactivity" {
-			t.Errorf("Wrong SendResponse error or no error:", reqErr)
+		if !errors.Is(reqErr, ErrClosedInactivity) {
+			t.Errorf("Wrong SendResponse error: %v; want %v", reqErr, ErrClosedInactivity)
 		}
 		wg.Done()
 	}()

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -42,6 +43,11 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"golang.org/x/sync/errgroup"
+)
+
+var (
+	ErrRequestPathTooShort     = errors.New("request path too short")
+	ErrMissingServerNameHeader = errors.New("missing required header")
 )
 
 const (
@@ -131,7 +137,7 @@ func extractBackendNameAndPath(r *http.Request) (backendName string, path string
 		pathParts := strings.SplitN(strings.TrimPrefix(r.URL.Path, clientPrefix), "/", 2)
 		backendName = pathParts[0]
 		if backendName == "" {
-			err = fmt.Errorf("request path %q too short: missing remote server identifier after %q", r.URL.Path, clientPrefix)
+			err = fmt.Errorf("%w: %q missing remote server identifier after %q", ErrRequestPathTooShort, r.URL.Path, clientPrefix)
 			return
 		}
 		path = "/"
@@ -143,7 +149,7 @@ func extractBackendNameAndPath(r *http.Request) (backendName string, path string
 		// identified by "X-Server-Name" header.
 		headers, ok := r.Header["X-Server-Name"]
 		if !ok {
-			err = fmt.Errorf("request for path %q is missing required header %q", r.URL.Path, "X-Server-Name")
+			err = fmt.Errorf("%w: %q missing for path %q", ErrMissingServerNameHeader, "X-Server-Name", r.URL.Path)
 			return
 		}
 		backendName = headers[0]
@@ -264,9 +270,7 @@ func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseW
 			// Here we get the client stream (e.g. kubectl or k9s)
 			n, err := bufrw.Read(bytes)
 			if err != nil {
-				// TODO(https://github.com/golang/go/issues/4373): in Go 1.13,
-				// we may be able to suppress the "read from closed connection" better.
-				if strings.Contains(err.Error(), "use of closed network connection") {
+				if errors.Is(err, net.ErrClosed) {
 					// Request ended and connection closed by HTTP server.
 					slog.Info("End of bidi-stream stream (closed socket)", slog.String("ID", backendCtx.Id))
 				} else {

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -197,13 +197,13 @@ func TestClientBadRequest(t *testing.T) {
 			desc:     "url-path misses the backend name and path",
 			req:      httptest.NewRequest("GET", "/client/", strings.NewReader("body")),
 			wantCode: 400,
-			wantMsg:  "request path \"/client/\" too short:",
+			wantMsg:  "request path too short:",
 		},
 		{
 			desc:     "url-path misses the backend header",
 			req:      httptest.NewRequest("GET", "/", strings.NewReader("body")),
 			wantCode: 400,
-			wantMsg:  "missing required header \"X-Server-Name\"",
+			wantMsg:  "missing required header:",
 		},
 	}
 


### PR DESCRIPTION
Define own errors to avoid comparing strings in the tests.