### PR TITLE
Add a new annotation to temporarily bypass synk.

### DIFF
--- a/docs/concepts/app-management.md
+++ b/docs/concepts/app-management.md
@@ -110,3 +110,36 @@ During rollout, the chart-assignment-controller checks for Pods in the rollout b
 In some cases, this check is not necessary or might need to be opted out of.
 In this case, add a label `cloudrobotics.com/opt-out-error-checking=true` to your pods. Adding this
 instructs the chart-assignment-controller to not block the status from reaching `Ready`.
+
+## Development workflows: overriding resources
+
+During development, you might want to temporarily modify a resource (e.g. edit a
+Deployment's arguments or environment variables) that is managed by an `AppRollout`
+and `ChartAssignment`. By default, the `chart-assignment-controller` will detect
+these manual changes as drift and overwrite them to match the chart definition.
+
+To temporarily bypass this and prevent the controller from overwriting your changes:
+
+1. Edit the resource in the cluster (e.g., using `kubectl edit`).
+2. Add the annotation `synk.cloudrobotics.com/ignore: "true"` to the resource's metadata.
+3. Make your desired changes and save.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  annotations:
+    synk.cloudrobotics.com/ignore: "true"
+spec:
+  ...
+```
+
+When this annotation is present, the reconciliation library (`synk`) will skip
+updating the resource spec, but will still maintain its owner references so it
+does not get garbage collected. The resource will be reported with the `Ignored`
+action in the `ResourceSet` status.
+
+To revert to the state defined in the chart, simply remove the
+`synk.cloudrobotics.com/ignore` annotation (or set it to `"false"`). The next
+reconciliation will restore the original configuration.

--- a/src/go/pkg/apis/apps/v1alpha1/types.go
+++ b/src/go/pkg/apis/apps/v1alpha1/types.go
@@ -96,6 +96,7 @@ const (
 	ResourceActionCreate  ResourceAction = "Create"
 	ResourceActionUpdate  ResourceAction = "Update"
 	ResourceActionReplace ResourceAction = "Replace"
+	ResourceActionIgnored ResourceAction = "Ignored"
 )
 
 // +genclient

--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -57,6 +57,11 @@ import (
 // src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
 const totalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
 
+// Annotation to opt-out of resource synchronization. If set to "true" on a resource
+// in the cluster, Synk will not overwrite it with the chart version, but will still
+// update its owner references so it does not get pruned.
+const AnnotationIgnore = "synk.cloudrobotics.com/ignore"
+
 // Synk allows to synchronize sets of resources with a fixed cluster.
 type Synk struct {
 	discovery   discovery.CachedDiscoveryInterface
@@ -725,6 +730,24 @@ func (s *Synk) applyOne(ctx context.Context, resource *unstructured.Unstructured
 	}
 	if err := validateOwnerRefs(current, set); err != nil {
 		return apps.ResourceActionNone, fmt.Errorf("owner conflict: %w", err)
+	}
+
+	if set != nil && !isCustomResourceDefinition(current) && current.GetAnnotations()[AnnotationIgnore] == "true" {
+		// We are ignoring the desired spec change, but we must still update
+		// the owner reference on the current cluster resource to point to the
+		// new ResourceSet, otherwise it will be pruned when the old ResourceSet
+		// is deleted. We call setOwnerRef on 'current' (not 'resource') because
+		// we are updating the current cluster state directly instead of applying
+		// the desired resource.
+		setOwnerRef(current, set)
+		_, updateSpan := trace.StartSpan(ctx, "Update owner refs "+resource.GetName())
+		res, err := client.Update(ctx, current, metav1.UpdateOptions{})
+		updateSpan.End()
+		if err != nil {
+			return apps.ResourceActionIgnored, fmt.Errorf("update owner refs: %w", err)
+		}
+		*resource = *res
+		return apps.ResourceActionIgnored, nil
 	}
 
 	// Get what is running, what was installed and what we want to run.

--- a/src/go/pkg/synk/synk_test.go
+++ b/src/go/pkg/synk/synk_test.go
@@ -392,6 +392,84 @@ data:
 	f.verifyWriteActions()
 }
 
+func TestSynk_applyAllSkipsIgnoredResources(t *testing.T) {
+	var cmBefore corev1.ConfigMap
+	unmarshalYAML(t, &cmBefore, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: foo1
+  name: cm1
+  annotations:
+    synk.cloudrobotics.com/ignore: "true"
+data:
+  foo1: bar1`)
+	f := newFixture(t)
+	f.addObjects(&cmBefore)
+
+	// The updated resource we want to apply (from chart)
+	var cmUpdate corev1.ConfigMap
+	unmarshalYAML(t, &cmUpdate, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: foo1
+  name: cm1
+data:
+  foo1: baz1`) // Chart wants baz1, but we should ignore this and keep bar1
+	cm := toUnstructured(t, &cmUpdate)
+
+	set := &apps.ResourceSet{}
+	set.Name = "test.v1"
+	set.UID = "deadbeef"
+
+	results, err := f.newSynk().applyAll(t.Context(), set, &ApplyOptions{name: "test"},
+		cm.DeepCopy(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect an update action on the fake client.
+	// The object in the update action should be `cmBefore` (with data: foo1: bar1)
+	// but with owner references updated to point to `set`.
+	expectedCm := toUnstructured(t, &cmBefore)
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         "apps.cloudrobotics.com/v1alpha1",
+		Kind:               "ResourceSet",
+		Name:               set.Name,
+		UID:                set.UID,
+		BlockOwnerDeletion: new(true),
+	}
+	expectedCm.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+
+	f.expectActions(
+		k8stest.NewUpdateAction(gvrs["configmaps"], "foo1", expectedCm),
+	)
+	f.verifyWriteActions()
+
+	// Verify that the result returned by applyAll also reflects the ignored state
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	res, ok := results["/v1/ConfigMap/foo1/cm1"]
+	if !ok {
+		t.Fatalf("result for cm1 not found")
+	}
+	if res.err != nil {
+		t.Errorf("expected no error, got %s", res.err)
+	}
+	if res.action != apps.ResourceActionIgnored {
+		t.Errorf("expected action Ignored, got %s", res.action)
+	}
+	
+	// Check that the returned resource has the old data
+	val, _, _ := unstructured.NestedString(res.resource.Object, "data", "foo1")
+	if val != "bar1" {
+		t.Errorf("expected data.foo1 to be 'bar1' (ignored), but got %q", val)
+	}
+}
+
 func TestSynk_applyAllIsCreatingResources(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
This allows for a `kubectl edit` based workflow to make temporary changes, e.g. enable memory profiling.