### PR TITLE
Switch over nginx-ingress-lb selector to nginx shield

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,6 +49,7 @@ function include_config_and_defaults {
   ONPREM_FEDERATION=${ONPREM_FEDERATION:-true}
   GKE_SECRET_MANAGER_PLUGIN=${GKE_SECRET_MANAGER_PLUGIN:-false}
   USE_ISTIO=${USE_ISTIO:-false}
+  USE_NGINX_SHIELD=${USE_NGINX_SHIELD:-false}
 
   # lets-encrypt is used as the default certificate provider for backwards compatibility purposes
   CLOUD_ROBOTICS_CERTIFICATE_PROVIDER=${CLOUD_ROBOTICS_CERTIFICATE_PROVIDER:-lets-encrypt}
@@ -309,6 +310,7 @@ function helm_region_shared {
     --set-string "oauth2_proxy.client_secret=${CLOUD_ROBOTICS_OAUTH2_CLIENT_SECRET}"
     --set-string "oauth2_proxy.cookie_secret=${CLOUD_ROBOTICS_COOKIE_SECRET}"
     --set-string "use_istio=${USE_ISTIO}"
+    --set-string "use_nginx_shield=${USE_NGINX_SHIELD}"
     --set "use_tv_verbose=${CRC_USE_TV_VERBOSE}"
   )
 

--- a/src/app_charts/base/cloud/nginx-ingress-controller-shield.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller-shield.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.use_nginx_shield "true" }}
+{{- if and (eq .Values.use_nginx_shield "true") (eq .Values.use_istio "false") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/app_charts/base/cloud/nginx-ingress-controller.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller.yaml
@@ -14,6 +14,13 @@ data:
   # The token-vendor checks the Original-URI header to accept tokens from query
   # parameters.
   proxy-add-original-uri-header: "true"
+
+  {{- if eq .Values.use_nginx_shield "true" }}
+  # Best practice: Pair it with trusted proxy IP ranges
+  use-forwarded-headers: "true"
+  proxy-real-ip-cidr: "10.0.0.0/8,192.168.0.0/16"
+  {{- end}}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -124,7 +131,11 @@ spec:
       targetPort: 443
       appProtocol: HTTPS
   selector:
+    {{- if eq .Values.use_nginx_shield "true" }}
+    k8s-app: nginx-ingress-controller-shield
+    {{- else }}
     k8s-app: nginx-ingress-controller
+    {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: IngressClass


### PR DESCRIPTION
Switch over nginx-ingress-lb selector to nginx shield if use_nginx_shield is enabled

NOTE: 30s-1m of downtime for existing setups is expected as the new NGINX shield deployment pods are pulled,  initialized, passing readiness probes and NLB target pools updated. 