### PR TITLE
Update go-toolchain to 0.26.1.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "io_bazel_rules_go")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.25.4")
+go_sdk.download(version = "1.26.1")
 
 bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudrobotics/core/src
 
-go 1.25.0
+go 1.26.1
 
 require (
 	cloud.google.com/go v0.123.0 // indirect

--- a/src/go/tests/relay/BUILD.bazel
+++ b/src/go/tests/relay/BUILD.bazel
@@ -12,7 +12,7 @@ proto_library(
 
 go_proto_library(
     name = "grpc_test_proto_go",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],  # keep
     importpath = "github.com/googlecloudrobotics/core/src/go/tests/relay",
     proto = ":grpc_test_proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This is required to fix the build of the pending depnedabot PRs.