### PR TITLE
🐛 cr-syncer-auth-webhook: fallback to X-Envoy-Original-Path under path rewrites

### DIFF
--- a/src/go/cmd/cr-syncer-auth-webhook/main.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/main.go
@@ -109,10 +109,11 @@ func (h *handlers) resourceIsFiltered(groupKind string) bool {
 // validateRequest checks that the request is expected for the cr-syncer and
 // only accesses allowed resources.
 func (h *handlers) validateRequest(r *http.Request, robotName string) error {
-	urlString := r.Header.Get("X-Original-Url")
+	urlString := extractOriginalURL(r)
 	incomingReq, err := parseURL(urlString)
 	if err != nil {
-		slog.Error("unexpected value of X-Original-Url", slog.String("URL", urlString), ilog.Err(err))
+		slog.Error("unexpected value of origin URL header",
+			slog.String("URL", urlString), ilog.Err(err))
 		return err
 	}
 

--- a/src/go/cmd/cr-syncer-auth-webhook/request.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/request.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"slices"
@@ -28,6 +29,16 @@ type incomingRequest struct {
 
 	// ResourceName, or empty if no resource is specified (eg for a List or Watch of a filtered resource)
 	ResourceName string
+}
+
+// extractOriginalURL returns the raw origin URL or path from proxy headers.
+// Any scheme/host in X-Original-Url is stripped when passed to url.Parse(u).Path,
+// normalizing it to match X-Envoy-Original-Path.
+func extractOriginalURL(r *http.Request) string {
+	if u := r.Header.Get("X-Original-Url"); u != "" {
+		return u
+	}
+	return r.Header.Get("X-Envoy-Original-Path")
 }
 
 // parseURL parses the URL that the cr-syncer is hitting to find the

--- a/src/go/cmd/cr-syncer-auth-webhook/request_test.go
+++ b/src/go/cmd/cr-syncer-auth-webhook/request_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -97,6 +98,46 @@ func TestParseURLErrors(t *testing.T) {
 			_, err := parseURL(tc.url)
 			if err == nil {
 				t.Fatalf("parseURL(%q) succeeded unexpected", tc.url)
+			}
+		})
+	}
+}
+
+func TestExtractOriginalURL(t *testing.T) {
+	tests := []struct {
+		desc        string
+		originalURL string
+		envoyPath   string
+		want        string
+	}{
+		{
+			desc:        "prefers X-Original-Url when present",
+			originalURL: "http://host/apis/core.kubernetes/apis/apps/v1/deployments",
+			envoyPath:   "/apis/core.kubernetes/apis/apps/v1/deployments",
+			want:        "http://host/apis/core.kubernetes/apis/apps/v1/deployments",
+		},
+		{
+			desc:        "falls back to X-Envoy-Original-Path when X-Original-Url is empty",
+			originalURL: "",
+			envoyPath:   "/apis/core.kubernetes/apis/apps/v1/deployments",
+			want:        "/apis/core.kubernetes/apis/apps/v1/deployments",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/webhook", nil)
+			if err != nil {
+				t.Fatalf("http.NewRequest failed: %v", err)
+			}
+			if tc.originalURL != "" {
+				req.Header.Set("X-Original-Url", tc.originalURL)
+			}
+			if tc.envoyPath != "" {
+				req.Header.Set("X-Envoy-Original-Path", tc.envoyPath)
+			}
+			if got := extractOriginalURL(req); got != tc.want {
+				t.Errorf("extractOriginalURL() = %q, want %q", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Update validateRequest in cr-syncer-auth-webhook to check X-Envoy-Original-Path when X-Original-Url is empty.

#### Why

When cr-syncer-auth-webhook is deployed behind an Envoy-based Kubernetes Gateway (such as Istio or Gateway API with URLRewrite filters), Envoy strips `X-Original-Url` and preserves the original request path in `X-Envoy-Original-Path`. Because `cr-syncer-auth-webhook` checked only `X-Original-Url`, requests rewritten by Envoy resulted in an empty path (`""`) and were rejected with 400 Bad Request during certificate synchronization checks.

#### The code changes include:

- Introduce `extractOriginalURL` helper function in `main.go` to fall back to `X-Envoy-Original-Path` when `X-Original-Url` is empty.
- Update log message to `unexpected value of origin URL header` when URL parsing fails.