### PR TITLE
Refactor the in-process relay test

### DIFF
--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -544,6 +544,16 @@ func (s *Server) serverResponse(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) Start() {
+	addr := fmt.Sprintf(":%d", s.conf.Port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("Failed to listen", slog.String("Address", addr), ilog.Err(err))
+		panic("Failed to listen")
+	}
+	s.StartOnListener(ln)
+}
+
+func (s *Server) StartOnListener(ln net.Listener) {
 	h := http.NewServeMux()
 	h.HandleFunc("/healthz", s.health)
 	h.HandleFunc("/", s.userClientRequest)
@@ -565,7 +575,6 @@ func (s *Server) Start() {
 		Handler: h2h,
 	}
 	h1s := &http.Server{
-		Addr:    fmt.Sprintf(":%d", s.conf.Port),
 		Handler: och,
 		BaseContext: func(l net.Listener) context.Context {
 			slog.Info("Relay server listening", slog.Int("Port", l.Addr().(*net.TCPAddr).Port))
@@ -576,7 +585,7 @@ func (s *Server) Start() {
 	// listener, or because we got SIGTERM.
 	g, gCtx := errgroup.WithContext(mainCtx)
 	g.Go(func() error {
-		if err := h1s.ListenAndServe(); err != http.ErrServerClosed {
+		if err := h1s.Serve(ln); err != http.ErrServerClosed {
 			return err
 		}
 		// ErrServerClosed follows SIGTERM which is normal when updating the

--- a/src/go/tests/relay/BUILD.bazel
+++ b/src/go/tests/relay/BUILD.bazel
@@ -22,8 +22,6 @@ go_test(
     name = "in_process_relay_test",
     size = "small",
     srcs = ["in_process_relay_test.go"],
-    # https://github.com/googlecloudrobotics/core/issues/507
-    flaky = True,
     deps = [
         ":go_default_library",
         "//src/go/cmd/http-relay-client/client:go_default_library",

--- a/src/go/tests/relay/in_process_relay_test.go
+++ b/src/go/tests/relay/in_process_relay_test.go
@@ -18,98 +18,138 @@ import (
 )
 
 var (
-	relayPort   int // Will be initialized by initRelay()
-	backendPort int // Will be initialized by initRelay()
-	blockSize   = 10 * 1024
-	once        sync.Once
+	relayPort      int
+	backendPort    int
+	blockSize      = 10 * 1024
+	once           sync.Once
+	backendHandler http.Handler
+	backendMu      sync.RWMutex
 )
 
-func pickUnusedPortOrDie() int {
-	var addr *net.TCPAddr
-	var err error
-	if addr, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
-		var list *net.TCPListener
-		if list, err = net.ListenTCP("tcp", addr); err == nil {
-			defer list.Close()
-			return list.Addr().(*net.TCPAddr).Port
-		}
-	}
-	glog.Fatal("Failed to pick a free TCP port.")
-	return 0
+func setBackendHandler(h http.Handler) {
+	backendMu.Lock()
+	backendHandler = h
+	backendMu.Unlock()
+}
+
+func getBackendHandler() http.Handler {
+	backendMu.RLock()
+	defer backendMu.RUnlock()
+	return backendHandler
+}
+
+type backendResetter struct{}
+
+func (r backendResetter) Shutdown(ctx context.Context) error {
+	setBackendHandler(nil)
+	return nil
 }
 
 func initRelay() {
 	once.Do(func() {
 		glog.Info("Running init.")
 
-		backendPort = pickUnusedPortOrDie()
-		relayPort = pickUnusedPortOrDie()
+		// 1. Setup Backend Server
+		backendLn, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			glog.Fatalf("Failed to listen on backend port: %v", err)
+		}
+		backendPort = backendLn.Addr().(*net.TCPAddr).Port
+
+		backendSrv := &http.Server{
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if h := getBackendHandler(); h != nil {
+					h.ServeHTTP(w, r)
+				} else {
+					http.Error(w, "No backend handler configured", http.StatusInternalServerError)
+				}
+			}),
+		}
+		go backendSrv.Serve(backendLn)
+
+		// 2. Setup Relay Server
+		relayLn, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			glog.Fatalf("Failed to listen on relay port: %v", err)
+		}
+		relayPort = relayLn.Addr().(*net.TCPAddr).Port
+
+		relayServer := server.NewServer(server.Config{
+			BlockSize: blockSize,
+		})
+		go relayServer.StartOnListener(relayLn)
+
+		// 3. Setup Relay Client
+		config := client.DefaultClientConfig()
+		config.RelayScheme = "http"
+		config.RelayAddress = fmt.Sprint("127.0.0.1:", relayPort)
+		config.BackendScheme = "http"
+		config.BackendAddress = fmt.Sprint("127.0.0.1:", backendPort)
+		config.DisableAuthForRemote = true
+		relayClient := client.NewClient(config)
+		go relayClient.Start()
 
 		glog.Infof("Setting up relay.\n\tBackend port: %d\n\tRelay port: %d", backendPort, relayPort)
 
-		go func() {
-			relayServer := server.NewServer(server.Config{
-				Port:      relayPort,
-				BlockSize: blockSize,
-			})
-			relayServer.Start()
-		}()
-
-		go func() {
-			config := client.DefaultClientConfig()
-			config.RelayScheme = "http"
-			config.RelayAddress = fmt.Sprint("127.0.0.1:", relayPort)
-			config.BackendScheme = "http"
-			config.BackendAddress = fmt.Sprint("127.0.0.1:", backendPort)
-			config.DisableAuthForRemote = true
-			relayClient := client.NewClient(config)
-			relayClient.Start()
-		}()
-
+		// 4. Wait for Relay Server to be healthy
 		relayHealthy := false
 		deadline := time.Now().Add(5 * time.Second)
 		for time.Now().Before(deadline) {
 			relayHealthzAddr := fmt.Sprint("http://127.0.0.1:", relayPort, "/healthz")
 			res, err := http.Get(relayHealthzAddr)
 			if err != nil {
-				glog.Infof("Relay server is has not yet started, retrying.")
-				time.Sleep(250 * time.Millisecond)
+				glog.Infof("Relay server has not yet started, retrying.")
+				time.Sleep(100 * time.Millisecond)
 			} else {
 				glog.Info("Relay server is up and running.")
 				relayHealthy = true
-				defer res.Body.Close()
-				io.ReadAll(res.Body)
+				res.Body.Close()
 				break
 			}
 		}
 		if !relayHealthy {
-			glog.Fatal("Failed to bring up http relay for unknown reason.")
+			glog.Fatal("Failed to bring up http relay server.")
+		}
+
+		// 5. Wait for Relay Client to register
+		relayAddress := fmt.Sprintf("http://127.0.0.1:%d/client/server_name/", relayPort)
+		clientRegistered := false
+		deadline = time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			res, err := http.Get(relayAddress)
+			if err == nil {
+				body, _ := io.ReadAll(res.Body)
+				res.Body.Close()
+				if res.StatusCode == http.StatusServiceUnavailable && bytes.Contains(body, []byte("unknown client")) {
+					glog.Infof("Relay client has not yet registered, retrying.")
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+				glog.Info("Relay client registered.")
+				clientRegistered = true
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if !clientRegistered {
+			glog.Fatal("Relay client failed to register.")
 		}
 	})
 }
 
 func serveFunction(
-	f func(w http.ResponseWriter, r *http.Request)) *http.Server {
+	f func(w http.ResponseWriter, r *http.Request)) interface{ Shutdown(context.Context) error } {
 	return serveFunctionWithTimeout(f, 10*time.Second)
 }
 
 func serveFunctionWithTimeout(
 	f func(w http.ResponseWriter, r *http.Request),
-	handlerTimeout time.Duration) *http.Server {
-	httpHandlerFunc := http.HandlerFunc(f)
+	handlerTimeout time.Duration) interface{ Shutdown(context.Context) error } {
 
-	srv := &http.Server{
-		Addr:         fmt.Sprint("127.0.0.1:", backendPort),
-		ReadTimeout:  5 * time.Second, // Time between accepted connection and request body being read.
-		WriteTimeout: 5 * time.Second, // Time between request header being read and response body being written.
-		Handler:      http.TimeoutHandler(httpHandlerFunc, handlerTimeout, "Timeout"),
-	}
-
-	go func() {
-		srv.ListenAndServe()
-	}()
-
-	return srv
+	setBackendHandler(http.TimeoutHandler(http.HandlerFunc(f), handlerTimeout, "Timeout"))
+	return backendResetter{}
 }
 
 func TestHttpResponse(t *testing.T) {
@@ -127,7 +167,7 @@ func TestHttpResponse(t *testing.T) {
 	relayAddress := fmt.Sprint("http://127.0.0.1:", relayPort, "/client/server_name/")
 	res, err := http.Get(relayAddress)
 	if err != nil {
-		t.Error("Server responeded with an error. Error %v", err)
+		t.Fatalf("Server responded with an error. Error %v", err)
 	}
 	defer res.Body.Close()
 	observedResponse, err := io.ReadAll(res.Body)
@@ -154,7 +194,7 @@ func TestHttpTimeout(t *testing.T) {
 		return
 	}
 	if res.StatusCode != 503 {
-		t.Error("No timeout error received.")
+		t.Errorf("No timeout error received. Observed: %d", res.StatusCode)
 	}
 }
 
@@ -192,12 +232,12 @@ func TestHttpErrorPropagation(t *testing.T) {
 			relayAddress := fmt.Sprint("http://127.0.0.1:", relayPort, "/client/server_name/")
 			res, err := http.Get(relayAddress)
 			if err != nil {
-				t.Errorf("Server responeded with an error. Error %v", err)
-			}
-			if res.StatusCode != test.statusCode {
-				t.Errorf("Server responeded with an unexpected status code.\n\tExpected: %v\n\tObserved: %v", test.statusCode, res.StatusCode)
+				t.Fatalf("Server responded with an error. Error %v", err)
 			}
 			defer res.Body.Close()
+			if res.StatusCode != test.statusCode {
+				t.Errorf("Server responded with an unexpected status code.\n\tExpected: %v\n\tObserved: %v", test.statusCode, res.StatusCode)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Main change is to be able to reuse the listener and hence avoid the flakyness due to port-collisions. Sadly the test setup logic became more complex (initRelay).

Verified with --runs_per_test=1000

Fixed #507