### PR TITLE
Speed up relay tests

### DIFF
--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -76,6 +76,12 @@ var (
 	)
 )
 
+var (
+	// timeout settings to be adjustable for tests
+	relayTimeout      = 10 * time.Second
+	getRequestTimeout = 30 * time.Second
+)
+
 func init() {
 	prometheus.MustRegister(brokerRequests)
 	prometheus.MustRegister(brokerResponses)
@@ -180,7 +186,7 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 	// This blocks until we get a free spot in the broker's request channel.
 	case reqChan <- request:
 		return respChan, nil
-	case <-time.After(10 * time.Second):
+	case <-time.After(relayTimeout):
 		// This branch is triggered if the channel is not ready to consume the request
 		// since it is still busy with handling a different request.
 		return nil, fmt.Errorf("cannot reach the client %q; check that it's turned on, set up, and connected to the internet; if the network config recently changed, try again in 1-2 minutes (%w)", server, ErrRelayTimeout)
@@ -212,7 +218,7 @@ func (r *broker) GetRequest(ctx context.Context, server, path string) (*pb.HttpR
 	case req := <-reqChan:
 		brokerResponses.WithLabelValues("server_request", "ok", server).Inc()
 		return req, nil
-	case <-time.After(time.Second * 30):
+	case <-time.After(getRequestTimeout):
 		brokerResponses.WithLabelValues("server_request", "timeout", server).Inc()
 		return nil, ErrNoRequest
 	case <-ctx.Done():
@@ -235,7 +241,7 @@ func (r *broker) GetRequestStream(id string) ([]byte, bool) {
 	select {
 	case data := <-pr.requestStream:
 		return data, true
-	case <-time.After(time.Second * 30):
+	case <-time.After(getRequestTimeout):
 		return []byte{}, true
 	}
 }

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -26,6 +27,17 @@ import (
 	pb "github.com/googlecloudrobotics/core/src/proto/http-relay"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestMain(m *testing.M) {
+	// Set short timeouts for tests to speed them up.
+	// These can be overridden on a test-by-test basis if needed using:
+	//   oldRelayTimeout := relayTimeout
+	//   relayTimeout = ...
+	//   defer func() { relayTimeout = oldRelayTimeout }()
+	relayTimeout = 100 * time.Millisecond
+	getRequestTimeout = 200 * time.Millisecond
+	os.Exit(m.Run())
+}
 
 const (
 	// These IDs are used for testing multiple requests. The contents of the
@@ -272,14 +284,14 @@ func TestReapWhileSendingResponse(t *testing.T) {
 	go func() {
 		req, reqErr = b.GetRequest(context.Background(), "foo", "/")
 		if reqErr != nil {
-			t.Errorf("GetRequest error:", reqErr)
+			t.Errorf("GetRequest error: %v", reqErr)
 		}
 		wg.Done()
 	}()
 	go func() {
 		_, respErr = b.RelayRequest("foo", &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com/foo")})
 		if respErr != nil {
-			t.Errorf("RelayRequest error:", respErr)
+			t.Errorf("RelayRequest error: %v", respErr)
 		}
 		wg.Done()
 	}()

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -577,13 +577,13 @@ func (s *Server) StartOnListener(ln net.Listener) {
 	h1s := &http.Server{
 		Handler: och,
 		BaseContext: func(l net.Listener) context.Context {
-			slog.Info("Relay server listening", slog.Int("Port", l.Addr().(*net.TCPAddr).Port))
 			return mainCtx
 		},
 	}
 	// Wait for the server to terminate, either because it failed to create a
 	// listener, or because we got SIGTERM.
 	g, gCtx := errgroup.WithContext(mainCtx)
+	slog.Info("Relay server listening", slog.Int("Port", ln.Addr().(*net.TCPAddr).Port))
 	g.Go(func() error {
 		if err := h1s.Serve(ln); err != http.ErrServerClosed {
 			return err

--- a/src/go/tests/relay/nok8s_relay_test.go
+++ b/src/go/tests/relay/nok8s_relay_test.go
@@ -75,7 +75,7 @@ func (r *relay) start(backendAddress string, extraClientArgs ...string) error {
 		return fmt.Errorf("failed to start relay-server: %w", err)
 	}
 	r.rsPort = ""
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		slog.Info("Output", slog.String("Output", rsOut.String()))
 		if m := rsPortMatcher.FindStringSubmatch(rsOut.String()); m != nil {
 			r.rsPort = m[1]
@@ -83,7 +83,7 @@ func (r *relay) start(backendAddress string, extraClientArgs ...string) error {
 			break
 		}
 		slog.Info("Waiting for relay to be up-and-running ...")
-		time.Sleep(1 * time.Second)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if r.rsPort == "" {
 		return errors.New("timeout waiting for relay-server to launch")
@@ -105,13 +105,13 @@ func (r *relay) start(backendAddress string, extraClientArgs ...string) error {
 	}
 
 	connected := false
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		if strings.Contains(rsOut.String(), "Relay client connected") {
 			connected = true
 			break
 		}
 		slog.Info("Waiting for relay to be up-and-running ...")
-		time.Sleep(1 * time.Second)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if !connected {
 		return errors.New("timeout waiting for relay-client to connect to relay-server")


### PR DESCRIPTION
* Put relay-broker timeouts into vars that can be shortened by tests
* Use shorter sleeps in to integration test
* Drive by golang fixes (e.g. bad format strings).