### PR TITLE
Mark test helpers as such.

### DIFF
--- a/src/go/cmd/cr-syncer/syncer_test.go
+++ b/src/go/cmd/cr-syncer/syncer_test.go
@@ -60,6 +60,7 @@ type fixture struct {
 }
 
 func newFixture(t *testing.T) *fixture {
+	t.Helper()
 	return &fixture{T: t}
 }
 
@@ -553,6 +554,7 @@ func TestCRSyncer_populateWorkqueueWithFilter(t *testing.T) {
 }
 
 func channelFromQueue(t *testing.T, queue workqueue.Interface, inf cache.SharedIndexInformer) <-chan *unstructured.Unstructured {
+	t.Helper()
 	ch := make(chan *unstructured.Unstructured, 1)
 	go func() {
 		defer close(ch)

--- a/src/go/cmd/http-relay-client/client/client_test.go
+++ b/src/go/cmd/http-relay-client/client/client_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func assertMocksDoneWithin(t *testing.T, d time.Duration) {
+	t.Helper()
 	for start := time.Now(); time.Since(start) < d; {
 		if gock.IsDone() {
 			return

--- a/src/go/cmd/metadata-server/coredns_test.go
+++ b/src/go/cmd/metadata-server/coredns_test.go
@@ -68,6 +68,7 @@ const (
 )
 
 func createCorefile(t *testing.T, k8s kubernetes.Interface, corefileData string) {
+	t.Helper()
 	if _, err := k8s.CoreV1().ConfigMaps(configMapNamespace).Create(
 		context.Background(),
 		&v1.ConfigMap{
@@ -84,6 +85,7 @@ func createCorefile(t *testing.T, k8s kubernetes.Interface, corefileData string)
 }
 
 func readCorefile(t *testing.T, k8s kubernetes.Interface) string {
+	t.Helper()
 	cm, err := k8s.CoreV1().ConfigMaps(configMapNamespace).Get(context.Background(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("error reading ConfigMap coredns: %v", err)

--- a/src/go/cmd/token-vendor/api/v1/v1_test.go
+++ b/src/go/cmd/token-vendor/api/v1/v1_test.go
@@ -104,6 +104,7 @@ func TestPublicKeyConfigureHandlerWithK8s(t *testing.T) {
 }
 
 func runPublicKeyConfigureHandlerWithK8sCase(t *testing.T, test *publicKeyConfigureHandlerK8sTest) {
+	t.Helper()
 	// Setup fake K8s environment
 	cs := fake.NewSimpleClientset()
 	if err := populateK8sEnv(cs, "default", test.configmaps); err != nil {
@@ -210,6 +211,7 @@ func populateK8sEnv(env kubernetes.Interface, ns string, maps []*corev1.ConfigMa
 }
 
 func runPublicKeyReadHandlerWithK8sCase(t *testing.T, test *publicKeyReadHandlerK8sTest) {
+	t.Helper()
 	// Setup fake K8s environment
 	cs := fake.NewSimpleClientset()
 	if err := populateK8sEnv(cs, "default", test.configmaps); err != nil {
@@ -250,6 +252,7 @@ func runPublicKeyReadHandlerWithK8sCase(t *testing.T, test *publicKeyReadHandler
 }
 
 func mustRespBodyFromFile(t *testing.T, file string) io.ReadCloser {
+	t.Helper()
 	isResponseBody, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -258,6 +261,7 @@ func mustRespBodyFromFile(t *testing.T, file string) io.ReadCloser {
 }
 
 func mustNewRequest(t *testing.T, method, url string, body io.Reader) *http.Request {
+	t.Helper()
 	r, err := http.NewRequest(method, url, body)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -266,6 +270,7 @@ func mustNewRequest(t *testing.T, method, url string, body io.Reader) *http.Requ
 }
 
 func mustFileOpen(t *testing.T, name string) io.Reader {
+	t.Helper()
 	f, err := os.Open(name)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -274,6 +279,7 @@ func mustFileOpen(t *testing.T, name string) io.Reader {
 }
 
 func mustFileToString(t *testing.T, name string) string {
+	t.Helper()
 	fp := mustFileOpen(t, name)
 	bytes, err := io.ReadAll(fp)
 	if err != nil {
@@ -333,6 +339,7 @@ func TestPublicKeyPublishHandlerWithK8s(t *testing.T) {
 }
 
 func runPublicKeyPublishHandlerWithK8sCase(t *testing.T, test *publicKeyPublishHandlerK8sTest) {
+	t.Helper()
 	// Setup fake K8s environment
 	cs := fake.NewSimpleClientset()
 	if err := populateK8sEnv(cs, "default", test.configmaps); err != nil {

--- a/src/go/cmd/token-vendor/app/tokenvendor_test.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor_test.go
@@ -268,6 +268,7 @@ func getInMemoryRepo(deviceId, key string) repository.PubKeyRepository {
 }
 
 func createFakeJWTWithSubject(t *testing.T, deviceId, subject string) string {
+	t.Helper()
 	jwtWithSubject := jwt.StandardClaims{
 		Audience:  nil,
 		ExpiresAt: time.Now().Add(10 * time.Second).Unix(),

--- a/src/go/pkg/controller/chartassignment/release_test.go
+++ b/src/go/pkg/controller/chartassignment/release_test.go
@@ -15,6 +15,7 @@ const (
 )
 
 func verifyValues(t *testing.T, have string, wantValues chartutil.Values) {
+	t.Helper()
 	if want, err := wantValues.YAML(); err != nil {
 		t.Fatal(err)
 	} else if want != have {

--- a/src/go/pkg/synk/synk_test.go
+++ b/src/go/pkg/synk/synk_test.go
@@ -70,6 +70,7 @@ type fixture struct {
 }
 
 func newFixture(t *testing.T) *fixture {
+	t.Helper()
 	return &fixture{T: t}
 }
 
@@ -676,6 +677,7 @@ func unmarshalYAML(t *testing.T, v interface{}, s string) {
 }
 
 func toUnstructured(t *testing.T, o runtime.Object) *unstructured.Unstructured {
+	t.Helper()
 	var u unstructured.Unstructured
 	if err := convert(o, &u); err != nil {
 		t.Fatal(err)

--- a/src/go/tests/relay/nok8s_relay_test.go
+++ b/src/go/tests/relay/nok8s_relay_test.go
@@ -352,6 +352,7 @@ type relayWithGrpcServer struct {
 }
 
 func (r *relayWithGrpcServer) mustStop(t *testing.T) {
+	t.Helper()
 	r.Listener.Close()
 	r.GrpcServer.Stop()
 	if err := r.Relay.stop(); err != nil {


### PR DESCRIPTION
This improves reporting failed tests.