### PR TITLE
🐛 token-vendor: replace non-existent app-prometheus-relay with app-prometheus in token-vendor-grant

### DIFF
--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -130,9 +130,6 @@ spec:
     namespace: app-k8s-relay
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
-    namespace: app-prometheus-relay
-  - group: gateway.networking.k8s.io
-    kind: HTTPRoute
     namespace: app-prometheus
   to:
   - group: ""

--- a/src/app_charts/token-vendor/cloud/http-route.yaml
+++ b/src/app_charts/token-vendor/cloud/http-route.yaml
@@ -131,6 +131,9 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     namespace: app-prometheus-relay
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: app-prometheus
   to:
   - group: ""
     kind: Service


### PR DESCRIPTION
Replace the non-existent `app-prometheus-relay` namespace with `app-prometheus` in `token-vendor-grant` (`ReferenceGrant`) to permit cross-namespace Gateway API routes originating from `prometheus-relay-server-auth` (`HTTPRoute`) in `app-prometheus`.

#### Why

The `app-prometheus-relay` namespace does not exist in the codebase. `prometheus-relay-server-auth` (`HTTPRoute`) runs directly in namespace `app-prometheus`. Replacing the incorrect namespace fixes `backendRef token-vendor/app-token-vendor not accessible to a HTTPRoute in namespace "app-prometheus" (missing a ReferenceGrant?)`.

#### The code changes include:

- Replace `app-prometheus-relay` with `app-prometheus` inside `spec.from` of `token-vendor-grant` (`src/app_charts/token-vendor/cloud/http-route.yaml`).

go/traj/9d82abaf-9e10-4a86-8ced-4ed6cc528b87
TESTED=on private cluster
RELNOTES=NONE
TAG=agy
CONV=31856ea3-b5df-4ef7-ad44-192d5caa0722
Assignees: Tobias-Pe
Pull Request: https://github.com/googlecloudrobotics/core/pull/790
