### PR TITLE
🐛 gateway: Add trailing slash to path prefix matches to avoid double slashes with ReplacePrefixMatch

### DIFF
--- a/src/app_charts/base/cloud/kubernetes-api.yaml
+++ b/src/app_charts/base/cloud/kubernetes-api.yaml
@@ -41,7 +41,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /apis/core.kubernetes
+        value: /apis/core.kubernetes/
 {{- if eq . "-auth" }}
     filters:
     - type: URLRewrite

--- a/src/app_charts/prometheus/cloud/grafana-http-route.yaml
+++ b/src/app_charts/prometheus/cloud/grafana-http-route.yaml
@@ -17,7 +17,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /grafana
+        value: /grafana/
 {{- if eq . "-auth" }}
 {{- $authUrl := urlParse (tpl $.Values.gf_ingress_auth_url $) }}
 {{- $authUrlHeader := $.Values.gf_ingress_auth_url_header }}

--- a/src/app_charts/prometheus/cloud/prometheus-http-route.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-http-route.yaml
@@ -17,7 +17,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /prometheus
+        value: /prometheus/
 {{- if eq . "-auth" }}
 {{- $authUrl := urlParse (tpl $.Values.prom_ingress_auth_url $) }}
 {{- $authUrlHeader := $.Values.prom_ingress_auth_url_header }}


### PR DESCRIPTION
Ensure PathPrefix match values for kubernetes-api, grafana, and prometheus end in a trailing slash so URLRewrite ReplacePrefixMatch: / produces clean single-slash paths instead of double slashes.

#### Why

Fix double slashes (//apis/...) in HTTP/2 requests when ReplacePrefixMatch: / is applied to prefixes without trailing slashes

#### The code changes include:

- Add trailing slash `/apis/core.kubernetes/` to `kubernetes-api.yaml` PathPrefix match to prevent `//apis/...` when `ReplacePrefixMatch: /` rewrites the path.
- Add trailing slash `/grafana/` to `grafana-http-route.yaml` PathPrefix match to prevent `//` on Grafana API subpaths.
- Add trailing slash `/prometheus/` to `prometheus-http-route.yaml` PathPrefix match to prevent `//` on Prometheus API subpaths.

go/traj/f521d819-4257-4a9b-b9f8-53bfa47865e8
TESTED=on private cluster
RELNOTES=NONE
TAG=agy
CONV=83b810ff-8c02-4bfd-a194-1057ee54b528

Pull Request: https://github.com/googlecloudrobotics/core/pull/794