### PR TITLE
🧱 base-cloud: Comment out hostname in external gateway listeners

### DIFF
--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -14,14 +14,14 @@ spec:
     type: IPAddress
   listeners:
   - name: http
-    hostname: {{ .Values.domain }}
+    # hostname: {{ .Values.domain }} # Uncomment to restrict this listener to the configured domain. Required if multiple Gateways share the same IP.
     protocol: HTTP
     port: 80
     allowedRoutes:
       namespaces:
         from: All
   - name: https
-    hostname: {{ .Values.domain }}
+    # hostname: {{ .Values.domain }} # Uncomment to restrict this listener to the configured domain. Required if multiple Gateways share the same IP (via SNI).
     protocol: HTTPS
     port: 443
     tls:


### PR DESCRIPTION
Comment out the hostname field in http and https listeners of the external crc-gateway.
This allows TLS handshakes without SNI by default, fixing issues with clients/proxies that do not send SNI.
Added comments explaining how to uncomment if host-based routing is needed (e.g. if multiple gateways share the same IP).

#### Why

Allow TLS handshakes without SNI by default to support more clients, while providing instructions to enable it if needed for multi-gateway setups.

#### The code changes include:

- Comment out hostname in http listener in base-cloud istio.yaml template.
- Comment out hostname in https listener in base-cloud istio.yaml template.

go/traj/7de9d91c-7964-436e-9be8-f6d4f8a308ab
TESTED=Manually tested
RELNOTES=NONE
TAG=agy
CONV=13a705e3-635c-4db8-aa9e-0ef4d8f0e30d