### PR TITLE
🧱 base-cloud: Remove hostname restriction from crc-gateway listeners

### DIFF
--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -14,14 +14,12 @@ spec:
     type: IPAddress
   listeners:
   - name: http
-    hostname: {{ .Values.domain }}
     protocol: HTTP
     port: 80
     allowedRoutes:
       namespaces:
         from: All
   - name: https
-    hostname: {{ .Values.domain }}
     protocol: HTTPS
     port: 443
     tls:


### PR DESCRIPTION
Omit the hostname field in http and https listeners of the external crc-gateway to allow TLS handshakes without SNI.