### PR TITLE
Address continous memory growth in the http-relay server.

### DIFF
--- a/src/go/cmd/http-relay-server/main.go
+++ b/src/go/cmd/http-relay-server/main.go
@@ -49,6 +49,8 @@ var (
 		"the log message level required to be logged")
 	inactiveRequestTimeout = flag.Duration("inactive_request_timeout", server.DefaultInactiveRequestTimeout,
 		"Timeout for inactive requests. In particular, this sets a limit on how long the backend can wait before writing headers and the response status.")
+	inactiveBackendTimeout = flag.Duration("inactive_backend_timeout", server.DefaultInactiveBackendTimeout,
+		"Timeout for inactive backends. Backends (robots) that have not shown any activity for this duration will be cleaned up along with their metrics.")
 	pprofPort = flag.Int("pprof_port", 0, "If non-zero, serves pprof endpoints on this port.")
 )
 
@@ -84,6 +86,7 @@ func main() {
 		Port:                   *port,
 		BlockSize:              *blockSize,
 		InactiveRequestTimeout: *inactiveRequestTimeout,
+		InactiveBackendTimeout: *inactiveBackendTimeout,
 	})
 	server.Start(ctx)
 }

--- a/src/go/cmd/http-relay-server/server/broker.go
+++ b/src/go/cmd/http-relay-server/server/broker.go
@@ -127,15 +127,20 @@ func (e *RelayClientUnavailableError) Error() string {
 // Responses (resp) are mapped by stream id (randomly generated hex string).
 // There can be multiple concurrent transfers per relay-client, each identified
 // by a unique id query parameter.
+type backendState struct {
+	reqChan      chan *pb.HttpRequest
+	lastActivity time.Time
+}
+
 type broker struct {
 	m    sync.Mutex
-	req  map[string]chan *pb.HttpRequest
+	req  map[string]*backendState
 	resp map[string]*pendingResponse
 }
 
 func newBroker() *broker {
 	return &broker{
-		req:  make(map[string]chan *pb.HttpRequest),
+		req:  make(map[string]*backendState),
 		resp: make(map[string]*pendingResponse),
 	}
 }
@@ -158,11 +163,13 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 	}
 
 	r.m.Lock()
