### PR TITLE
Cleanup context handling

### DIFF
--- a/src/go/cmd/app-rollout-controller/main.go
+++ b/src/go/cmd/app-rollout-controller/main.go
@@ -54,7 +54,7 @@ func main() {
 	logHandler := ilog.NewLogHandler(slog.Level(*logLevel), os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
-	ctx := context.Background()
+	ctx := signals.SetupSignalHandler()
 	kubernetesConfig, err := rest.InClusterConfig()
 	if err != nil {
 		slog.Error("Failed to initialize Kubernetes config", ilog.Err(err))
@@ -103,5 +103,5 @@ func runController(ctx context.Context, cfg *rest.Config, params map[string]inte
 	srv.Register("/approllout/validate", approllout.NewAppRolloutValidationWebhook(mgr))
 	srv.Register("/app/validate", approllout.NewAppValidationWebhook(mgr))
 
-	return mgr.Start(signals.SetupSignalHandler())
+	return mgr.Start(ctx)
 }

--- a/src/go/cmd/chart-assignment-controller/main.go
+++ b/src/go/cmd/chart-assignment-controller/main.go
@@ -57,7 +57,7 @@ func main() {
 	logHandler := ilog.NewLogHandler(slog.Level(*logLevel), os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
-	ctx := context.Background()
+	ctx := signals.SetupSignalHandler()
 	if *stackdriverProjectID != "" && !*cloudCluster {
 		sd, err := stackdriver.NewExporter(stackdriver.Options{
 			ProjectID: *stackdriverProjectID,
@@ -136,5 +136,5 @@ func runController(ctx context.Context, cfg *rest.Config, cluster string) error 
 		srv.Register("/chartassignment/validate", webhook)
 	}
 
-	return mgr.Start(signals.SetupSignalHandler())
+	return mgr.Start(ctx)
 }

--- a/src/go/cmd/cr-syncer/health_test.go
+++ b/src/go/cmd/cr-syncer/health_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,7 +18,7 @@ func TestHealthy(t *testing.T) {
 			gvr: "RobotList",
 		},
 	)
-	h := newHealthHandler(context.Background(), client)
+	h := newHealthHandler(t.Context(), client)
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -42,7 +41,7 @@ func TestHealthyForBadRequest(t *testing.T) {
 	client.PrependReactor("*", "*", func(k8stest.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewBadRequest("")
 	})
-	h := newHealthHandler(context.Background(), client)
+	h := newHealthHandler(t.Context(), client)
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -66,7 +65,7 @@ func TestUnhealthy(t *testing.T) {
 	client.PrependReactor("*", "*", func(k8stest.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewUnauthorized("")
 	})
-	h := newHealthHandler(context.Background(), client)
+	h := newHealthHandler(t.Context(), client)
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 

--- a/src/go/cmd/cr-syncer/main.go
+++ b/src/go/cmd/cr-syncer/main.go
@@ -46,12 +46,15 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
@@ -62,7 +65,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/zpages"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	crdtypes "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -238,7 +240,6 @@ func streamCrds(done <-chan struct{}, clientset crdclientset.Interface, crds cha
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
-	ctx := context.Background()
 
 	ll := slog.Level(*logLevel)
 	if *verbose {
@@ -246,6 +247,9 @@ func main() {
 	}
 	logHandler := ilog.NewLogHandler(ll, os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	localConfig, err := rest.InClusterConfig()
 	if err != nil {
@@ -304,31 +308,40 @@ func main() {
 		os.Exit(1)
 	}
 	syncers := make(map[string]*crSyncer)
-	for crd := range crds {
-		name := crd.CRD.GetName()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("Shutting down")
+			return
+		case crd, ok := <-crds:
+			if !ok {
+				return
+			}
+			name := crd.CRD.GetName()
 
-		if cur, ok := syncers[name]; ok {
-			if crd.Type == watch.Added {
-				slog.Warn("Already had a running sync", slog.String("syncer", name))
-			}
-			cur.stop()
-			delete(syncers, name)
-		}
-		if crd.Type == watch.Added || crd.Type == watch.Modified {
-			// The modify procedure is very heavyweight: We throw away
-			// the informer for the CRD (read: all cached data) on every
-			// modification and recreate it. If that ever turns out to
-			// be a problem, we should use a shared informer cache
-			// instead.
-			s, err := newCRSyncer(ctx, *crd.CRD, local, remote, *robotName)
-			if err != nil {
-				if err != errIgnoredCRD {
-					slog.Error("skipping custom resource", slog.String("Resource", name), ilog.Err(err))
+			if cur, ok := syncers[name]; ok {
+				if crd.Type == watch.Added {
+					slog.Warn("Already had a running sync", slog.String("syncer", name))
 				}
-				continue
+				cur.stop()
+				delete(syncers, name)
 			}
-			syncers[name] = s
-			go s.run()
+			if crd.Type == watch.Added || crd.Type == watch.Modified {
+				// The modify procedure is very heavyweight: We throw away
+				// the informer for the CRD (read: all cached data) on every
+				// modification and recreate it. If that ever turns out to
+				// be a problem, we should use a shared informer cache
+				// instead.
+				s, err := newCRSyncer(ctx, *crd.CRD, local, remote, *robotName)
+				if err != nil {
+					if err != errIgnoredCRD {
+						slog.Error("skipping custom resource", slog.String("Resource", name), ilog.Err(err))
+					}
+					continue
+				}
+				syncers[name] = s
+				go s.run()
+			}
 		}
 	}
 }

--- a/src/go/cmd/cr-syncer/main_test.go
+++ b/src/go/cmd/cr-syncer/main_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -62,7 +61,7 @@ func TestStreamCrdsSeesPreexistingObject(t *testing.T) {
 }
 
 func TestStreamCrdsSeesAdditionAndDeletion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	g := NewGomegaWithT(t)
 	cs := fakecrdclientset.NewSimpleClientset()
 
@@ -100,7 +99,7 @@ func TestStreamCrdsSeesAdditionAndDeletion(t *testing.T) {
 }
 
 func TestStreamCrdsSeesUpdate(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	g := NewGomegaWithT(t)
 	cs := fakecrdclientset.NewSimpleClientset()
 

--- a/src/go/cmd/cr-syncer/syncer.go
+++ b/src/go/cmd/cr-syncer/syncer.go
@@ -384,7 +384,7 @@ func (s *crSyncer) run() {
 		return
 	}
 
-	ctx, err := tag.New(context.Background(), tag.Insert(tagResource, s.crd.Name))
+	ctx, err := tag.New(s.ctx, tag.Insert(tagResource, s.crd.Name))
 	if err != nil {
 		panic(err)
 	}

--- a/src/go/cmd/cr-syncer/syncer_test.go
+++ b/src/go/cmd/cr-syncer/syncer_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -94,7 +93,7 @@ func (f *fixture) newCRSyncer(crd crdtypes.CustomResourceDefinition, robotName s
 		f.remoteObjects...,
 	)
 
-	crs, err := newCRSyncer(context.Background(), crd, f.local, f.remote, robotName)
+	crs, err := newCRSyncer(f.T.Context(), crd, f.local, f.remote, robotName)
 	if err != nil {
 		f.Fatal(err)
 	}

--- a/src/go/cmd/gcr-credential-refresher/main.go
+++ b/src/go/cmd/gcr-credential-refresher/main.go
@@ -19,6 +19,9 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/googlecloudrobotics/core/src/go/pkg/gcr"
@@ -64,13 +67,20 @@ func updateCredentials(ctx context.Context) error {
 // on startup, and then every 10 minutes.
 func main() {
 	flag.Parse()
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	for {
 		if err := updateCredentials(ctx); err != nil {
 			log.Fatal(err)
 		}
 		log.Printf("Updated GCR credentials in local cluster")
-		time.Sleep(updateInterval)
+
+		select {
+		case <-ctx.Done():
+			log.Printf("Shutting down")
+			return
+		case <-time.After(updateInterval):
+		}
 	}
 }

--- a/src/go/cmd/http-relay-client/client/client_test.go
+++ b/src/go/cmd/http-relay-client/client/client_test.go
@@ -16,7 +16,6 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -106,7 +105,7 @@ func TestLocalProxy(t *testing.T) {
 	config := DefaultClientConfig()
 	config.ServerName = "foo"
 	client := NewClient(config)
-	err := client.localProxy(context.Background(), &http.Client{}, &http.Client{})
+	err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -175,7 +174,7 @@ func TestBackendError(t *testing.T) {
 	// 1. pulls a request from the realy-server (/server/request)
 	// 2. send that request to the backend server (here localhost:8080/foo/bar?a=b)
 	// 3. retrieves the response from the backend and sends it to the relay-server
-	err := client.localProxy(context.Background(), &http.Client{}, &http.Client{})
+	err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -206,7 +205,7 @@ func TestServerTimeout(t *testing.T) {
 	config := DefaultClientConfig()
 	config.ServerName = "foo"
 	client := NewClient(config)
-	err := client.localProxy(context.Background(), &http.Client{}, &http.Client{})
+	err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
 	if err != ErrTimeout {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/src/go/cmd/http-relay-client/main.go
+++ b/src/go/cmd/http-relay-client/main.go
@@ -28,6 +28,8 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"github.com/googlecloudrobotics/core/src/go/cmd/http-relay-client/client"
@@ -107,6 +109,9 @@ func main() {
 	logHandler := ilog.NewLogHandler(slog.Level(logLevel), os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if stackdriverProjectID != "" {
 		sd, err := stackdriver.NewExporter(stackdriver.Options{
 			ProjectID: stackdriverProjectID,
@@ -121,5 +126,5 @@ func main() {
 	}
 
 	client := client.NewClient(config)
-	client.Start(context.Background())
+	client.Start(ctx)
 }

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -92,7 +92,7 @@ func (bt *brokerConn) bakeRequest(b *broker, s string) {
 
 func (bt *brokerConn) runReceiver(t *testing.T, b *broker, s string, wg *sync.WaitGroup) {
 	bt.bakeRequest(b, s)
-	req, err := b.GetRequest(context.Background(), s, "/")
+	req, err := b.GetRequest(t.Context(), s, "/")
 	if err != nil {
 		t.Errorf("Error when getting request: %v", err)
 	}
@@ -129,7 +129,7 @@ func (bt *brokerConn) runSenderStream(t *testing.T, b *broker, s string, m strin
 // It returns after the first response has been sent.
 func (bt *brokerConn) runReceiverStream(t *testing.T, b *broker, s string, wg *sync.WaitGroup, done <-chan bool) {
 	bt.bakeRequest(b, s)
-	req, err := b.GetRequest(context.Background(), s, "/")
+	req, err := b.GetRequest(t.Context(), s, "/")
 	if err != nil {
 		t.Errorf("Error when getting request: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestTimeout(t *testing.T) {
 	}()
 	go func() {
 		slog.Info("Getting request")
-		b.GetRequest(context.Background(), "foo", "/")
+		b.GetRequest(t.Context(), "foo", "/")
 		slog.Info("Reaping inactive requests")
 		b.ReapInactiveRequests(time.Now().Add(10 * time.Second))
 		slog.Info("Done")
@@ -282,7 +282,7 @@ func TestReapWhileSendingResponse(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		req, reqErr = b.GetRequest(context.Background(), "foo", "/")
+		req, reqErr = b.GetRequest(t.Context(), "foo", "/")
 		if reqErr != nil {
 			t.Errorf("GetRequest error: %v", reqErr)
 		}
@@ -330,7 +330,7 @@ func TestReapWhileSendingRequest(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		req, reqErr = b.GetRequest(context.Background(), "foo", "/")
+		req, reqErr = b.GetRequest(t.Context(), "foo", "/")
 		if reqErr != nil {
 			t.Errorf("GetRequest error: %v", reqErr)
 		}
@@ -394,7 +394,7 @@ func TestRelayRequestMultipleClients(t *testing.T) {
 
 func TestGetRequestServerRestarting(t *testing.T) {
 	b := newBroker()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
 	_, err := b.GetRequest(ctx, "foo", "/")

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -56,7 +55,7 @@ func TestClientHandler(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() { server.userClientRequest(respRecorder, req); wg.Done() }()
-	relayRequest, err := server.b.GetRequest(context.Background(), "foo", "/")
+	relayRequest, err := server.b.GetRequest(t.Context(), "foo", "/")
 	if err != nil {
 		t.Errorf("Error when getting request: %v", err)
 	}
@@ -124,7 +123,7 @@ func TestClientHandlerWithChunkedResponse(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() { server.userClientRequest(respRecorder, req); wg.Done() }()
-	relayRequest, err := server.b.GetRequest(context.Background(), "foo", "/")
+	relayRequest, err := server.b.GetRequest(t.Context(), "foo", "/")
 	if err != nil {
 		t.Errorf("Error when getting request: %v", err)
 	}
@@ -356,7 +355,7 @@ func TestRequestStreamHandler(t *testing.T) {
 	go func() { server.userClientRequest(respRecorder, req); wg.Done() }()
 
 	// Simulate a 101 Switching Protocols response from the backend.
-	relayRequest, err := server.b.GetRequest(context.Background(), "foo", "/")
+	relayRequest, err := server.b.GetRequest(t.Context(), "foo", "/")
 	if err != nil {
 		t.Errorf("Error when getting request: %v", err)
 	}
@@ -670,7 +669,7 @@ func TestTrailers(t *testing.T) {
 				server.userClientRequest(respRecorder, req)
 			}()
 
-			relayRequest, err := server.b.GetRequest(context.Background(), "foo", "/")
+			relayRequest, err := server.b.GetRequest(t.Context(), "foo", "/")
 			if err != nil {
 				t.Fatalf("Failed to get request: %v", err)
 			}

--- a/src/go/cmd/metadata-server/coredns_test.go
+++ b/src/go/cmd/metadata-server/coredns_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -70,7 +69,7 @@ const (
 func createCorefile(t *testing.T, k8s kubernetes.Interface, corefileData string) {
 	t.Helper()
 	if _, err := k8s.CoreV1().ConfigMaps(configMapNamespace).Create(
-		context.Background(),
+		t.Context(),
 		&v1.ConfigMap{
 			Data: map[string]string{
 				corefileName: corefileData,
@@ -86,7 +85,7 @@ func createCorefile(t *testing.T, k8s kubernetes.Interface, corefileData string)
 
 func readCorefile(t *testing.T, k8s kubernetes.Interface) string {
 	t.Helper()
-	cm, err := k8s.CoreV1().ConfigMaps(configMapNamespace).Get(context.Background(), configMapName, metav1.GetOptions{})
+	cm, err := k8s.CoreV1().ConfigMaps(configMapNamespace).Get(t.Context(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("error reading ConfigMap coredns: %v", err)
 		return ""
@@ -124,7 +123,7 @@ func TestPatchCorefile(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			k8s := fake.NewSimpleClientset()
 			createCorefile(t, k8s, tc.input)
 
@@ -163,7 +162,7 @@ func TestPatchCorefile(t *testing.T) {
 }
 
 func TestPatchCorefileUnexpected(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	k8s := fake.NewSimpleClientset()
 	createCorefile(t, k8s, defaultCorefileUnexpected)
 

--- a/src/go/cmd/metadata-server/main.go
+++ b/src/go/cmd/metadata-server/main.go
@@ -95,7 +95,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -188,12 +189,10 @@ func main() {
 		os.Exit(1)
 	}()
 
-	stop := make(chan os.Signal)
-	signal.Notify(stop, syscall.SIGTERM)
-
-	<-stop
+	<-ctx.Done()
 	if !*runningOnGKE {
-		RevertCorefile(ctx, k8s)
+		// Use a fresh context for cleanup because ctx is already cancelled here.
+		RevertCorefile(context.Background(), k8s)
 	}
 	removeNATRule()
 }

--- a/src/go/cmd/setup-dev/main.go
+++ b/src/go/cmd/setup-dev/main.go
@@ -24,7 +24,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -64,9 +66,10 @@ func main() {
 	logHandler := ilog.NewLogHandler(slog.LevelInfo, os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-	vars, err := configutil.ReadConfig(*project)
+	vars, err := configutil.ReadConfig(ctx, *project)
 	if err != nil {
 		slog.Error("Failed to read config", ilog.Err(err))
 		os.Exit(1)
@@ -76,7 +79,7 @@ func main() {
 		domain = fmt.Sprintf("www.endpoints.%s.cloud.goog", *project)
 	}
 
-	tokenSource, err := google.DefaultTokenSource(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
+	tokenSource, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		slog.Error("Failed to create OAuth2 token source", ilog.Err(err))
 		os.Exit(1)
@@ -100,7 +103,7 @@ func main() {
 	}
 	// TODO(ensonic): these are only used for the ssh-app
 	// dev credentials are always created
-	client := oauth2.NewClient(context.Background(), tokenSource)
+	client := oauth2.NewClient(ctx, tokenSource)
 	if err := setupDevCredentials(client, domain, *robotName); err != nil {
 		slog.Error("Failed to set up credentials", ilog.Err(err))
 		os.Exit(1)

--- a/src/go/cmd/setup-robot/main.go
+++ b/src/go/cmd/setup-robot/main.go
@@ -22,9 +22,11 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/googlecloudrobotics/core/src/go/pkg/configutil"
 	"github.com/googlecloudrobotics/core/src/go/pkg/gcr"
@@ -175,7 +177,9 @@ func main() {
 	logHandler := ilog.NewLogHandler(slog.LevelInfo, os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	envToken := os.Getenv("ACCESS_TOKEN")
 	if envToken == "" {
 		slog.Error("ACCESS_TOKEN environment variable is required.")
@@ -207,7 +211,7 @@ func main() {
 	// Set up the OAuth2 token source.
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: envToken})
 
-	vars, err := configutil.ReadConfig(*project, option.WithTokenSource(tokenSource))
+	vars, err := configutil.ReadConfig(ctx, *project, option.WithTokenSource(tokenSource))
 	if err != nil {
 		slog.Error("Failed to read config for project", ilog.Err(err))
 		os.Exit(1)

--- a/src/go/cmd/setup-robot/main_test.go
+++ b/src/go/cmd/setup-robot/main_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"os"
 	"reflect"
@@ -109,7 +108,7 @@ func TestParseKeyValues_HandlesSpaces(t *testing.T) {
 }
 
 func TestCheckRobotName_SucceedsWhenCRDNotFound(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	sc := runtime.NewScheme()
 	*robotName = "robot_name"
 
@@ -135,7 +134,7 @@ func TestCheckRobotName_SucceedsWhenCRDNotFound(t *testing.T) {
 }
 
 func TestCheckRobotName(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	sc := runtime.NewScheme()
 	registry.AddToScheme(sc)
 	*robotName = "robot_name"
@@ -198,7 +197,7 @@ func TestCheckRobotName(t *testing.T) {
 }
 
 func TestCreateOrUpdateRobot_Succeeds(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	hostname, err := os.Hostname()
 	if err != nil {
 		t.Fatal("Could not determine hostname")

--- a/src/go/cmd/synk/synk.go
+++ b/src/go/cmd/synk/synk.go
@@ -116,7 +116,7 @@ func runInit(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
-	if err := s.Init(); err != nil {
+	if err := s.Init(cmd.Context()); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
@@ -133,7 +133,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
-	if err := s.Delete(context.Background(), args[0]); err != nil {
+	if err := s.Delete(cmd.Context(), args[0]); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
@@ -145,13 +145,13 @@ func runApply(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, "unrecognized number of arguments, exactly one (name) expected")
 		os.Exit(2)
 	}
-	if err := apply(args[0]); err != nil {
+	if err := apply(cmd.Context(), args[0]); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }
 
-func apply(name string) error {
+func apply(ctx context.Context, name string) error {
 	// If a target namesapce for the chart is given, enforce it.
 	namespace, enforceNamespace, err := restOpts.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
@@ -190,7 +190,7 @@ func apply(name string) error {
 	}
 	if err := backoff.Retry(
 		func() error {
-			_, err := s.Apply(context.Background(), name, opts, resources...)
+			_, err := s.Apply(ctx, name, opts, resources...)
 			if err != nil {
 				if synk.IsTransientErr(err) {
 					return err
@@ -199,7 +199,7 @@ func apply(name string) error {
 			}
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(retryBackoff), retries),
+		backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(retryBackoff), retries), ctx),
 	); err != nil {
 		return fmt.Errorf("apply files: %w", err)
 	}

--- a/src/go/cmd/token-vendor/api/v1/v1_test.go
+++ b/src/go/cmd/token-vendor/api/v1/v1_test.go
@@ -105,17 +105,18 @@ func TestPublicKeyConfigureHandlerWithK8s(t *testing.T) {
 
 func runPublicKeyConfigureHandlerWithK8sCase(t *testing.T, test *publicKeyConfigureHandlerK8sTest) {
 	t.Helper()
+	ctx := t.Context()
 	// Setup fake K8s environment
 	cs := fake.NewSimpleClientset()
-	if err := populateK8sEnv(cs, "default", test.configmaps); err != nil {
+	if err := populateK8sEnv(ctx, cs, "default", test.configmaps); err != nil {
 		t.Fatal(err)
 	}
-	kcl, err := k8s.NewK8sRepository(context.TODO(), cs, "default")
+	kcl, err := k8s.NewK8sRepository(ctx, cs, "default")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Setup app & API handler
-	tv, err := app.NewTokenVendor(context.TODO(), kcl, nil, nil, "aud", saName)
+	tv, err := app.NewTokenVendor(ctx, kcl, nil, nil, "aud", saName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,9 +202,9 @@ func TestPublicKeyReadHandlerWithK8s(t *testing.T) {
 	}
 }
 
-func populateK8sEnv(env kubernetes.Interface, ns string, maps []*corev1.ConfigMap) error {
+func populateK8sEnv(ctx context.Context, env kubernetes.Interface, ns string, maps []*corev1.ConfigMap) error {
 	for _, m := range maps {
-		if _, err := env.CoreV1().ConfigMaps(ns).Create(context.TODO(), m, metav1.CreateOptions{}); err != nil {
+		if _, err := env.CoreV1().ConfigMaps(ns).Create(ctx, m, metav1.CreateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -212,17 +213,18 @@ func populateK8sEnv(env kubernetes.Interface, ns string, maps []*corev1.ConfigMa
 
 func runPublicKeyReadHandlerWithK8sCase(t *testing.T, test *publicKeyReadHandlerK8sTest) {
 	t.Helper()
+	ctx := t.Context()
 	// Setup fake K8s environment
 	cs := fake.NewSimpleClientset()
-	if err := populateK8sEnv(cs, "default", test.configmaps); err != nil {
+	if err := populateK8sEnv(ctx, cs, "default", test.configmaps); err != nil {
 		t.Fatal(err)
 	}
-	kcl, err := k8s.NewK8sRepository(context.TODO(), cs, "default")
+	kcl, err := k8s.NewK8sRepository(ctx, cs, "default")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Setup app & API handler
-	tv, err := app.NewTokenVendor(context.TODO(), kcl, nil, nil, "aud", saName)
+	tv, err := app.NewTokenVendor(ctx, kcl, nil, nil, "aud", saName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,17 +342,18 @@ func TestPublicKeyPublishHandlerWithK8s(t *testing.T) {
 
 func runPublicKeyPublishHandlerWithK8sCase(t *testing.T, test *publicKeyPublishHandlerK8sTest) {
 	t.Helper()
+	ctx := t.Context()
 	// Setup fake K8s environment
 	cs := fake.NewSimpleClientset()
-	if err := populateK8sEnv(cs, "default", test.configmaps); err != nil {
+	if err := populateK8sEnv(ctx, cs, "default", test.configmaps); err != nil {
 		t.Fatal(err)
 	}
-	kcl, err := k8s.NewK8sRepository(context.TODO(), cs, "default")
+	kcl, err := k8s.NewK8sRepository(ctx, cs, "default")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Setup app & API handler
-	tv, err := app.NewTokenVendor(context.TODO(), kcl, nil, nil, "aud", saName)
+	tv, err := app.NewTokenVendor(ctx, kcl, nil, nil, "aud", saName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -605,6 +608,8 @@ func TestVerifyTokenHandler(t *testing.T) {
 }
 
 func runVerifyTokenHandlerTest(t *testing.T, test *VerifyTokenHandlerTest) {
+	t.Helper()
+	ctx := t.Context()
 	isToken := "ya29." + strings.Repeat("a", 100)
 	// fake IAM response
 	fakeIAMHandler := func(req *http.Request) *http.Response {
@@ -640,11 +645,11 @@ func runVerifyTokenHandlerTest(t *testing.T, test *VerifyTokenHandlerTest) {
 
 	// setup app and http client
 	client := NewTestHTTPClient(fakeIAMHandler)
-	tver, err := oauth.NewTokenVerifier(context.TODO(), client, "testproject")
+	tver, err := oauth.NewTokenVerifier(ctx, client, "testproject")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	tv, err := app.NewTokenVendor(context.TODO(), nil, tver, nil, "aud", saName)
+	tv, err := app.NewTokenVendor(ctx, nil, tver, nil, "aud", saName)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -734,6 +739,8 @@ func TestTokenOAuth2HandlerExpired(t *testing.T) {
 }
 
 func runTokenOAuth2HandlerTestWithK8s(t *testing.T, test TokenOAuth2HandlerTest) {
+	t.Helper()
+	ctx := t.Context()
 	// fake GCP IAM response for an access token
 	fakeIAMAPI := func(req *http.Request) *http.Response {
 		const wantUrl = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/robot-service@testproject.iam.gserviceaccount.com:generateAccessToken?alt=json&prettyPrint=false"
@@ -752,12 +759,12 @@ func runTokenOAuth2HandlerTestWithK8s(t *testing.T, test TokenOAuth2HandlerTest)
 	}
 	// setup app and http client
 	clientIAM := NewTestHTTPClient(fakeIAMAPI)
-	ts, err := tokensource.NewGCPTokenSource(context.TODO(), clientIAM, test.scopes)
+	ts, err := tokensource.NewGCPTokenSource(ctx, clientIAM, test.scopes)
 	if err != nil {
 		t.Fatal(err)
 	}
 	cs := fake.NewSimpleClientset()
-	if err = populateK8sEnv(cs, "default",
+	if err = populateK8sEnv(ctx, cs, "default",
 		[]*corev1.ConfigMap{
 			{
 				TypeMeta: metav1.TypeMeta{
@@ -772,11 +779,11 @@ func runTokenOAuth2HandlerTestWithK8s(t *testing.T, test TokenOAuth2HandlerTest)
 		}); err != nil {
 		t.Fatal(err)
 	}
-	r, err := k8s.NewK8sRepository(context.TODO(), cs, "default")
+	r, err := k8s.NewK8sRepository(ctx, cs, "default")
 	if err != nil {
 		t.Fatal(err)
 	}
-	tv, err := app.NewTokenVendor(context.TODO(), r, nil, ts, test.acceptedAud, saName)
+	tv, err := app.NewTokenVendor(ctx, r, nil, ts, test.acceptedAud, saName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -851,7 +858,7 @@ func Test_verifyJWTHandler(t *testing.T) {
 	t.Parallel()
 
 	cs := fake.NewSimpleClientset()
-	if err := populateK8sEnv(cs, "default",
+	if err := populateK8sEnv(t.Context(), cs, "default",
 		[]*corev1.ConfigMap{
 			{
 				TypeMeta: metav1.TypeMeta{
@@ -866,11 +873,11 @@ func Test_verifyJWTHandler(t *testing.T) {
 		}); err != nil {
 		t.Fatal(err)
 	}
-	r, err := k8s.NewK8sRepository(context.TODO(), cs, "default")
+	r, err := k8s.NewK8sRepository(t.Context(), cs, "default")
 	if err != nil {
 		t.Fatal(err)
 	}
-	tv, err := app.NewTokenVendor(context.TODO(), r, nil, nil, "testaud", saName)
+	tv, err := app.NewTokenVendor(t.Context(), r, nil, nil, "testaud", saName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/go/cmd/token-vendor/app/tokenvendor_test.go
+++ b/src/go/cmd/token-vendor/app/tokenvendor_test.go
@@ -248,7 +248,7 @@ func TestTokenVendor_ValidateJWT(t *testing.T) {
 				accAud:        tt.fields.accAud,
 				defaultSAName: tt.fields.defaultSAName,
 			}
-			got, err := tv.ValidateJWT(context.Background(), tt.args.jwtk)
+			got, err := tv.ValidateJWT(t.Context(), tt.args.jwtk)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateJWT() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/src/go/cmd/token-vendor/main.go
+++ b/src/go/cmd/token-vendor/main.go
@@ -21,8 +21,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strings"
+	"syscall"
 
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -104,7 +106,9 @@ func main() {
 	slog.SetDefault(slog.New(logHandler))
 
 	// init components
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	var rep repository.PubKeyRepository
 	var err error
 	switch *keyStore {

--- a/src/go/cmd/token-vendor/repository/k8s/k8s_test.go
+++ b/src/go/cmd/token-vendor/repository/k8s/k8s_test.go
@@ -15,7 +15,6 @@
 package k8s
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -26,7 +25,7 @@ import (
 
 // Publish a key, retrieve it again and check listing of all keys.
 func TestPublishListLookup(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := fake.NewSimpleClientset()
 	kcl, err := NewK8sRepository(ctx, cs, "default")
 	if err != nil {
@@ -51,7 +50,7 @@ func TestPublishListLookup(t *testing.T) {
 
 // Publish a key and override it with another one.
 func TestPublishKeyUpdate(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := fake.NewSimpleClientset()
 	kcl, err := NewK8sRepository(ctx, cs, "default")
 	if err != nil {
@@ -75,7 +74,7 @@ func TestPublishKeyUpdate(t *testing.T) {
 }
 
 func TestLookupDoesNotExist(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := fake.NewSimpleClientset()
 	kcl, err := NewK8sRepository(ctx, cs, "default")
 	if err != nil {
@@ -91,7 +90,7 @@ func TestLookupDoesNotExist(t *testing.T) {
 }
 
 func TestConfigure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := fake.NewSimpleClientset()
 	kcl, err := NewK8sRepository(ctx, cs, "default")
 	if err != nil {
@@ -116,7 +115,7 @@ func TestConfigure(t *testing.T) {
 }
 
 func TestReConfigure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := fake.NewSimpleClientset()
 	kcl, err := NewK8sRepository(ctx, cs, "default")
 	if err != nil {

--- a/src/go/cmd/token-vendor/repository/memory/memory_test.go
+++ b/src/go/cmd/token-vendor/repository/memory/memory_test.go
@@ -15,7 +15,6 @@
 package memory
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -24,7 +23,7 @@ import (
 
 // Test publish and lookup key
 func TestPublishAndLookup(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	m, err := NewMemoryRepository(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +51,7 @@ func TestPublishAndLookup(t *testing.T) {
 }
 
 func TestLookupNotFound(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	m, err := NewMemoryRepository(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +66,7 @@ func TestLookupNotFound(t *testing.T) {
 }
 
 func TestConfigure(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	m, err := NewMemoryRepository(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/src/go/pkg/configutil/config_reader.go
+++ b/src/go/pkg/configutil/config_reader.go
@@ -79,8 +79,7 @@ func setDefaultVars(vars map[string]string) {
 // Uses the following defaults if the variables are not set:
 //
 //	CLOUD_ROBOTICS_CONTAINER_REGISTRY="gcr.io/<GCP_PROJECT_ID>"
-func ReadConfig(project string, opts ...option.ClientOption) (map[string]string, error) {
-	ctx := context.Background()
+func ReadConfig(ctx context.Context, project string, opts ...option.ClientOption) (map[string]string, error) {
 	client, err := storage.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/src/go/pkg/controller/chartassignment/controller.go
+++ b/src/go/pkg/controller/chartassignment/controller.go
@@ -58,7 +58,7 @@ func Add(ctx context.Context, mgr manager.Manager, cloud bool) error {
 		cloud:    cloud,
 	}
 	var err error
-	r.releases, err = newReleases(mgr.GetConfig(), r.recorder)
+	r.releases, err = newReleases(ctx, mgr.GetConfig(), r.recorder)
 	if err != nil {
 		return err
 	}

--- a/src/go/pkg/controller/chartassignment/controller_test.go
+++ b/src/go/pkg/controller/chartassignment/controller_test.go
@@ -15,7 +15,6 @@
 package chartassignment
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -43,7 +42,7 @@ func TestReconciler_Reconcile_NotFound(t *testing.T) {
 
 	// When a resource is not found, the reconciler should return success (nil error)
 	// and not requeue, as there's nothing left to reconcile.
-	res, err := r.Reconcile(context.Background(), req)
+	res, err := r.Reconcile(t.Context(), req)
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
@@ -69,7 +68,7 @@ func TestReconciler_ensureNamespace(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, err := r.ensureNamespace(ctx, as)
 	if err != nil {
 		t.Fatalf("ensureNamespace failed: %v", err)
@@ -114,13 +113,13 @@ func TestReconciler_ensureSecrets(t *testing.T) {
 		},
 	}
 
-	err := r.ensureSecrets(context.Background(), as)
+	err := r.ensureSecrets(t.Context(), as)
 	if err != nil {
 		t.Fatalf("ensureSecrets failed: %v", err)
 	}
 
 	var copiedSecret corev1.Secret
-	err = client.Get(context.Background(), kclient.ObjectKey{Namespace: "app-ns", Name: "test-secret"}, &copiedSecret)
+	err = client.Get(t.Context(), kclient.ObjectKey{Namespace: "app-ns", Name: "test-secret"}, &copiedSecret)
 	if err != nil {
 		t.Fatalf("Secret not copied to app-ns: %v", err)
 	}
@@ -146,6 +145,7 @@ func TestReconciler_Reconcile_Delete(t *testing.T) {
 	mockSynk := NewMockInterface(ctrl)
 
 	releases := &releases{
+		ctx:  t.Context(),
 		m:    map[string]*release{},
 		synk: mockSynk,
 	}
@@ -158,6 +158,7 @@ func TestReconciler_Reconcile_Delete(t *testing.T) {
 
 	// Mock release status as Deleted
 	releases.m["test-app"] = &release{
+		ctx:    t.Context(),
 		status: releaseStatus{phase: apps.ChartAssignmentPhaseDeleted},
 	}
 
@@ -167,7 +168,7 @@ func TestReconciler_Reconcile_Delete(t *testing.T) {
 		NamespacedName: kclient.ObjectKey{Name: "test-app"},
 	}
 
-	res, err := r.Reconcile(context.Background(), req)
+	res, err := r.Reconcile(t.Context(), req)
 	if err != nil {
 		t.Fatalf("Reconcile failed: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestReconciler_Reconcile_Delete(t *testing.T) {
 
 	// Verify ChartAssignment was deleted (no more finalizers)
 	var updatedAs apps.ChartAssignment
-	err = client.Get(context.Background(), kclient.ObjectKey{Name: "test-app"}, &updatedAs)
+	err = client.Get(t.Context(), kclient.ObjectKey{Name: "test-app"}, &updatedAs)
 	if !k8serrors.IsNotFound(err) {
 		t.Errorf("Expected ChartAssignment to be deleted, but found: %v", updatedAs)
 	}

--- a/src/go/pkg/controller/chartassignment/release.go
+++ b/src/go/pkg/controller/chartassignment/release.go
@@ -47,6 +47,7 @@ import (
 
 // releases is a cache of releases currently handled.
 type releases struct {
+	ctx      context.Context
 	recorder record.EventRecorder
 	synk     synk.Interface
 
@@ -54,12 +55,13 @@ type releases struct {
 	m   map[string]*release
 }
 
-func newReleases(cfg *rest.Config, rec record.EventRecorder) (*releases, error) {
+func newReleases(ctx context.Context, cfg *rest.Config, rec record.EventRecorder) (*releases, error) {
 	synk, err := synk.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &releases{
+		ctx:      ctx,
 		recorder: rec,
 		m:        map[string]*release{},
 		synk:     synk,
@@ -68,6 +70,7 @@ func newReleases(cfg *rest.Config, rec record.EventRecorder) (*releases, error) 
 
 // release is a cache object which acts as a proxy for Synk ResourceSets.
 type release struct {
+	ctx      context.Context
 	name     string
 	synk     synk.Interface
 	recorder record.EventRecorder
@@ -108,6 +111,7 @@ func (rs *releases) add(name string) *release {
 		return r
 	}
 	r = &release{
+		ctx:      rs.ctx,
 		name:     name,
 		synk:     rs.synk,
 		recorder: rs.recorder,
@@ -167,6 +171,8 @@ func (r *release) start(f func()) bool {
 	select {
 	case r.actorc <- f:
 		return true
+	case <-r.ctx.Done():
+		return false
 	default:
 	}
 	return false
@@ -220,7 +226,7 @@ func (r *release) delete(as *apps.ChartAssignment) {
 	r.setPhase(apps.ChartAssignmentPhaseDeleting)
 	r.recorder.Event(as, core.EventTypeNormal, "DeleteChart", "deleting chart")
 
-	if err := r.synk.Delete(context.Background(), as.Name); err != nil {
+	if err := r.synk.Delete(r.ctx, as.Name); err != nil {
 		r.recorder.Event(as, core.EventTypeWarning, "Failure", err.Error())
 		r.setFailed(fmt.Errorf("delete release: %w", err), synk.IsTransientErr(err))
 	}
@@ -265,7 +271,7 @@ func (r *release) update(as *apps.ChartAssignment) {
 			slog.Error("decoding TraceID", slog.String("TraceID", tid), ilog.Err(err))
 		}
 	}
-	ctx, span := trace.StartSpanWithRemoteParent(context.Background(), "Apply "+as.Name, spanContext)
+	ctx, span := trace.StartSpanWithRemoteParent(r.ctx, "Apply "+as.Name, spanContext)
 	_, err = r.synk.Apply(ctx, as.Name, opts, resources...)
 	span.End()
 	if err != nil {

--- a/src/go/pkg/controller/chartassignment/release_test.go
+++ b/src/go/pkg/controller/chartassignment/release_test.go
@@ -88,6 +88,7 @@ spec:
 
 	mockSynk := NewMockInterface(ctrl)
 	r := &release{
+		ctx:      t.Context(),
 		synk:     mockSynk,
 		recorder: &record.FakeRecorder{},
 	}
@@ -115,6 +116,7 @@ spec:
 
 	mockSynk := NewMockInterface(ctrl)
 	r := &release{
+		ctx:      t.Context(),
 		synk:     mockSynk,
 		recorder: &record.FakeRecorder{},
 	}

--- a/src/go/pkg/robotauth/robotauth_test.go
+++ b/src/go/pkg/robotauth/robotauth_test.go
@@ -1,7 +1,6 @@
 package robotauth
 
 import (
-	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
@@ -71,11 +70,11 @@ func TestK8sSecretLoadStoreRoundtrip(t *testing.T) {
 	if err := quick.Check(func(a RobotAuth, ns string) bool {
 		cs := fake.NewSimpleClientset()
 
-		if err := a.StoreInK8sSecret(context.TODO(), cs, ns); err != nil {
-			t.Errorf("Failed to store k8s secret: %v", err)
+		if err := a.StoreInK8sSecret(t.Context(), cs, ns); err != nil {
+			t.Errorf("Failed to store secret: %v", err)
 		}
 
-		l, err := LoadFromK8sSecret(context.TODO(), cs, ns)
+		l, err := LoadFromK8sSecret(t.Context(), cs, ns)
 		if err != nil {
 			t.Errorf("Failed to read k8s secret: %v", err)
 		}
@@ -91,7 +90,7 @@ func TestCreateJWT(t *testing.T) {
 		PrivateKey: []byte(testPrivKey),
 	}
 
-	jwtk, err := a.CreateJWT(context.TODO(), time.Minute*10)
+	jwtk, err := a.CreateJWT(t.Context(), time.Minute*10)
 	if err != nil {
 		t.Errorf("Failed to create JWT: %v", err)
 	}

--- a/src/go/pkg/setup/setupcommon_test.go
+++ b/src/go/pkg/setup/setupcommon_test.go
@@ -16,7 +16,6 @@ package setup
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -81,7 +80,7 @@ func TestCreateOrUpdateRobot(t *testing.T) {
 		Resource: "robots",
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	robotName := "test-robot"
 	robotType := "test-type"
 	project := "test-project"

--- a/src/go/pkg/synk/interface.go
+++ b/src/go/pkg/synk/interface.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Interface interface {
-	Init() error
+	Init(ctx context.Context) error
 	Delete(ctx context.Context, name string) error
 	Apply(ctx context.Context, name string, opts *ApplyOptions, resources ...*unstructured.Unstructured) (*apps.ResourceSet, error)
 }

--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -132,7 +132,7 @@ func (o *ApplyOptions) errorf(r *unstructured.Unstructured, action apps.Resource
 // Init installs the ResourceSet CRD into the cluster and waits for
 // it to become available.
 // It does not need to be called before each use of Synk.
-func (s *Synk) Init() error {
+func (s *Synk) Init(ctx context.Context) error {
 	vTrue := true
 	crd := &apiextensions.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
@@ -177,7 +177,7 @@ func (s *Synk) Init() error {
 	if err := convert(crd, &u); err != nil {
 		return err
 	}
-	if _, err := s.applyOne(context.Background(), &u, nil); err != nil {
+	if _, err := s.applyOne(ctx, &u, nil); err != nil {
 		return fmt.Errorf("create ResourceSet CRD: %w", err)
 	}
 
@@ -193,7 +193,7 @@ func (s *Synk) Init() error {
 			}
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 60),
+		backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 60), ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("wait for ResourceSet CRD: %w", err)

--- a/src/go/pkg/synk/synk_test.go
+++ b/src/go/pkg/synk/synk_test.go
@@ -15,7 +15,6 @@
 package synk
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -183,7 +182,7 @@ func TestSynk_IsTransientErr(t *testing.T) {
 
 // TODO(rodrigoq): test Apply() directly rather than the private methods
 func TestSynk_initialize(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := newFixture(t).newSynk()
 
 	_, _, err := s.initialize(ctx, &ApplyOptions{name: "test"},
@@ -238,7 +237,7 @@ status:
 }
 
 func TestSynk_updateResourceSetStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	f := newFixture(t)
 	s := f.newSynk()
 
@@ -365,7 +364,7 @@ data:
 	// Note: We can't test applying an Unstructured object here, as the
 	// fake client doesn't support strategic merge patches:
 	// https://github.com/kubernetes/client-go/issues/613
-	results, err := f.newSynk().applyAll(context.Background(), set, &ApplyOptions{name: "test"},
+	results, err := f.newSynk().applyAll(t.Context(), set, &ApplyOptions{name: "test"},
 		cm.DeepCopy(),
 	)
 	if err != nil {
@@ -407,7 +406,7 @@ func TestSynk_applyAllIsCreatingResources(t *testing.T) {
 	set.Name = "test.v1"
 	set.UID = "deadbeef"
 
-	results, err := f.newSynk().applyAll(context.Background(), set, &ApplyOptions{name: "test"},
+	results, err := f.newSynk().applyAll(t.Context(), set, &ApplyOptions{name: "test"},
 		rollout.DeepCopy(),
 		deploy.DeepCopy(),
 	)
@@ -501,7 +500,7 @@ func TestSynk_applyAllRetriesResourceExpired(t *testing.T) {
 				return true, nil, k8serrors.NewResourceExpired("gone")
 			})
 
-			_, err := s.applyAll(context.Background(), set, &ApplyOptions{name: "test"},
+			_, err := s.applyAll(t.Context(), set, &ApplyOptions{name: "test"},
 				deploy.DeepCopy(),
 			)
 			if err == nil {
@@ -516,13 +515,13 @@ func TestSynk_applyAllRetriesResourceExpired(t *testing.T) {
 }
 
 func TestSynk_skipsTestResources(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s := newFixture(t).newSynk()
 
 	testPod := newUnstructured("v1", "Pod", "ns", "pod2")
 	testPod.SetAnnotations(map[string]string{"helm.sh/hook": "test-success"})
 
-	_, _, err := s.initialize(context.Background(), &ApplyOptions{name: "test"},
+	_, _, err := s.initialize(ctx, &ApplyOptions{name: "test"},
 		newUnstructured("v1", "Pod", "ns", "pod1"),
 		testPod,
 	)
@@ -557,7 +556,7 @@ status:
 }
 
 func TestSynk_deleteResourceSets(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	nu := func(name, version string) *unstructured.Unstructured {
 		u := newUnstructured("apps.cloudrobotics.com/v1alpha1", "ResourceSet", "", name+"."+version)
 		u.SetLabels(map[string]string{"name": name})
@@ -586,7 +585,7 @@ func TestSynk_deleteResourceSets(t *testing.T) {
 }
 
 func TestSynk_deleteFailedResourceSets(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	nu := func(name, version string, failed bool) *unstructured.Unstructured {
 		u := newUnstructured("apps.cloudrobotics.com/v1alpha1", "ResourceSet", "", name+"."+version)
 		u.SetLabels(map[string]string{"name": name})
@@ -643,7 +642,7 @@ spec:
       storage: true`)
 
 	if err := s.populateNamespaces(
-		context.Background(),
+		t.Context(),
 		"ns2",
 		[]*unstructured.Unstructured{&exampleCRD},
 		ns1, pod1, pod2, cr1,
@@ -798,7 +797,7 @@ func TestSynk_canReplace(t *testing.T) {
 }
 
 func TestSynk_Delete(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	f := newFixture(t)
 	s := f.newSynk()
 
@@ -831,7 +830,7 @@ func TestSynk_Init(t *testing.T) {
 		},
 	}
 
-	err := s.Init()
+	err := s.Init(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/go/tests/k8s_integration_test.go
+++ b/src/go/tests/k8s_integration_test.go
@@ -173,7 +173,7 @@ func TestCloudClusterAppStatus(t *testing.T) {
 			Version: "v1alpha1",
 		})
 		slog.Info("Querying AppRollouts...", slog.String("Context", kubernetesContext))
-		err = client.List(context.Background(), appRollouts)
+		err = client.List(t.Context(), appRollouts)
 		if err != nil {
 			slog.Error("Failed to list AppRollouts", ilog.Err(err))
 			time.Sleep(10 * time.Second)
@@ -208,7 +208,7 @@ func TestCloudClusterAppStatus(t *testing.T) {
 }
 
 func TestKubernetesCloudClusterStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	kubernetesCloudContext, err := kubeutils.GetCloudKubernetesContext()
 	if err != nil {
 		t.Error(err)
@@ -220,7 +220,7 @@ func TestKubernetesCloudClusterStatus(t *testing.T) {
 }
 
 func TestKubernetesRobotClusterStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	kubernetesRobotContext, err := kubeutils.GetRobotKubernetesContext()
 	if err != nil {
 		t.Error(err)

--- a/src/go/tests/relay/nok8s_relay_test.go
+++ b/src/go/tests/relay/nok8s_relay_test.go
@@ -392,7 +392,7 @@ func mustStartRelayWithGrpcServer(t *testing.T, service testpb.TestServiceServer
 	relayAddress := "127.0.0.1:" + result.Relay.rsPort
 
 	// Create gRPC client via relay.
-	result.Ctx = metadata.AppendToOutgoingContext(context.Background(), "x-server-name", "remote1")
+	result.Ctx = metadata.AppendToOutgoingContext(t.Context(), "x-server-name", "remote1")
 	result.Conn, err = grpc.DialContext(result.Ctx, relayAddress,
 		grpc.WithInsecure(),
 		grpc.WithDefaultCallOptions(


### PR DESCRIPTION
1. Modernized Graceful Shutdown: Updated all entry-point main.go files to use os/signal.NotifyContext. This provides a base context that is automatically cancelled upon receiving termination signals (SIGINT/SIGTERM), allowing for graceful cleanup of all downstream components.
   - Updated: setup-dev, setup-robot, token-vendor, cr-syncer, http-relay-client, metadata-server, and gcr-credential-refresher.
2. Context Propagation in Controllers: Refactored the Kubernetes controllers (chart-assignment-controller and app-rollout-controller) to use signals.SetupSignalHandler() for their base context, which is then passed down to reconcilers and background release managers.
3. Refactored Library Functions: Updated configutil.ReadConfig and Synk.Init to accept a context.Context as their first parameter. This ensures that these long-running or network-dependent operations can be cancelled by their callers.
4. Eliminated Deprecated Contexts: Replaced the obsolete golang.org/x/net/context with the standard library's context package in cr-syncer.
5. Audit of context.TODO() and context.Background():
   - Confirmed that context.TODO() is not used (only in generated code).
   - Reduced the usage of context.Background() in production code, replacing it with passed-down contexts to ensure proper cancellation propagation.
6. Cleanup of tests to use t.Context()