### PR TITLE
Add missing "return"

### DIFF
--- a/src/go/cmd/cr-syncer-auth-webhook/main.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/main.go
@@ -178,6 +178,7 @@ func (h *handlers) auth(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.Error("failed to read /var/run/secrets/kubernetes.io/serviceaccount/token", ilog.Err(err))
 		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Add("Authorization", "Bearer "+string(k8sToken))
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Don't add Auth header with token that we failed to get.