-	if r.req[server] == nil {
+	bs := r.req[server]
+	if bs == nil {
 		// If we haven't seen this relay client before, immediately return error.
 		r.m.Unlock()
 		return nil, &RelayClientUnavailableError{client: server}
 	}
+	bs.lastActivity = time.Now()
 	if r.resp[id] != nil {
 		r.m.Unlock()
 		return nil, fmt.Errorf("%w %s on server %s", ErrMultipleClients, id, server)
@@ -176,7 +183,7 @@ func (r *broker) RelayRequest(server string, request *pb.HttpRequest) (<-chan *p
 		requestPath:    targetUrl.Path,
 		markReap:       make(chan struct{}),
 	}
-	reqChan := r.req[server]
+	reqChan := bs.reqChan
 	respChan := r.resp[id].responseStream
 	r.m.Unlock()
 
@@ -207,12 +214,17 @@ func (r *broker) StopRelayRequest(requestId string) {
 // until a client makes a request.
 func (r *broker) GetRequest(ctx context.Context, server, path string) (*pb.HttpRequest, error) {
 	r.m.Lock()
-	if r.req[server] == nil {
+	bs := r.req[server]
+	if bs == nil {
 		// This happens when the relay-server started and a client connects before
 		// the relay-client connected.
-		r.req[server] = make(chan *pb.HttpRequest)
+		bs = &backendState{
+			reqChan: make(chan *pb.HttpRequest),
+		}
+		r.req[server] = bs
 	}
-	reqChan := r.req[server]
+	bs.lastActivity = time.Now()
+	reqChan := bs.reqChan
 	r.m.Unlock()
 
 	brokerRequests.WithLabelValues("server_request", server).Inc()
@@ -298,6 +310,9 @@ func (r *broker) SendResponse(resp *pb.HttpResponse) error {
 	} else {
 		pr.lastActivity = time.Now()
 	}
+	if bs := r.req[backendName]; bs != nil {
+		bs.lastActivity = time.Now()
+	}
 	duration := time.Since(pr.startTime).Seconds()
 	// Release the lock on the broker before we write to `responseStream` so it does not
 	// block other requests.
@@ -358,4 +373,33 @@ func (r *broker) removeRequest(id string, pr *pendingResponse) {
 	pr.sendMutex.Unlock()
 
 	delete(r.resp, id)
+}
+
+func (r *broker) ReapInactiveBackends(threshold time.Time) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	for server, bs := range r.req {
+		if bs.lastActivity.Before(threshold) {
+			slog.Info("Timeout on inactive backend", slog.String("ServerName", server))
+			
+			// Delete metrics
+			brokerRequests.DeleteLabelValues("client", server)
+			brokerRequests.DeleteLabelValues("server_request", server)
+			brokerRequests.DeleteLabelValues("server_response", server)
+			
+			brokerResponses.DeleteLabelValues("client", "missing_message", server)
+			brokerResponses.DeleteLabelValues("client", "missing_header", server)
+			brokerResponses.DeleteLabelValues("client", "ok", server)
+			brokerResponses.DeleteLabelValues("server_request", "ok", server)
+			brokerResponses.DeleteLabelValues("server_request", "timeout", server)
+			brokerResponses.DeleteLabelValues("server_response", "ok", server)
+			brokerResponses.DeleteLabelValues("server_response", "not recognized or reaches the inactivity timeout", server)
+			
+			brokerResponseDurations.DeleteLabelValues("server_response", server)
+			brokerBackendResponseDurations.DeleteLabelValues("server_response", server)
+			brokerOverheadDurations.DeleteLabelValues("server_response", server)
+
+			delete(r.req, server)
+		}
+	}
 }

--- a/src/go/cmd/http-relay-server/server/broker_test.go
+++ b/src/go/cmd/http-relay-server/server/broker_test.go
@@ -85,7 +85,7 @@ func (bt *brokerConn) bakeRequest(b *broker, s string) {
 	// ensure that the request is created before the user client connects
 	b.m.Lock()
 	if _, found := b.req[s]; !found {
-		b.req[s] = make(chan *pb.HttpRequest)
+		b.req[s] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
 	}
 	b.m.Unlock()
 	close(bt.ready)
@@ -245,7 +245,7 @@ func TestTimeout(t *testing.T) {
 	b := newBroker()
 	// create the request channel manually to avoid race condition between the 2
 	// goroutines below
-	b.req["foo"] = make(chan *pb.HttpRequest)
+	b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -273,7 +273,7 @@ func TestTimeout(t *testing.T) {
 func TestReapWhileSendingResponse(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		b := newBroker()
-		b.req["foo"] = make(chan *pb.HttpRequest)
+		b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
 
 		// create a broker connection between the user client and backend side, but don't
 		// start sending data. "req" is backend side and "resp" is user client side.
@@ -322,7 +322,7 @@ func TestReapWhileSendingResponse(t *testing.T) {
 func TestReapWhileSendingRequest(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		b := newBroker()
-		b.req["foo"] = make(chan *pb.HttpRequest)
+		b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
 
 		// create a broker connection between the user client and backend side, but don't
 		// start sending data. "req" is backend side and "resp" is user client side.
@@ -381,7 +381,7 @@ func TestRelayRequestUrlParseError(t *testing.T) {
 
 func TestRelayRequestMultipleClients(t *testing.T) {
 	b := newBroker()
-	b.req["foo"] = make(chan *pb.HttpRequest, 1)
+	b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest, 1), lastActivity: time.Now()}
 	req1 := &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com")}
 	_, err := b.RelayRequest("foo", req1)
 	if err != nil {
@@ -412,7 +412,7 @@ func TestRelayRequestRelayTimeout(t *testing.T) {
 	}
 	b := newBroker()
 	// Create an unbuffered channel and don't read from it to trigger timeout.
-	b.req["foo"] = make(chan *pb.HttpRequest)
+	b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
 	req := &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com")}
 
 	_, err := b.RelayRequest("foo", req)
@@ -426,7 +426,7 @@ func TestGetRequestStreamTimeout(t *testing.T) {
 		t.Skip("Skipping slow timeout test")
 	}
 	b := newBroker()
-	b.req["foo"] = make(chan *pb.HttpRequest, 1) // make it block
+	b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest, 1), lastActivity: time.Now()} // make it block
 	req := &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com")}
 	b.RelayRequest("foo", req)
 
@@ -441,7 +441,7 @@ func TestGetRequestStreamTimeout(t *testing.T) {
 
 func TestStopRelayRequestCleanup(t *testing.T) {
 	b := newBroker()
-	b.req["foo"] = make(chan *pb.HttpRequest, 1)
+	b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest, 1), lastActivity: time.Now()}
 	req := &pb.HttpRequest{Id: proto.String(idOne), Url: proto.String("http://example.com")}
 
 	respChan, err := b.RelayRequest("foo", req)
@@ -476,5 +476,38 @@ func TestStopRelayRequestCleanup(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Error("Timed out waiting for respChan to close")
+	}
+}
+
+func TestReapInactiveBackends(t *testing.T) {
+	b := newBroker()
+	
+	// Create an active backend
+	b.req["active"] = &backendState{
+		reqChan:      make(chan *pb.HttpRequest),
+		lastActivity: time.Now(),
+	}
+	
+	// Create an inactive backend
+	b.req["inactive"] = &backendState{
+		reqChan:      make(chan *pb.HttpRequest),
+		lastActivity: time.Now().Add(-15 * time.Minute),
+	}
+
+	// Record some metrics for both to ensure deletion doesn't panic
+	brokerRequests.WithLabelValues("client", "active").Inc()
+	brokerRequests.WithLabelValues("client", "inactive").Inc()
+
+	// Reap backends inactive for more than 10 minutes
+	b.ReapInactiveBackends(time.Now().Add(-10 * time.Minute))
+
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	if _, ok := b.req["active"]; !ok {
+		t.Error("Active backend was incorrectly reaped")
+	}
+	if _, ok := b.req["inactive"]; ok {
+		t.Error("Inactive backend was not reaped")
 	}
 }

--- a/src/go/cmd/http-relay-server/server/server.go
+++ b/src/go/cmd/http-relay-server/server/server.go
@@ -62,6 +62,8 @@ const (
 	DefaultBlockSize = 10 * 1024
 	// DefaultInactiveRequestTimeout is the default timeout for inactive requests. In particular, this sets a limit on how long the backend can wait before writing headers and the response status.
 	DefaultInactiveRequestTimeout = 60 * time.Second
+	// DefaultInactiveBackendTimeout is the default timeout for inactive backends.
+	DefaultInactiveBackendTimeout = 30 * time.Minute
 )
 
 type Config struct {
@@ -71,6 +73,8 @@ type Config struct {
 	BlockSize int
 	// InactiveRequestTimeout is the timeout for inactive requests.
 	InactiveRequestTimeout time.Duration
+	// InactiveBackendTimeout is the timeout for inactive backends.
+	InactiveBackendTimeout time.Duration
 }
 
 type Server struct {
@@ -87,6 +91,9 @@ func NewServer(conf Config) *Server {
 	}
 	if conf.InactiveRequestTimeout == 0 {
 		conf.InactiveRequestTimeout = DefaultInactiveRequestTimeout
+	}
+	if conf.InactiveBackendTimeout == 0 {
+		conf.InactiveBackendTimeout = DefaultInactiveBackendTimeout
 	}
 	s := &Server{
 		conf: conf,
@@ -579,6 +586,8 @@ func (s *Server) StartOnListener(ctx context.Context, ln net.Listener) {
 				return nil
 			case t := <-ticker.C:
 				s.b.ReapInactiveRequests(t.Add(-1 * s.conf.InactiveRequestTimeout))
+				// Reap backends that have been inactive for InactiveBackendTimeout.
+				s.b.ReapInactiveBackends(t.Add(-1 * s.conf.InactiveBackendTimeout))
 			}
 		}
 	})

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -439,7 +439,7 @@ func TestServerRequestResponseHandler(t *testing.T) {
 	}()
 
 	// create the request channel to avoid 503 error for unknown clients.
-	server.b.req["b"] = make(chan *pb.HttpRequest)
+	server.b.req["b"] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
 	serverRespChan, err := server.b.RelayRequest("b", backendReq)
 	if err != nil {
 		t.Errorf("Got relay request error: %v", err)


### PR DESCRIPTION
The  pprof  heap profile confirmed that a large amount of memory was held by Prometheus metrics (histograms and counters). These metrics use the backend label (which corresponds to the robot name). In integration testing environments where robots are frequently created and deleted, the number of unique backend label values grows indefinitely. Since Prometheus metrics are never automatically cleaned up, this causes a persistent memory leak.

This change implementes a cleanup mechanism for inactive backends:
1. Activity Tracking: The  broker  now tracks the  lastActivity  time for each backend (in broker.go).
1. Periodic Cleanup: The server now periodically (every 10 seconds) calls ReapInactiveBackends  (in server.go).
1. Metrics Deletion: If a backend has been inactive for more than 30 minutes (configurable via flag), it is removed from the broker's internal map, and all its associated Prometheus metrics are deleted from the registry.