### PR TITLE
Fix memory leak in http-relay-server.

### DIFF
--- a/src/go/cmd/http-relay-server/main.go
+++ b/src/go/cmd/http-relay-server/main.go
@@ -25,7 +25,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -46,10 +49,18 @@ var (
 		"the log message level required to be logged")
 	inactiveRequestTimeout = flag.Duration("inactive_request_timeout", server.DefaultInactiveRequestTimeout,
 		"Timeout for inactive requests. In particular, this sets a limit on how long the backend can wait before writing headers and the response status.")
+	pprofPort = flag.Int("pprof_port", 0, "If non-zero, serves pprof endpoints on this port.")
 )
 
 func main() {
 	flag.Parse()
+	if *pprofPort != 0 {
+		go func() {
+			slog.Info("Starting pprof server", slog.Int("port", *pprofPort))
+			err := http.ListenAndServe(fmt.Sprintf(":%d", *pprofPort), nil)
+			slog.Error("pprof server failed", ilog.Err(err))
+		}()
+	}
 	logHandler := ilog.NewLogHandler(slog.Level(*logLevel), os.Stderr)
 	slog.SetDefault(slog.New(logHandler))
 

--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -198,7 +198,9 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 func (r *broker) StopRelayRequest(requestId string) {
 	r.m.Lock()
 	defer r.m.Unlock()
-	delete(r.resp, requestId)
+	if pr, ok := r.resp[requestId]; ok {
+		r.removeRequest(requestId, pr)
+	}
 }
 
 // GetRequest obtains a client's request for the server identifier. It blocks
@@ -332,25 +334,28 @@ func (r *broker) SendResponse(resp *pb.HttpResponse) error {
 
 func (r *broker) ReapInactiveRequests(threshold time.Time) {
 	r.m.Lock()
+	defer r.m.Unlock()
 	for id, pr := range r.resp {
 		if pr.lastActivity.Before(threshold) {
 			slog.Info("Timeout on inactive request", slog.String("ID", id))
-			// Closing `pr.markReap` tells `SendResponse` and `PutRequestStream` to stop.
-			close(pr.markReap)
-
-			pr.requestStreamMutex.Lock()
-			close(pr.requestStream)
-			pr.requestStreamMutex.Unlock()
-
-			// If we block on this lock, it means `SendResponse` is writing to the channel, since we just closed
-			// `markReap`, it should release the lock soon and we can safely close the channel.
-			pr.sendMutex.Lock()
-			close(pr.responseStream)
-			pr.sendMutex.Unlock()
-
-			// Amazingly, this is safe in Go: https://stackoverflow.com/questions/23229975/is-it-safe-to-remove-selected-keys-from-map-within-a-range-loop
-			delete(r.resp, id)
+			r.removeRequest(id, pr)
 		}
 	}
-	r.m.Unlock()
+}
+
+func (r *broker) removeRequest(id string, pr *pendingResponse) {
+	// Closing `pr.markReap` tells `SendResponse` and `PutRequestStream` to stop.
+	close(pr.markReap)
+
+	pr.requestStreamMutex.Lock()
+	close(pr.requestStream)
+	pr.requestStreamMutex.Unlock()
+
+	// If we block on this lock, it means `SendResponse` is writing to the channel, since we just closed
+	// `markReap`, it should release the lock soon and we can safely close the channel.
+	pr.sendMutex.Lock()
+	close(pr.responseStream)
+	pr.sendMutex.Unlock()
+
+	delete(r.resp, id)
 }

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -435,3 +435,43 @@ func TestGetRequestStreamTimeout(t *testing.T) {
 		t.Errorf("Expected empty data on timeout, got %d bytes", len(data))
 	}
 }
+
+func TestStopRelayRequestCleanup(t *testing.T) {
+	b := newBroker()
+	b.req["foo"] = make(chan *pb.HttpRequest, 1)
+	req := &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com")}
+
+	respChan, err := b.RelayRequest("foo", req)
+	if err != nil {
+		t.Fatalf("RelayRequest failed: %v", err)
+	}
+
+	// Verify request is in broker
+	b.m.Lock()
+	if _, ok := b.resp[idOne]; !ok {
+		b.m.Unlock()
+		t.Fatal("Request not found in broker")
+	}
+	b.m.Unlock()
+
+	// Stop the request
+	b.StopRelayRequest(idOne)
+
+	// Verify request is removed from broker
+	b.m.Lock()
+	if _, ok := b.resp[idOne]; ok {
+		b.m.Unlock()
+		t.Error("Request still found in broker after StopRelayRequest")
+	}
+	b.m.Unlock()
+
+	// Verify the response channel is closed
+	select {
+	case _, ok := <-respChan:
+		if ok {
+			t.Error("respChan not closed after StopRelayRequest")
+		}
+	case <-time.After(time.Second):
+		t.Error("Timed out waiting for respChan to close")
+	}
+}


### PR DESCRIPTION
When a request is stopped (e.g., if the user-client times out or closes the connection), StopRelayRequest was simply deleting the request from the internal map. However, it was not closing the associated responseStream and requestStream channels. This caused the goroutines ranging over these channels (started in Server.responseFilter and Server.bidirectionalStream) to block indefinitely, leading to a steady increase in goroutines and memory usage over time.

This change refactores the cleanup logic into a common removeRequest helper that explicitly closes all channels and signals the goroutines to exit before removing the request from the map. It ensures that resources are always reclaimed regardless of whether the request timed out or was explicitly stopped.

In addition this adds a new test to cover this and pprof support (so that we can easily identify similar cases in the future).