### PR TITLE
Extend test coverage with new test cases and new tests.

### DIFF
--- a/src/go/pkg/configutil/config_reader_test.go
+++ b/src/go/pkg/configutil/config_reader_test.go
@@ -22,33 +22,63 @@ import (
 
 func TestBashUnescape(t *testing.T) {
 	tests := []struct {
+		name string
 		s    string
 		want string
 	}{
+		// no escapes
 		{
+			name: "empty string",
+			s:    "",
+			want: "",
+		},
+		{
+			name: "single character",
+			s:    "a",
+			want: "a",
+		},
+		{
+			name: "single quotes",
+			s:    `'foo'`,
+			want: `foo`,
+		},
+		// escapes
+		{
+			name: "backslash escapes",
 			s:    `foo\ \b\a\r\!`,
 			want: `foo bar!`,
 		},
 		{
-			s:    `"foo\ \"bar\"\!"`,
-			want: `foo\ "bar"!`,
+			name: "single quotes with backslash",
+			s:    `'foo\ bar!'`,
+			want: `foo\ bar!`,
 		},
 		{
-			s:    `'foo\ '\''bar'\''\!'`,
-			want: `foo\ 'bar'\!`,
+			name: "double quotes with backslash",
+			s:    `"foo\ bar!"`,
+			want: `foo\ bar!`,
 		},
 		{
+			name: "mixed quotes",
 			s:    `"foo\ \b\a\r\!'`,
 			want: `"foo bar!'`,
 		},
+		{
+			name: "complex double quotes",
+			s:    `"\\ \$\" \` + "`" + ` \!"`,
+			want: `\ $" ` + "`" + ` !`,
+		},
 	}
 
-	for i, tc := range tests {
-		if got := bashUnescape(tc.s); got != tc.want {
-			t.Errorf("[%d] bashUnescape(`%s`) = `%s`', want `%s`", i, tc.s, got, tc.want)
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bashUnescape(tc.s); got != tc.want {
+				t.Errorf("bashUnescape(%q) = %q, want %q", tc.s, got, tc.want)
+			}
+		})
 	}
 }
+
 
 func TestGetConfigFromReader(t *testing.T) {
 	s := `

--- a/src/go/pkg/controller/chartassignment/BUILD.bazel
+++ b/src/go/pkg/controller/chartassignment/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "controller_test.go",
         "release_test.go",
         "synk_interface_test.go",
         "validator_test.go",
@@ -66,8 +67,14 @@ go_test(
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
         "//src/go/pkg/kubetest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",
         "@io_k8s_helm//pkg/chartutil:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
     ],
 )

--- a/src/go/pkg/controller/chartassignment/controller_test.go
+++ b/src/go/pkg/controller/chartassignment/controller_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 The Cloud Robotics Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chartassignment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconciler_Reconcile_NotFound(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
+
+	r := &Reconciler{
+		kube: client,
+	}
+
+	req := reconcile.Request{
+		NamespacedName: kclient.ObjectKey{Name: "non-existent"},
+	}
+
+	// When a resource is not found, the reconciler should return success (nil error)
+	// and not requeue, as there's nothing left to reconcile.
+	res, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Errorf("Unexpected result: %v", res)
+	}
+}
+
+func TestReconciler_ensureNamespace(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
+
+	r := &Reconciler{
+		kube: client,
+	}
+
+	as := &apps.ChartAssignment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-app",
+			UID:  "test-uid",
+		},
+		Spec: apps.ChartAssignmentSpec{
+			NamespaceName: "app-ns",
+		},
+	}
+
+	ctx := context.Background()
+	ns, err := r.ensureNamespace(ctx, as)
+	if err != nil {
+		t.Fatalf("ensureNamespace failed: %v", err)
+	}
+
+	if ns.Name != "app-ns" {
+		t.Errorf("Expected namespace name 'app-ns', got %q", ns.Name)
+	}
+
+	// Verify namespace was created in fake client
+	var createdNS corev1.Namespace
+	err = client.Get(ctx, kclient.ObjectKey{Name: "app-ns"}, &createdNS)
+	if err != nil {
+		t.Fatalf("Namespace not found in fake client: %v", err)
+	}
+	if createdNS.Labels["app"] != "test-app" {
+		t.Errorf("Expected label app=test-app, got %v", createdNS.Labels["app"])
+	}
+}
+
+func TestReconciler_ensureSecrets(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+			Labels: map[string]string{
+				"cloudrobotics.com/copy-to-chart-namespaces": "true",
+			},
+		},
+		Data: map[string][]byte{"foo": []byte("bar")},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(secret).Build()
+
+	r := &Reconciler{
+		kube: client,
+	}
+
+	as := &apps.ChartAssignment{
+		Spec: apps.ChartAssignmentSpec{
+			NamespaceName: "app-ns",
+		},
+	}
+
+	err := r.ensureSecrets(context.Background(), as)
+	if err != nil {
+		t.Fatalf("ensureSecrets failed: %v", err)
+	}
+
+	var copiedSecret corev1.Secret
+	err = client.Get(context.Background(), kclient.ObjectKey{Namespace: "app-ns", Name: "test-secret"}, &copiedSecret)
+	if err != nil {
+		t.Fatalf("Secret not copied to app-ns: %v", err)
+	}
+}
+
+func TestReconciler_Reconcile_Delete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := metav1.Now()
+	as := &apps.ChartAssignment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-app",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizer},
+		},
+		Spec: apps.ChartAssignmentSpec{
+			NamespaceName: "app-ns",
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(as).Build()
+	mockSynk := NewMockInterface(ctrl)
+
+	releases := &releases{
+		m:    map[string]*release{},
+		synk: mockSynk,
+	}
+
+	r := &Reconciler{
+		kube:     client,
+		releases: releases,
+		recorder: &record.FakeRecorder{},
+	}
+
+	// Mock release status as Deleted
+	releases.m["test-app"] = &release{
+		status: releaseStatus{phase: apps.ChartAssignmentPhaseDeleted},
+	}
+
+	mockSynk.EXPECT().Delete(gomock.Any(), "test-app").Return(nil).AnyTimes()
+
+	req := reconcile.Request{
+		NamespacedName: kclient.ObjectKey{Name: "test-app"},
+	}
+
+	res, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	if !res.Requeue {
+		t.Errorf("Expected requeue during deletion")
+	}
+
+	// Verify ChartAssignment was deleted (no more finalizers)
+	var updatedAs apps.ChartAssignment
+	err = client.Get(context.Background(), kclient.ObjectKey{Name: "test-app"}, &updatedAs)
+	if !k8serrors.IsNotFound(err) {
+		t.Errorf("Expected ChartAssignment to be deleted, but found: %v", updatedAs)
+	}
+}
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	apps.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	return scheme
+}

