### PR TITLE
We need to double the oauth2 proxy routes

### DIFF
--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -100,17 +100,19 @@ spec:
             port:
               name: http
 ---
+{{- range list "" "-auth" }}
+{{- $sectionName := "https" }}{{ if eq . "-auth" }}{{ $sectionName = "http" }}{{ end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: oauth2-proxy
+  name: oauth2-proxy{{ . }}
 spec:
   hostnames:
-  - {{ .Values.domain }}
+  - {{ $.Values.domain }}
   parentRefs:
-  - name: crc-gateway
+  - name: crc{{ . }}-gateway
     namespace: default
-    sectionName: https
+    sectionName: {{ $sectionName }}
   rules:
   - matches:
     - path:
@@ -129,14 +131,14 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: oauth2-proxy-interactive
+  name: oauth2-proxy-interactive{{ . }}
 spec:
   hostnames:
-  - {{ .Values.domain }}
+  - {{ $.Values.domain }}
   parentRefs:
-  - name: crc-gateway
+  - name: crc{{ . }}-gateway
     namespace: default
-    sectionName: https
+    sectionName: {{ $sectionName }}
   rules:
   - matches:
     - path:
@@ -146,6 +148,7 @@ spec:
     - name: oauth2-proxy
       port: 80
 ---
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:


### PR DESCRIPTION
When  extAuthz  finishes its check against  crc-auth-gateway  and approves a request by returning 200 OK (for instance, when calling /oauth2/userinfo with a valid session cookie, or accessing an authenticated endpoint under /web-apis ), Envoy at crc-gateway proceeds to forward the actual request.

oauth2-proxy-interactive  (/oauth2) and  oauth2-proxy (/web-apis): Tell crc-gateway where to send the physical HTTP request once authorization has succeeded. Without these routes on crc-gateway, approved requests would result in a  404 Not Found  at the public gateway layer.