### PR TITLE
Conditionally set CertDir in webhook.Options

### DIFF
--- a/src/go/cmd/chart-assignment-controller/main.go
+++ b/src/go/cmd/chart-assignment-controller/main.go
@@ -107,9 +107,16 @@ func runController(ctx context.Context, cfg *rest.Config, cluster string) error 
 	scheme.AddToScheme(sc)
 	apps.AddToScheme(sc)
 
+	webhookOptions := webhook.Options{
+		Port: *webhookPort,
+	}
+	if *certDir != "" {
+		webhookOptions.CertDir = *certDir
+	}
+
 	mgr, err := manager.New(cfg, manager.Options{
 		Scheme:                 sc,
-		WebhookServer:          webhook.NewServer(webhook.Options{CertDir: *certDir, Port: *webhookPort}),
+		WebhookServer:          webhook.NewServer(webhookOptions),
 		Metrics:                metricsserver.Options{BindAddress: "0"}, // disabled
 		HealthProbeBindAddress: fmt.Sprintf(":%d", *healthzPort),
 	})


### PR DESCRIPTION
If certDir flag is empty, don't set it to allow using default.

CONV=808ad955-b32a-4e1d-83a8-75059054d0fb