### PR TITLE
Upgrade com_github_cenkalti_backoff to v4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,7 +54,7 @@ go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//src:go.mod")
 use_repo(
     go_deps,
-    "com_github_cenkalti_backoff",
+    "com_github_cenkalti_backoff_v4",
     "com_github_form3tech_oss_jwt_go",
     "com_github_fsnotify_fsnotify",
     "com_github_getlantern_httptest",
@@ -67,7 +67,6 @@ use_repo(
     "com_github_jaypipes_pcidb",
     "com_github_motemen_go_loghttp",
     "com_github_onsi_gomega",
-    "com_github_pkg_errors",
     "com_github_prometheus_client_golang",
     "com_github_spf13_cobra",
     "com_github_spf13_pflag",

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590

--- a/src/go.sum
+++ b/src/go.sum
@@ -98,6 +98,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/src/go/cmd/http-relay-client/client/BUILD.bazel
+++ b/src/go/cmd/http-relay-client/client/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     importpath = "github.com/googlecloudrobotics/core/src/go/cmd/http-relay-client/client",
     deps = [
         "//src/proto/http-relay:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@io_opencensus_go//plugin/ochttp:go_default_library",
         "@io_opencensus_go//plugin/ochttp/propagation/tracecontext:go_default_library",

--- a/src/go/cmd/http-relay-client/client/client.go
+++ b/src/go/cmd/http-relay-client/client/client.go
@@ -42,7 +42,7 @@ import (
 	pb "github.com/googlecloudrobotics/core/src/proto/http-relay"
 	"github.com/googlecloudrobotics/ilog"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"go.opencensus.io/trace"

--- a/src/go/cmd/metadata-server/BUILD.bazel
+++ b/src/go/cmd/metadata-server/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//src/go/pkg/robotauth:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
         "@com_github_google_nftables//:go_default_library",
         "@com_github_google_nftables//expr:go_default_library",

--- a/src/go/cmd/metadata-server/metadata.go
+++ b/src/go/cmd/metadata-server/metadata.go
@@ -28,7 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/googlecloudrobotics/core/src/go/pkg/robotauth"
 	"github.com/googlecloudrobotics/ilog"
 	"golang.org/x/oauth2"

--- a/src/go/cmd/setup-dev/BUILD.bazel
+++ b/src/go/cmd/setup-dev/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "//src/go/pkg/robotauth:go_default_library",
         "//src/go/pkg/setup:go_default_library",
         "//src/go/pkg/setup/util:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_client_go//dynamic:go_default_library",

--- a/src/go/cmd/setup-dev/main.go
+++ b/src/go/cmd/setup-dev/main.go
@@ -27,7 +27,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/googlecloudrobotics/core/src/go/pkg/configutil"
 	"github.com/googlecloudrobotics/core/src/go/pkg/kubeutils"
 	"github.com/googlecloudrobotics/core/src/go/pkg/robotauth"

--- a/src/go/cmd/synk/BUILD.bazel
+++ b/src/go/cmd/synk/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
         "//src/go/pkg/synk:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",

--- a/src/go/cmd/synk/synk.go
+++ b/src/go/cmd/synk/synk.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
 	"github.com/googlecloudrobotics/core/src/go/pkg/synk"
 	"github.com/googlecloudrobotics/ilog"

--- a/src/go/pkg/gcr/BUILD.bazel
+++ b/src/go/pkg/gcr/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     deps = [
         "//src/go/pkg/kubeutils:go_default_library",
         "//src/go/pkg/robotauth:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/src/go/pkg/gcr/update_gcr_credentials.go
+++ b/src/go/pkg/gcr/update_gcr_credentials.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/googlecloudrobotics/core/src/go/pkg/kubeutils"
 	"github.com/googlecloudrobotics/core/src/go/pkg/robotauth"
 	"github.com/googlecloudrobotics/ilog"

--- a/src/go/pkg/kubetest/BUILD.bazel
+++ b/src/go/pkg/kubetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
         "//src/go/pkg/gcr:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//rbac/v1:go_default_library",

--- a/src/go/pkg/kubetest/kubetest.go
+++ b/src/go/pkg/kubetest/kubetest.go
@@ -35,7 +35,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	crcapps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
 	"github.com/googlecloudrobotics/core/src/go/pkg/gcr"
 	"golang.org/x/sync/errgroup"
@@ -521,4 +521,3 @@ func (f *Fixture) ChartAssignmentHasStatus(ca *crcapps.ChartAssignment, expected
 		return nil
 	}
 }
-

--- a/src/go/pkg/kubeutils/BUILD.bazel
+++ b/src/go/pkg/kubeutils/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/googlecloudrobotics/core/src/go/pkg/kubeutils",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/src/go/pkg/kubeutils/kubeutils.go
+++ b/src/go/pkg/kubeutils/kubeutils.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/src/go/pkg/setup/BUILD.bazel
+++ b/src/go/pkg/setup/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//src/go/pkg/robotauth:go_default_library",
         "//src/go/pkg/setup/util:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",

--- a/src/go/pkg/setup/setupcommon.go
+++ b/src/go/pkg/setup/setupcommon.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/googlecloudrobotics/core/src/go/pkg/robotauth"
 	"github.com/googlecloudrobotics/core/src/go/pkg/setup/util"
 

--- a/src/go/pkg/synk/BUILD.bazel
+++ b/src/go/pkg/synk/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@com_github_googlecloudrobotics_ilog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",

--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
 	"github.com/googlecloudrobotics/ilog"
 	"go.opencensus.io/trace"

--- a/src/go/tests/apps/BUILD.bazel
+++ b/src/go/tests/apps/BUILD.bazel
@@ -19,7 +19,7 @@ go_test(
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
         "//src/go/pkg/kubetest:go_default_library",
-        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cenkalti_backoff_v4//:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/src/go/tests/apps/apps_test.go
+++ b/src/go/tests/apps/apps_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	crcapps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
 	"github.com/googlecloudrobotics/core/src/go/pkg/kubetest"
 	apps "k8s.io/api/apps/v1"


### PR DESCRIPTION
Replaced the v2/v3 API with the v4 API for github.com/cenkalti/backoff. Updated Go imports to "github.com/cenkalti/backoff/v4", updated go.mod, MODULE.bazel, and regenerated BUILD.bazel files using Gazelle.

TAG=agy
CONV=a49debcb-293c-430c-817d-1d78e9229fdd