--- a/src/go/pkg/robotauth/robotauth_test.go
+++ b/src/go/pkg/robotauth/robotauth_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"testing/quick"
@@ -154,5 +157,104 @@ func TestCreateJWTSource(t *testing.T) {
 	}
 	if want := time.Unix(textTokenExpiryUnix, 0); token.Expiry != want {
 		t.Errorf("token.Expiry = %v, want %v", token.Expiry, want)
+	}
+}
+
+func TestCreatePrivateKey(t *testing.T) {
+	r := &RobotAuth{}
+	if err := r.CreatePrivateKey(); err != nil {
+		t.Fatalf("CreatePrivateKey() failed: %v", err)
+	}
+
+	if len(r.PrivateKey) == 0 {
+		t.Fatal("CreatePrivateKey() did not set PrivateKey")
+	}
+
+	block, _ := pem.Decode(r.PrivateKey)
+	if block == nil {
+		t.Fatal("Failed to decode generated PrivateKey as PEM")
+	}
+	if block.Type != "PRIVATE KEY" {
+		t.Errorf("Expected PEM type 'PRIVATE KEY', got %q", block.Type)
+	}
+}
+
+func TestServiceAccountEmail(t *testing.T) {
+	r := &RobotAuth{
+		RobotName: "my-robot",
+		ProjectId: "my-project",
+	}
+
+	tests := []struct {
+		name    string
+		saName  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "short name",
+			saName:  "robot-service",
+			want:    "robot-service@my-project.iam.gserviceaccount.com",
+			wantErr: false,
+		},
+		{
+			name:    "full email",
+			saName:  "other@other-project.iam.gserviceaccount.com",
+			want:    "other@other-project.iam.gserviceaccount.com",
+			wantErr: false,
+		},
+		{
+			name:    "empty name",
+			saName:  "",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid email",
+			saName:  "somebody@example.com",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := r.ServiceAccountEmail(tc.saName)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ServiceAccountEmail(%q) error = %v, wantErr %v", tc.saName, err, tc.wantErr)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("ServiceAccountEmail(%q) = %q, want %q", tc.saName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFileLoadStoreRoundtrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFile := filepath.Join(tmpDir, "robot-id.json")
+
+	r := &RobotAuth{
+		RobotName:           "my-robot",
+		ProjectId:           "my-project",
+		PublicKeyRegistryId: "my-registry",
+		PrivateKey:          []byte("secret"),
+		Domain:              "example.com",
+	}
+
+	// Let's just test LoadFromFile with a specific path.
+	data, _ := json.Marshal(r)
+	if err := os.WriteFile(keyFile, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadFromFile(keyFile)
+	if err != nil {
+		t.Fatalf("LoadFromFile() failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(r, got) {
+		t.Errorf("LoadFromFile() = %v, want %v", got, r)
 	}
 }

--- a/src/go/pkg/setup/BUILD.bazel
+++ b/src/go/pkg/setup/BUILD.bazel
@@ -37,6 +37,10 @@ go_test(
     deps = [
         "//src/go/pkg/setup/util:go_default_library",  # keep
         "@com_github_golang_mock//gomock:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_client_go//dynamic/fake:go_default_library",
     ],
 )

--- a/src/go/pkg/setup/setupcommon_test.go
+++ b/src/go/pkg/setup/setupcommon_test.go
@@ -15,12 +15,23 @@
 package setup
 
 import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
 )
 
 func TestSelectRobot(t *testing.T) {
@@ -65,3 +76,128 @@ func TestWaitForService_OkIfServiceResponds(t *testing.T) {
 		t.Errorf("WaitForService returned error: %v", err)
 	}
 }
+
+func TestCreateOrUpdateRobot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewSimpleDynamicClient(scheme)
+	resource := client.Resource(schema.GroupVersionResource{
+		Group:    "registry.cloudrobotics.com",
+		Version:  "v1alpha1",
+		Resource: "robots",
+	})
+
+	ctx := context.Background()
+	robotName := "test-robot"
+	robotType := "test-type"
+	project := "test-project"
+	labels := map[string]string{"foo": "bar"}
+	annotations := map[string]string{"baz": "qux"}
+
+	// 1. Test Create
+	err := CreateOrUpdateRobot(ctx, resource, robotName, robotType, project, labels, annotations)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateRobot failed to create: %v", err)
+	}
+
+	got, err := resource.Get(ctx, robotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get created robot: %v", err)
+	}
+	if got.GetName() != robotName {
+		t.Errorf("Expected name %q, got %q", robotName, got.GetName())
+	}
+	if !reflect.DeepEqual(got.GetLabels(), labels) {
+		t.Errorf("Expected labels %v, got %v", labels, got.GetLabels())
+	}
+	if !reflect.DeepEqual(got.GetAnnotations(), annotations) {
+		t.Errorf("Expected annotations %v, got %v", annotations, got.GetAnnotations())
+	}
+
+	// 2. Test Update
+	newLabels := map[string]string{"foo": "updated", "new": "label"}
+	err = CreateOrUpdateRobot(ctx, resource, robotName, "new-type", project, newLabels, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateRobot failed to update: %v", err)
+	}
+
+	got, err = resource.Get(ctx, robotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get updated robot: %v", err)
+	}
+	if !reflect.DeepEqual(got.GetLabels(), newLabels) {
+		t.Errorf("Expected labels %v, got %v", newLabels, got.GetLabels())
+	}
+	spec := got.Object["spec"].(map[string]interface{})
+	if spec["type"] != "new-type" {
+		t.Errorf("Expected type %q, got %q", "new-type", spec["type"])
+	}
+}
+
+func TestGetPublicKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		pem  []byte
+	}{
+		{
+			name: "PKCS1",
+			pem: pem.EncodeToMemory(&pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: x509.MarshalPKCS1PrivateKey(key),
+			}),
+		},
+		{
+			name: "PKCS8",
+			pem: pem.EncodeToMemory(&pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: pkcs8Bytes,
+			}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pub, err := getPublicKey(tc.pem)
+			if err != nil {
+				t.Fatalf("getPublicKey() failed: %v", err)
+			}
+			if !bytes.Contains(pub, []byte("BEGIN PUBLIC KEY")) {
+				t.Errorf("result missing header: %s", string(pub))
+			}
+		})
+	}
+}
+
+func TestGetPublicKey_Invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		pem  []byte
+	}{
+		{
+			name: "not a PEM block",
+			pem:  []byte("not a key"),
+		},
+		{
+			name: "empty input",
+			pem:  []byte(""),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := getPublicKey(tc.pem); err == nil {
+				t.Errorf("getPublicKey(%s) should have failed", tc.name)
+			}
+		})
+	}
+}
+

