### PR TITLE
Remove resource limits for shield; do not need to verify legacy nginx…

### DIFF
--- a/src/app_charts/base/cloud/nginx-ingress-controller-shield-configmap.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller-shield-configmap.yaml
@@ -345,6 +345,9 @@ data:
           # Set the SNI hostname to match the incoming client host header.
           proxy_ssl_name $host;
 
+          # Disable verification of the backend certificates.
+          proxy_ssl_verify off;
+
           # Force the proxy protocol to use HTTP/1.1 to match standard backend communication.
           proxy_http_version 1.1;
 
@@ -394,6 +397,9 @@ data:
 
           # Set the SNI hostname to match the client host.
           grpc_ssl_name $host;
+
+          # Disable validation of certificate of upstream gRPC backend.
+          grpc_ssl_verify off;
 
           # Pass Host header to backend.
           grpc_set_header Host $host;

--- a/src/app_charts/base/cloud/nginx-ingress-controller-shield.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller-shield.yaml
@@ -54,9 +54,6 @@ spec:
           requests:
             cpu: 50m
             memory: 64Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
@@ -92,9 +89,6 @@ spec:
           requests:
             cpu: "1"
             memory: 1Gi
-          limits:
-            cpu: "2"
-            memory: 2Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
- Remove resource limits for shield (worker process model don't play nice with CFS) ; 
- do not need to verify legacy nginx as we only have 1 upstream