### PR TITLE
Set cluster upgrade timeout based on node count

### DIFF
--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -151,6 +151,10 @@ resource "google_container_node_pool" "cloud_robotics_base_pool" {
       "https://www.googleapis.com/auth/userinfo.email",
     ]
   }
+
+  timeouts {
+    update = "${var.max_node_count * 10}m"
+  }
 }
 
 resource "google_container_node_pool" "cloud_robotics_base_pool_ar" {
@@ -179,6 +183,10 @@ resource "google_container_node_pool" "cloud_robotics_base_pool_ar" {
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/userinfo.email",
     ]
+  }
+
+  timeouts {
+    update = "${var.max_node_count * 10}m"
   }
 }
 


### PR DESCRIPTION
Sometimes when upgrading a large number of nodes it may exceed the default timeout of 1h.