### PR TITLE
🐛 token-vendor: add bypass route on crc-auth-gateway for verify/oauth2 endpoints

### DIFF
--- a/src/app_charts/base/cloud/istio.yaml
+++ b/src/app_charts/base/cloud/istio.yaml
@@ -204,4 +204,18 @@ spec:
     targetPort: 8080
   selector:
     app: crc-auth-gateway-catchall-svc
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: catchall-svc-grant
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: app-token-vendor
+  to:
+  - group: ""
+    kind: Service
+    name: crc-auth-gateway-catchall-svc
 {{- end}}

--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -99,9 +99,15 @@ spec:
     sectionName: http
   rules:
   - backendRefs:
-    - name: status-echo
+    - name: crc-auth-gateway-catchall-svc
       namespace: default
-      port: 80
+      port: 8080
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          replaceFullPath: /status/200
+          type: ReplaceFullPath
     matches:
     - path:
         type: PathPrefix
@@ -112,6 +118,21 @@ spec:
     - path:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/token.oauth2
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: catchall-svc-grant-app-token-vendor
+  namespace: default
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: app-token-vendor
+  to:
+  - group: ""
+    kind: Service
+    name: crc-auth-gateway-catchall-svc
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant

--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -122,21 +122,6 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: catchall-svc-grant-app-token-vendor
-  namespace: default
-spec:
-  from:
-  - group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    namespace: app-token-vendor
-  to:
-  - group: ""
-    kind: Service
-    name: crc-auth-gateway-catchall-svc
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
-metadata:
   name: token-vendor-grant
 spec:
   from:

--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -86,6 +86,33 @@ spec:
         type: PathPrefix
         value: /apis/core.token-vendor/v1/token.oauth2
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: token-vendor-auth-bypass
+spec:
+  hostnames:
+  - {{ .Values.domain }}
+  parentRefs:
+  - name: crc-auth-gateway
+    namespace: default
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: status-echo
+      namespace: default
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /apis/core.token-vendor/v1/token.verify
+    - path:
+        type: PathPrefix
+        value: /apis/core.token-vendor/v1/jwt.verify
+    - path:
+        type: PathPrefix
+        value: /apis/core.token-vendor/v1/token.oauth2
+---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:


### PR DESCRIPTION
Add token-vendor-auth-bypass HTTPRoute on crc-auth-gateway routing to status-echo (200 OK) to prevent 404 responses during external authorization checks.

#### Why

When external authorization (`ext_authz`) verifies requests to `/apis/core.token-vendor/v1/token.oauth2`, `/token.verify`, or `/jwt.verify`, `crc-auth-gateway` previously lacked a matching route and fell back to `crc-auth-catch-all` (`404 Not Found`). Because `token-vendor` handles its own authentication for these endpoints, we add an `HTTPRoute` on `crc-auth-gateway` targeting `status-echo:80` (`200 OK`) so `crc-gateway` permits the request to reach the `token-vendor` service.

#### The code changes include:

- Add `HTTPRoute/token-vendor-auth-bypass` right between `token-vendor` and `token-vendor-grant` in `src/app_charts/token-vendor/cloud/http-route.yaml`.