### PR TITLE
Code style cleanups

### DIFF
--- a/src/go/cmd/app-rollout-controller/main.go
+++ b/src/go/cmd/app-rollout-controller/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	if err := runController(ctx, kubernetesConfig, helmParams); err != nil {
-		slog.Error("Exit", ilog.Err(runController(ctx, kubernetesConfig, helmParams)))
+		slog.Error("Exit", ilog.Err(err))
 		os.Exit(1)
 	}
 	slog.Info("Exit")

--- a/src/go/cmd/chart-assignment-controller/main.go
+++ b/src/go/cmd/chart-assignment-controller/main.go
@@ -58,7 +58,7 @@ func main() {
 	slog.SetDefault(slog.New(logHandler))
 
 	ctx := context.Background()
-	if *stackdriverProjectID != "" && *cloudCluster == false {
+	if *stackdriverProjectID != "" && !*cloudCluster {
 		sd, err := stackdriver.NewExporter(stackdriver.Options{
 			ProjectID: *stackdriverProjectID,
 		})
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	var clusterName string
-	if *cloudCluster == true {
+	if *cloudCluster {
 		clusterName = "cloud"
 		slog.Info("Starting chart-assignment-controller in cloud setup")
 	} else {

--- a/src/go/cmd/cr-syncer/syncer.go
+++ b/src/go/cmd/cr-syncer/syncer.go
@@ -339,14 +339,12 @@ func (s *crSyncer) processNextWorkItem(
 	// Errors are counted in syncUpstream and syncDownstream functions
 	if s.conflictErrors >= *conflictErrorLimit {
 		slog.Info("Restarting informers because of too many conflict errors", slog.String("CRD", s.crd.GetName()))
-		err := s.restartInformers()
-		if err != nil {
+		if err := s.restartInformers(); err != nil {
 			slog.Warn("Restarting informers failed", slog.String("CRD", s.crd.GetName()))
 			q.AddRateLimited(key)
 			return true
-		} else {
-			s.conflictErrors = 0
 		}
+		s.conflictErrors = 0
 	}
 
 	ctx, err := tag.New(ctx, tag.Insert(tagEventSource, qName))

--- a/src/go/cmd/gcr-credential-refresher/main.go
+++ b/src/go/cmd/gcr-credential-refresher/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"time"
 
@@ -38,20 +39,20 @@ func updateCredentials(ctx context.Context) error {
 	// Connect to the surrounding k8s cluster.
 	localConfig, err := rest.InClusterConfig()
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to load in-cluster config: %w", err)
 	}
 	localClient, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 	robotAuth, err := robotauth.LoadFromFile(*robotIdFile)
 	if err != nil {
-		log.Fatalf("failed to read robot id file %s: %v", *robotIdFile, err)
+		return fmt.Errorf("failed to read robot id file %s: %w", *robotIdFile, err)
 	}
 
 	effectiveSA, err := robotAuth.ServiceAccountEmail(*robotSAName)
 	if err != nil {
-		log.Fatalf("failed to construct service account from '%s': %v", *robotSAName, err)
+		return fmt.Errorf("failed to construct service account from '%s': %w", *robotSAName, err)
 	}
 
 	// Perform a token exchange with the TokenVendor in the cloud cluster and update the

--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -128,10 +128,10 @@ type broker struct {
 }
 
 func newBroker() *broker {
-	var r broker
-	r.req = make(map[string]chan *pb.HttpRequest)
-	r.resp = make(map[string]*pendingResponse)
-	return &r
+	return &broker{
+		req:  make(map[string]chan *pb.HttpRequest),
+		resp: make(map[string]*pendingResponse),
+	}
 }
 
 // Healthy can be used for server health checks. If the server is deadlocked it

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -268,8 +268,7 @@ func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseW
 			// This must be a new buffer each time, as the channel is not making a copy
 			bytes := make([]byte, s.conf.BlockSize)
 			// Here we get the client stream (e.g. kubectl or k9s)
-			n, err := bufrw.Read(bytes)
-			if err != nil {
+			if n, err := bufrw.Read(bytes); err != nil {
 				if errors.Is(err, net.ErrClosed) {
 					// Request ended and connection closed by HTTP server.
 					slog.Info("End of bidi-stream stream (closed socket)", slog.String("ID", backendCtx.Id))
@@ -278,19 +277,20 @@ func (s *Server) bidirectionalStream(backendCtx backendContext, w http.ResponseW
 					slog.Error("Error reading from bidi-stream", slog.String("ID", backendCtx.Id), ilog.Err(err))
 				}
 				return
+			} else {
+				slog.Info("Read from bidi-stream", slog.String("ID", backendCtx.Id), slog.Int("Bytes", n))
+				if ok = s.b.PutRequestStream(backendCtx.Id, bytes[:n]); !ok {
+					slog.Info("End of bidi-stream stream", slog.String("ID", backendCtx.Id))
+					return
+				}
+				slog.Info("Uploaded from bidi-stream", slog.String("ID", backendCtx.Id), slog.Int("Bytes", n))
 			}
-			slog.Info("Read from bidi-stream", slog.String("ID", backendCtx.Id), slog.Int("Bytes", n))
-			if ok = s.b.PutRequestStream(backendCtx.Id, bytes[:n]); !ok {
-				slog.Info("End of bidi-stream stream", slog.String("ID", backendCtx.Id))
-				return
-			}
-			slog.Info("Uploaded from bidi-stream", slog.String("ID", backendCtx.Id), slog.Int("Bytes", n))
 		}
 	}()
 
 	numBytes := 0
 	for responseChunk := range responseChunks {
-		if _, err = bufrw.Write(responseChunk.Body); err != nil {
+		if _, err := bufrw.Write(responseChunk.Body); err != nil {
 			slog.Error("Error writing response to bidi-stream", slog.String("ID", backendCtx.Id), ilog.Err(err))
 			return
 		}
@@ -434,7 +434,7 @@ func (s *Server) userClientRequest(w http.ResponseWriter, r *http.Request) {
 	// i.e. this will block until
 	numBytes := 0
 	for responseChunk := range responseChunksChan {
-		if _, err = w.Write(responseChunk.Body); err != nil {
+		if _, err := w.Write(responseChunk.Body); err != nil {
 			slog.Error("Error writing response to user-client", slog.String("ID", backendCtx.Id), ilog.Err(err))
 			return
 		}
@@ -524,13 +524,13 @@ func (s *Server) serverResponse(w http.ResponseWriter, r *http.Request) {
 	}
 
 	br := &pb.HttpResponse{}
-	if err = proto.Unmarshal(body, br); err != nil {
+	if err := proto.Unmarshal(body, br); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Send the response to the actual user-client using our broker.
-	if err = s.b.SendResponse(br); err != nil {
+	if err := s.b.SendResponse(br); err != nil {
 		// SendResponse fails if and only if the request ID is bad.
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/src/go/cmd/metadata-server/main.go
+++ b/src/go/cmd/metadata-server/main.go
@@ -57,8 +57,7 @@ func detectChangesToFile(filename string) <-chan struct{} {
 		slog.Error("NewWatcher", slog.Any("Error", err))
 		os.Exit(1)
 	}
-	err = watcher.Add(filename)
-	if err != nil {
+	if err := watcher.Add(filename); err != nil {
 		slog.Error("Watcher.Add", slog.Any("Error", err))
 		os.Exit(1)
 	}

--- a/src/go/cmd/metadata-server/metadata.go
+++ b/src/go/cmd/metadata-server/metadata.go
@@ -127,11 +127,10 @@ func NewIdentityHandler(ctx context.Context) (*IdentityHandler, error) {
 		return nil, fmt.Errorf("failed to read robot id file %s: %w", *robotIdFile, err)
 	}
 
-	i := &IdentityHandler{
+	return &IdentityHandler{
 		AllowedSources: allowedSources,
 		robotAuth:      robotAuth,
-	}
-	return i, nil
+	}, nil
 }
 
 func fromAcceptedIP(w http.ResponseWriter, r *http.Request, allowedSources *net.IPNet) bool {
@@ -160,7 +159,6 @@ func (h *IdentityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		slog.Error("Unable to create JWT", ilog.Err(err))
 		http.Error(w, "Unable to create jwt", http.StatusInternalServerError)
 		return
-
 	}
 
 	w.Header().Set("Metadata-Flavor", "Google")

--- a/src/go/cmd/setup-dev/main.go
+++ b/src/go/cmd/setup-dev/main.go
@@ -92,8 +92,7 @@ func main() {
 	robotGVR := schema.GroupVersionResource{Group: "registry.cloudrobotics.com", Version: "v1alpha1", Resource: "robots"}
 	robotClient := k8s.Resource(robotGVR).Namespace("default")
 
-	*robotName, err = setup.GetRobotName(ctx, f, robotClient, *robotName)
-	if err != nil {
+	if *robotName, err = setup.GetRobotName(ctx, f, robotClient, *robotName); err != nil {
 		slog.Error("Failed to get robot name", ilog.Err(err))
 		os.Exit(1)
 	}

--- a/src/go/cmd/token-vendor/main.go
+++ b/src/go/cmd/token-vendor/main.go
@@ -107,7 +107,8 @@ func main() {
 	ctx := context.Background()
 	var rep repository.PubKeyRepository
 	var err error
-	if *keyStore == Kubernetes {
+	switch *keyStore {
+	case Kubernetes:
 		config, err := rest.InClusterConfig()
 		if err != nil {
 			slog.Error("Failed to get config", ilog.Err(err))
@@ -120,18 +121,16 @@ func main() {
 			slog.Error("Failed to make clientset", ilog.Err(err))
 			os.Exit(1)
 		}
-		rep, err = k8s.NewK8sRepository(ctx, cs, *namespace)
-		if err != nil {
+		if rep, err = k8s.NewK8sRepository(ctx, cs, *namespace); err != nil {
 			slog.Error("Failed to make k8s repository client", ilog.Err(err))
 			os.Exit(1)
 		}
-	} else if *keyStore == Memory {
-		rep, err = memory.NewMemoryRepository(ctx)
-		if err != nil {
+	case Memory:
+		if rep, err = memory.NewMemoryRepository(ctx); err != nil {
 			slog.Error("Failed to make in-memory repository", ilog.Err(err))
 			os.Exit(1)
 		}
-	} else {
+	default:
 		slog.Error("unsupported key store option", slog.String("Value", *keyStore))
 		os.Exit(1)
 	}
@@ -166,8 +165,7 @@ func main() {
 
 	// serve API
 	addr := fmt.Sprintf("%s:%d", *bind, *port)
-	err = api.SetupAndServe(addr)
-	if err != nil {
+	if err := api.SetupAndServe(addr); err != nil {
 		slog.Error("Failed to listen", slog.String("IP", addr), ilog.Err(err))
 		os.Exit(1)
 	}

--- a/src/go/pkg/robotauth/robotauth.go
+++ b/src/go/pkg/robotauth/robotauth.go
@@ -73,8 +73,7 @@ func LoadFromFile(keyfile string) (*RobotAuth, error) {
 	}
 
 	var robotAuth RobotAuth
-	err = json.Unmarshal(raw, &robotAuth)
-	if err != nil {
+	if err := json.Unmarshal(raw, &robotAuth); err != nil {
 		return nil, fmt.Errorf("failed to parse %v: %v", credentialsFile, err)
 	}
 
@@ -110,8 +109,7 @@ func (r *RobotAuth) StoreInFile() error {
 		return err
 	}
 
-	err = os.WriteFile(file, raw, 0600)
-	if err != nil {
+	if err := os.WriteFile(file, raw, 0600); err != nil {
 		return fmt.Errorf("failed to write %v: %v", credentialsFile, err)
 	}
 


### PR DESCRIPTION
* use one-line error handling form with limited scope where possible.
* return structs as we initialize them (without intermediate vars)
* use swicth case over multiple if else blocks.