### PR TITLE
Replace gomega with regular go test mechanisms.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,7 +65,6 @@ use_repo(
     "com_github_jaypipes_ghw",
     "com_github_jaypipes_pcidb",
     "com_github_motemen_go_loghttp",
-    "com_github_onsi_gomega",
     "com_github_prometheus_client_golang",
     "com_github_spf13_cobra",
     "com_github_spf13_pflag",

--- a/src/go.mod
+++ b/src/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27
 	github.com/motemen/go-nuts v0.0.0-20220604134737-2658d0104f31 // indirect
-	github.com/onsi/gomega v1.39.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/src/go/cmd/cr-syncer/BUILD.bazel
+++ b/src/go/cmd/cr-syncer/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "@io_opencensus_go//tag:go_default_library",
         "@io_opencensus_go//zpages:go_default_library",
         "@io_opencensus_go_contrib_exporter_prometheus//:go_default_library",
-        "@org_golang_x_net//context:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
         "@org_golang_x_oauth2//google:go_default_library",
     ],
@@ -55,7 +54,6 @@ go_test(
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/client/clientset/clientset/fake:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/src/go/cmd/cr-syncer/main_test.go
+++ b/src/go/cmd/cr-syncer/main_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/gomega"
 	crdtypes "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	fakecrdclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,6 @@ import (
 )
 
 func TestStreamCrdsSeesPreexistingObject(t *testing.T) {
-	g := NewGomegaWithT(t)
 	items := []runtime.Object{
 		&crdtypes.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{
@@ -47,8 +45,12 @@ func TestStreamCrdsSeesPreexistingObject(t *testing.T) {
 		defer wg.Done()
 		select {
 		case crd := <-crds:
-			g.Expect(crd.Type).To(Equal(watch.Added))
-			g.Expect(crd.CRD.GetName()).To(Equal("foo"))
+			if crd.Type != watch.Added {
+				t.Errorf("crd.Type = %v; want %v", crd.Type, watch.Added)
+			}
+			if name := crd.CRD.GetName(); name != "foo" {
+				t.Errorf("crd.CRD.GetName() = %q; want %q", name, "foo")
+			}
 		case <-time.After(15 * time.Second):
 			t.Errorf("Received no watch event; wanted add for foo")
 		}
@@ -62,7 +64,6 @@ func TestStreamCrdsSeesPreexistingObject(t *testing.T) {
 
 func TestStreamCrdsSeesAdditionAndDeletion(t *testing.T) {
 	ctx := t.Context()
-	g := NewGomegaWithT(t)
 	cs := fakecrdclientset.NewSimpleClientset()
 
 	crds := make(chan CrdChange)
@@ -82,8 +83,12 @@ func TestStreamCrdsSeesAdditionAndDeletion(t *testing.T) {
 		metav1.CreateOptions{})
 	select {
 	case crd := <-crds:
-		g.Expect(crd.Type).To(Equal(watch.Added))
-		g.Expect(crd.CRD.GetName()).To(Equal("later"))
+		if crd.Type != watch.Added {
+			t.Errorf("crd.Type = %v; want %v", crd.Type, watch.Added)
+		}
+		if name := crd.CRD.GetName(); name != "later" {
+			t.Errorf("crd.CRD.GetName() = %q; want %q", name, "later")
+		}
 	case <-time.After(15 * time.Second):
 		t.Errorf("Received no watch event; wanted add for later")
 	}
@@ -91,8 +96,12 @@ func TestStreamCrdsSeesAdditionAndDeletion(t *testing.T) {
 	cs.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, "later", metav1.DeleteOptions{})
 	select {
 	case crd := <-crds:
-		g.Expect(crd.Type).To(Equal(watch.Deleted))
-		g.Expect(crd.CRD.GetName()).To(Equal("later"))
+		if crd.Type != watch.Deleted {
+			t.Errorf("crd.Type = %v; want %v", crd.Type, watch.Deleted)
+		}
+		if name := crd.CRD.GetName(); name != "later" {
+			t.Errorf("crd.CRD.GetName() = %q; want %q", name, "later")
+		}
 	case <-time.After(15 * time.Second):
 		t.Errorf("Received no watch event; wanted deleted for later")
 	}
@@ -100,7 +109,6 @@ func TestStreamCrdsSeesAdditionAndDeletion(t *testing.T) {
 
 func TestStreamCrdsSeesUpdate(t *testing.T) {
 	ctx := t.Context()
-	g := NewGomegaWithT(t)
 	cs := fakecrdclientset.NewSimpleClientset()
 
 	crds := make(chan CrdChange)
@@ -120,8 +128,12 @@ func TestStreamCrdsSeesUpdate(t *testing.T) {
 		metav1.CreateOptions{})
 	select {
 	case crd := <-crds:
-		g.Expect(crd.Type).To(Equal(watch.Added))
-		g.Expect(crd.CRD.GetName()).To(Equal("later"))
+		if crd.Type != watch.Added {
+			t.Errorf("crd.Type = %v; want %v", crd.Type, watch.Added)
+		}
+		if name := crd.CRD.GetName(); name != "later" {
+			t.Errorf("crd.CRD.GetName() = %q; want %q", name, "later")
+		}
 	case <-time.After(15 * time.Second):
 		t.Errorf("Received no watch event; wanted add for later")
 	}
@@ -138,8 +150,12 @@ func TestStreamCrdsSeesUpdate(t *testing.T) {
 		metav1.UpdateOptions{})
 	select {
 	case crd := <-crds:
-		g.Expect(crd.Type).To(Equal(watch.Modified))
-		g.Expect(crd.CRD.GetName()).To(Equal("later"))
+		if crd.Type != watch.Modified {
+			t.Errorf("crd.Type = %v; want %v", crd.Type, watch.Modified)
+		}
+		if name := crd.CRD.GetName(); name != "later" {
+			t.Errorf("crd.CRD.GetName() = %q; want %q", name, "later")
+		}
 	case <-time.After(15 * time.Second):
 		t.Errorf("Received no watch event; wanted modified for later")
 	}

--- a/src/go/cmd/http-relay-client/client/BUILD.bazel
+++ b/src/go/cmd/http-relay-client/client/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/proto/http-relay:go_default_library",
-        "@com_github_onsi_gomega//:go_default_library",
         "@in_gopkg_h2non_gock_v1//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],

--- a/src/go/cmd/http-relay-client/client/client_test.go
+++ b/src/go/cmd/http-relay-client/client/client_test.go
@@ -22,7 +22,6 @@ import (
 
 	pb "github.com/googlecloudrobotics/core/src/proto/http-relay"
 
-	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/h2non/gock.v1"
 )
@@ -213,7 +212,6 @@ func TestServerTimeout(t *testing.T) {
 }
 
 func TestBuildResponsesTimesOut(t *testing.T) {
-	g := NewGomegaWithT(t)
 	bodyChannel := make(chan []byte)
 	responseChannel := make(chan *pb.HttpResponse)
 	resp := &pb.HttpResponse{
@@ -226,20 +224,44 @@ func TestBuildResponsesTimesOut(t *testing.T) {
 	go client.buildResponses(bodyChannel, resp, responseChannel)
 	bodyChannel <- []byte("foo")
 	resp = <-responseChannel
-	g.Expect(*resp.Id).To(Equal("20"))
-	g.Expect(*resp.StatusCode).To(Equal(int32(200)))
-	g.Expect(string(resp.Body)).To(Equal("foo"))
-	g.Expect(resp.Eof).To(BeNil())
+	if got, want := resp.GetId(), "20"; got != want {
+		t.Errorf("resp.Id = %q; want %q", got, want)
+	}
+	if got, want := resp.GetStatusCode(), int32(200); got != want {
+		t.Errorf("resp.StatusCode = %d; want %d", got, want)
+	}
+	if got, want := string(resp.Body), "foo"; got != want {
+		t.Errorf("resp.Body = %q; want %q", got, want)
+	}
+	if resp.Eof != nil {
+		t.Errorf("resp.Eof = %v; want nil", *resp.Eof)
+	}
 	bodyChannel <- []byte("bar")
 	resp = <-responseChannel
-	g.Expect(*resp.Id).To(Equal("20"))
-	g.Expect(resp.StatusCode).To(BeNil())
-	g.Expect(string(resp.Body)).To(Equal("bar"))
-	g.Expect(resp.Eof).To(BeNil())
+	if got, want := resp.GetId(), "20"; got != want {
+		t.Errorf("resp.Id = %q; want %q", got, want)
+	}
+	if resp.StatusCode != nil {
+		t.Errorf("resp.StatusCode = %d; want nil", *resp.StatusCode)
+	}
+	if got, want := string(resp.Body), "bar"; got != want {
+		t.Errorf("resp.Body = %q; want %q", got, want)
+	}
+	if resp.Eof != nil {
+		t.Errorf("resp.Eof = %v; want nil", *resp.Eof)
+	}
 	close(bodyChannel)
 	resp = <-responseChannel
-	g.Expect(*resp.Id).To(Equal("20"))
-	g.Expect(resp.StatusCode).To(BeNil())
-	g.Expect(string(resp.Body)).To(Equal(""))
-	g.Expect(*resp.Eof).To(Equal(true))
+	if got, want := resp.GetId(), "20"; got != want {
+		t.Errorf("resp.Id = %q; want %q", got, want)
+	}
+	if resp.StatusCode != nil {
+		t.Errorf("resp.StatusCode = %d; want nil", *resp.StatusCode)
+	}
+	if got, want := string(resp.Body), ""; got != want {
+		t.Errorf("resp.Body = %q; want %q", got, want)
+	}
+	if resp.Eof == nil || !*resp.Eof {
+		t.Errorf("resp.Eof = %v; want true", resp.Eof)
+	}
 }

--- a/src/go/pkg/gcr/BUILD.bazel
+++ b/src/go/pkg/gcr/BUILD.bazel
@@ -25,5 +25,4 @@ go_test(
     srcs = ["update_gcr_credential_test.go"],
     embed = [":go_default_library"],
     visibility = ["//visibility:private"],
-    deps = ["@com_github_onsi_gomega//:go_default_library"],
 )

--- a/src/go/pkg/gcr/update_gcr_credential_test.go
+++ b/src/go/pkg/gcr/update_gcr_credential_test.go
@@ -15,13 +15,12 @@
 package gcr
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
-
-	. "github.com/onsi/gomega"
 )
 
 func TestDockercfgJSON(t *testing.T) {
-	g := NewGomegaWithT(t)
 	expectedJSON := `{
   "https://gcr.io":{"username":"oauth2accesstoken","password":"ya29.yaddayadda","email":"not@val.id","auth":"b2F1dGgyYWNjZXNzdG9rZW46eWEyOS55YWRkYXlhZGRh"},
   "https://asia.gcr.io":{"username":"oauth2accesstoken","password":"ya29.yaddayadda","email":"not@val.id","auth":"b2F1dGgyYWNjZXNzdG9rZW46eWEyOS55YWRkYXlhZGRh"},
@@ -31,5 +30,15 @@ func TestDockercfgJSON(t *testing.T) {
 
 	gotJSON := DockerCfgJSON("ya29.yaddayadda")
 
-	g.Expect(gotJSON).To(MatchJSON(expectedJSON))
+	var expected, got map[string]interface{}
+	if err := json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
+		t.Fatalf("failed to unmarshal expected JSON: %v", err)
+	}
+	if err := json.Unmarshal(gotJSON, &got); err != nil {
+		t.Fatalf("failed to unmarshal got JSON: %v", err)
+	}
+
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("JSONs do not match.\nExpected: %s\nGot: %s", expectedJSON, string(gotJSON))
+	}
 }


### PR DESCRIPTION
This was only used in 3 tests and while it is more verbose, it simplifies dependency management and aligns the tests.