--- a/src/go/pkg/synk/BUILD.bazel
+++ b/src/go/pkg/synk/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/api/meta/testrestmapper:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -270,6 +270,7 @@ type transientErr struct {
 }
 
 // IsTransientErr returns true if the error may resolve by retrying the operation.
+// It must not be called with a nil error.
 func IsTransientErr(err error) bool {
 	// Either a custom error is specifically wrapped in transientErr or the innermost
 	// error is a known transient Kubernetes API error.

--- a/src/go/pkg/synk/synk_test.go
+++ b/src/go/pkg/synk/synk_test.go
@@ -24,6 +24,7 @@ import (
 
 	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,25 +44,30 @@ import (
 // Thus we implement our own static one.
 type fakeCachedDiscoveryClient struct {
 	discovery.CachedDiscoveryInterface
+	resources map[string]*metav1.APIResourceList
 }
 
 func (d *fakeCachedDiscoveryClient) Invalidate() {}
 
 func (d *fakeCachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	return nil, []*metav1.APIResourceList{
-		{
-			GroupVersion: "v1",
-			APIResources: []metav1.APIResource{
-				{Kind: "Pod", Namespaced: true},
-				{Kind: "Namespace", Namespaced: false},
-			},
-		},
-	}, nil
+	var list []*metav1.APIResourceList
+	for _, l := range d.resources {
+		list = append(list, l)
+	}
+	return nil, list, nil
+}
+
+func (d *fakeCachedDiscoveryClient) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	if list, ok := d.resources[gv]; ok {
+		return list, nil
+	}
+	return nil, k8serrors.NewNotFound(schema.GroupResource{}, gv)
 }
 
 type fixture struct {
 	*testing.T
-	fake *k8stest.Fake
+	fake      *k8stest.Fake
+	discovery *fakeCachedDiscoveryClient
 
 	// Starting state the respective client will report.
 	objects []runtime.Object
@@ -71,16 +77,29 @@ type fixture struct {
 
 func newFixture(t *testing.T) *fixture {
 	t.Helper()
-	return &fixture{T: t}
+	f := &fixture{
+		T:         t,
+		discovery: &fakeCachedDiscoveryClient{resources: make(map[string]*metav1.APIResourceList)},
+	}
+	// Add default v1 resources.
+	f.discovery.resources["v1"] = &metav1.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Kind: "Pod", Namespaced: true},
+			{Kind: "Namespace", Namespaced: false},
+		},
+	}
+	return f
 }
 
 func (f *fixture) newSynk() *Synk {
 	sc := runtime.NewScheme()
 	scheme.AddToScheme(sc)
-	apps.AddToScheme(sc) // For tests with CRDs.
+	apps.AddToScheme(sc)          // For tests with CRDs.
+	apiextensions.AddToScheme(sc) // For CRD tests.
 	var (
 		client = dynamicfake.NewSimpleDynamicClient(sc, f.objects...)
-		s      = New(client, &fakeCachedDiscoveryClient{})
+		s      = New(client, f.discovery)
 	)
 	s.mapper = testrestmapper.TestOnlyStaticRESTMapper(sc)
 	s.resetMapper = func() {}
@@ -114,42 +133,49 @@ func (f *fixture) verifyWriteActions() {
 
 func TestSynk_IsTransientErr(t *testing.T) {
 	tests := []struct {
-		err  error
+		name string
+		errs []error
 		want bool
 	}{
 		{
-			errors.New("generic error"),
-			false,
+			name: "transient",
+			want: true,
+			errs: []error{
+				transientErr{errors.New("transientErr struct")},
+				&transientErr{errors.New("transientErr pointer")},
+				k8serrors.NewResourceExpired("gone"),
+				k8serrors.NewForbidden(schema.GroupResource{
+					Group:    "apps",
+					Resource: "deployments",
+				}, "my-deployment", errors.New("unable to create new content in namespace app-test-chart because it is being terminated")),
+				k8serrors.NewConflict(schema.GroupResource{}, "", nil),
+				k8serrors.NewAlreadyExists(schema.GroupResource{}, ""),
+				k8serrors.NewNotFound(schema.GroupResource{}, ""),
+				k8serrors.NewGone(""),
+				k8serrors.NewInternalError(errors.New("internal")),
+				k8serrors.NewServerTimeout(schema.GroupResource{}, "", 0),
+				k8serrors.NewTimeoutError("", 0),
+				k8serrors.NewTooManyRequests("", 0),
+				k8serrors.NewServiceUnavailable(""),
+				&discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{}},
+			},
 		},
 		{
-			transientErr{errors.New("transientErr struct")},
-			true,
-		},
-		{
-			&transientErr{errors.New("transientErr pointer")},
-			true,
-		},
-		{
-			k8serrors.NewUnauthorized("unauthorized"),
-			false,
-		},
-		{
-			k8serrors.NewResourceExpired("gone"),
-			true,
-		},
-		{
-			k8serrors.NewForbidden(schema.GroupResource{
-				Group:    "apps",
-				Resource: "deployments",
-			}, "my-deployment", errors.New("unable to create new content in namespace app-test-chart because it is being terminated")),
-			true,
+			name: "non-transient",
+			want: false,
+			errs: []error{
+				errors.New("generic error"),
+				k8serrors.NewUnauthorized("unauthorized"),
+			},
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.err.Error(), func(t *testing.T) {
-			if got := IsTransientErr(tc.err); got != tc.want {
-				t.Errorf("IsTransientErr(%v)=%v, want %v", tc.err, got, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			for _, err := range tc.errs {
+				if got := IsTransientErr(err); got != tc.want {
+					t.Errorf("IsTransientErr(%T) = %v, want %v", err, got, tc.want)
+				}
 			}
 		})
 	}
@@ -657,6 +683,170 @@ data:
 
 	if applied := getAppliedAnnotation(&cmLarge); len(applied) > 0 {
 		t.Errorf("expected no last-applied annotation set, but got %v", applied)
+	}
+}
+
+func TestSynk_validateNamespace(t *testing.T) {
+	tests := []struct {
+		desc      string
+		namespace string
+		optsNs    string
+		wantErr   bool
+	}{
+		{
+			desc:      "empty namespace is allowed",
+			namespace: "",
+			optsNs:    "my-ns",
+			wantErr:   false,
+		},
+		{
+			desc:      "kube-system is allowed",
+			namespace: "kube-system",
+			optsNs:    "my-ns",
+			wantErr:   false,
+		},
+		{
+			desc:      "default is allowed",
+			namespace: "default",
+			optsNs:    "my-ns",
+			wantErr:   false,
+		},
+		{
+			desc:      "opts namespace is allowed",
+			namespace: "my-ns",
+			optsNs:    "my-ns",
+			wantErr:   false,
+		},
+		{
+			desc:      "other namespace is not allowed",
+			namespace: "other-ns",
+			optsNs:    "my-ns",
+			wantErr:   true,
+		},
+		{
+			desc:      "custom ns not allowed-listed via optsNs",
+			namespace: "my-ns",
+			optsNs:    "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := newUnstructured("v1", "Pod", tc.namespace, "pod1")
+			err := validateNamespace(r, tc.optsNs)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateNamespace() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSynk_canReplace(t *testing.T) {
+	tests := []struct {
+		desc     string
+		kind     string
+		err      error
+		expected bool
+	}{
+		{
+			desc:     "Deployment immutable field error",
+			kind:     "Deployment",
+			err:      errors.New("field is immutable"),
+			expected: true,
+		},
+		{
+			desc:     "Service may not change once set error",
+			kind:     "Service",
+			err:      errors.New("may not change once set"),
+			expected: true,
+		},
+		{
+			desc:     "Job immutable field error",
+			kind:     "Job",
+			err:      errors.New("field is immutable"),
+			expected: true,
+		},
+		{
+			desc:     "ValidatingWebhookConfiguration must be specified for an update",
+			kind:     "ValidatingWebhookConfiguration",
+			err:      errors.New("must be specified for an update"),
+			expected: true,
+		},
+		{
+			desc:     "Pod immutable field error (not replaceable)",
+			kind:     "Pod",
+			err:      errors.New("field is immutable"),
+			expected: false,
+		},
+		{
+			desc:     "Random error",
+			kind:     "Deployment",
+			err:      errors.New("random error"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			r := newUnstructured("v1", tc.kind, "ns", "name")
+			if got := canReplace(r, tc.err); got != tc.expected {
+				t.Errorf("canReplace() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSynk_Delete(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	s := f.newSynk()
+
+	err := s.Delete(ctx, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.expectActions(
+		k8stest.NewRootDeleteCollectionAction(resourceSetGVR, metav1.ListOptions{LabelSelector: "name=test"}),
+	)
+	// DeleteCollectionAction doesn't match DeleteActionImpl in sprintAction.
+	// But it should be in writes.
+	writes := filterReadActions(f.fake.Actions())
+	if len(writes) != 1 {
+		t.Errorf("expected 1 write action, got %d", len(writes))
+	}
+}
+
+func TestSynk_Init(t *testing.T) {
+	f := newFixture(t)
+	s := f.newSynk()
+
+	// Mock discovery to return the ResourceSet CRD after it's created.
+	// Init calls crdAvailable which calls ServerResourcesForGroupVersion.
+	f.discovery.resources["apps.cloudrobotics.com/v1alpha1"] = &metav1.APIResourceList{
+		GroupVersion: "apps.cloudrobotics.com/v1alpha1",
+		APIResources: []metav1.APIResource{
+			{Name: "resourcesets", Kind: "ResourceSet"},
+		},
+	}
+
+	err := s.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have called Create for the CRD.
+	writes := filterReadActions(f.fake.Actions())
+	found := false
+	for _, a := range writes {
+		if ca, ok := a.(k8stest.CreateAction); ok && ca.GetResource().Resource == "customresourcedefinitions" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected Create action for CustomResourceDefinition")
 	}
 }
 


### PR DESCRIPTION
Extend 3 existing tests and add a new one for the chart-assignment controller (to be on par with the app-rollout controller).

These give us more confidence when updating dependencies and moderinzing the code.