### PR TITLE
Create service monitors for cert-manager

### DIFF
--- a/src/app_charts/base/cert-manager-cloud.values.yaml
+++ b/src/app_charts/base/cert-manager-cloud.values.yaml
@@ -11,3 +11,9 @@ installCRDs: true
 serviceAccount:
   annotations:
     iam.gke.io/gcp-service-account: cert-manager@PROJECT-ID.iam.gserviceaccount.com
+
+# Enable Prometheus metrics endpoints and ServiceMonitor resource creation
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true


### PR DESCRIPTION
The prometheus setup being used does not use k8s service discovery, but rather service monitor. Hence, we [enable the creation of cert-manager's ServiceMonitor](https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#prometheus) resource for monitoring certificate expiry:

We monitor cert-expiry based on cert-manager rather than on the ingress as not all certificates are used by the ingress.


```
certmanager_certificate_expiration_timestamp_seconds
```

```
 diff -u bazel-bin/src/app_charts/
base/cert-manager-chart.cloud.yaml bazel-bin/src/app_charts/base/cert-manager-chart.cloud.prom.yaml
--- bazel-bin/src/app_charts/base/cert-manager-chart.cloud.yaml 2026-07-01 05:28:28.564795896 +0000
+++ bazel-bin/src/app_charts/base/cert-manager-chart.cloud.prom.yaml    2026-07-01 05:27:31.596880318 +0000
@@ -13037,10 +13037,6 @@
         app.kubernetes.io/version: "v1.16.3"
         app.kubernetes.io/managed-by: Helm
         helm.sh/chart: cert-manager-v1.16.3
-      annotations:
-        prometheus.io/path: "/metrics"
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '9402'
     spec:
       serviceAccountName: cert-manager-cainjector
       enableServiceLinks: false
@@ -13104,10 +13100,6 @@
         app.kubernetes.io/version: "v1.16.3"
         app.kubernetes.io/managed-by: Helm
         helm.sh/chart: cert-manager-v1.16.3
-      annotations:
-        prometheus.io/path: "/metrics"
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '9402'
     spec:
       serviceAccountName: cert-manager
       enableServiceLinks: false
@@ -13199,10 +13191,6 @@
         app.kubernetes.io/version: "v1.16.3"
         app.kubernetes.io/managed-by: Helm
         helm.sh/chart: cert-manager-v1.16.3
-      annotations:
-        prometheus.io/path: "/metrics"
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '9402'
     spec:
       serviceAccountName: cert-manager-webhook
       enableServiceLinks: false
@@ -13308,6 +13296,48 @@
         namespace: HELM-NAMESPACE
         path: /mutate
 ---
+# Source: cert-manager/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cert-manager
+  namespace: HELM-NAMESPACE
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.16.3"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: cert-manager-v1.16.3
+    prometheus: default
+spec:
+  jobLabel: cert-manager
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+        - cainjector
+        - cert-manager
+        - webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+        - cert-manager
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        - cainjector
+        - controller
+        - webhook
+  endpoints:
+  - targetPort: 9402
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 30s
+    honorLabels: false
+---
```