### PR TITLE
Move the validator code in approllout to own file

### DIFF
--- a/src/app_charts/base/BUILD.bazel
+++ b/src/app_charts/base/BUILD.bazel
@@ -92,7 +92,6 @@ helm_template(
     values = "cert-manager-cloud.values.yaml",
 )
 
-
 helm_template(
     name = "chart-assignment-controller-chart.cloud",
     chart = "//src/app_charts/chart-assignment-controller",
@@ -102,6 +101,7 @@ helm_template(
     release_name = "chart-assignment-controller",
     values = "chart-assignment-controller-cloud.values.yaml",
 )
+
 app_chart(
     name = "base-cloud",
     extra_templates = [

--- a/src/app_charts/chart-assignment-controller/BUILD.bazel
+++ b/src/app_charts/chart-assignment-controller/BUILD.bazel
@@ -15,9 +15,9 @@ oci_push(
 helm_chart(
     name = "chart-assignment-controller",
     chart = "Chart.yaml",
-    values = "values.yaml",
     images = [":push-image"],
     stamp = 1,
+    values = "values.yaml",
 )
 
 helm_push(

--- a/src/go/pkg/controller/approllout/BUILD.bazel
+++ b/src/go/pkg/controller/approllout/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["controller.go"],
+    srcs = [
+        "controller.go",
+        "validator.go",
+    ],
     importpath = "github.com/googlecloudrobotics/core/src/go/pkg/controller/approllout",
     visibility = ["//visibility:public"],
     deps = [
@@ -33,7 +36,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["controller_test.go"],
+    srcs = [
+        "controller_test.go",
+        "validator_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//src/go/pkg/apis/apps/v1alpha1:go_default_library",

--- a/src/go/pkg/controller/approllout/controller.go
+++ b/src/go/pkg/controller/approllout/controller.go
@@ -20,10 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"reflect"
 	"sort"
-	"strings"
 	"time"
 
 	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
@@ -31,11 +29,8 @@ import (
 	"github.com/googlecloudrobotics/ilog"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/helm/pkg/chartutil"
@@ -46,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/yaml"
 )
 
@@ -666,10 +660,6 @@ func chartAssignmentName(rollout string, typ componentType, robot string) string
 	return fmt.Sprintf("%s-%s", rollout, typ)
 }
 
-
-
-
-
 func setLabel(o *metav1.ObjectMeta, k, v string) {
 	if o.Labels == nil {
 		o.Labels = map[string]string{}
@@ -708,129 +698,4 @@ func indexOwnerReferences(o kclient.Object) (vs []string) {
 func indexAppName(o kclient.Object) []string {
 	ar := o.(*apps.AppRollout)
 	return []string{ar.Spec.AppName}
-}
-
-const (
-	// canonical name of an app
-	labelAppName = "cloudrobotics.com/app-name"
-	// version of that app. Note, the default version of the app has
-	// a version label of ""
-	labelAppVersion = "cloudrobotics.com/app-version"
-)
-
-// NewAppValidationWebhook returns a new webhook that validates Apps.
-//
-// This pertains to multiple versions of the same app, so that the labels
-// defined above are in sync with the name of the App.
-// The policy is
-// - an unversioned app defines
-//   - cloudrobotics.com/app-name
-//   - (optionally): cloudrobotics.com/app-version with a "" value
-//     this must match the name of the object
-//
-// - a versioned app defines
-//   - cloudrobotics.com/app-name
-//   - cloudrobotics.com/app-version
-//     the name of the App object must match LOWERCASE([app-name].v[app-version])
-func NewAppValidationWebhook(mgr manager.Manager) *admission.Webhook {
-	return &admission.Webhook{Handler: newAppValidator(mgr.GetScheme())}
-}
-
-// appValidator implements a validation webhook.
-type appValidator struct {
-	decoder runtime.Decoder
-}
-
-func newAppValidator(sc *runtime.Scheme) *appValidator {
-	return &appValidator{
-		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
-	}
-}
-
-func (v *appValidator) Handle(_ context.Context, req admission.Request) admission.Response {
-	cur := &apps.App{}
-	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	if err := appValidate(cur); err != nil {
-		return admission.Denied(err.Error())
-	}
-	return admission.Allowed("")
-}
-
-func appValidate(cur *apps.App) error {
-	name := cur.Name
-	appName, anok := cur.Labels[labelAppName]
-	appVersion, avok := cur.Labels[labelAppVersion]
-	if anok {
-		if avok && appVersion != "" {
-			// both name and version are defined
-			ename := strings.ToLower(fmt.Sprintf("%s.v%s", appName, appVersion))
-			if ename != name {
-				return fmt.Errorf("%q=%q, %q=%q: expected object name %q, got %q", labelAppName, appName, labelAppVersion, appVersion, ename, name)
-			}
-		} else {
-			// only name is defined
-			if appName != name {
-				return fmt.Errorf("%q=%q, undefined %q: expected object name %q, got %q", labelAppName, appName, labelAppVersion, appName, name)
-			}
-		}
-	}
-	// neither is defined, we're dealing with a legacy app
-	return nil
-}
-
-// NewAppRolloutValidationWebhook returns a new webhook that validates AppRollouts.
-func NewAppRolloutValidationWebhook(mgr manager.Manager) *admission.Webhook {
-	return &admission.Webhook{Handler: newAppRolloutValidator(mgr.GetScheme())}
-}
-
-// appRolloutValidator implements a validation webhook.
-type appRolloutValidator struct {
-	decoder runtime.Decoder
-}
-
-func newAppRolloutValidator(sc *runtime.Scheme) *appRolloutValidator {
-	return &appRolloutValidator{
-		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
-	}
-}
-
-func (v *appRolloutValidator) Handle(_ context.Context, req admission.Request) admission.Response {
-	cur := &apps.AppRollout{}
-
-	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	if err := appRolloutValidate(cur); err != nil {
-		return admission.Denied(err.Error())
-	}
-	return admission.Allowed("")
-}
-
-func appRolloutValidate(cur *apps.AppRollout) error {
-	if cur.Spec.AppName == "" {
-		return fmt.Errorf("spec.appName is missing for AppRollout %q", cur.Name)
-	}
-	errs := validation.NameIsDNSSubdomain(cur.Spec.AppName, false)
-	if len(errs) > 0 {
-		return fmt.Errorf("validate app name: %s", strings.Join(errs, ", "))
-	}
-	if _, ok := cur.Spec.Cloud.Values["robots"]; ok {
-		return fmt.Errorf(".spec.cloud.values.robots is a reserved field and must not be set")
-	}
-	for i, r := range cur.Spec.Robots {
-		if _, ok := r.Values["robot"]; ok {
-			return fmt.Errorf(".spec.robots[].values.robot is a reserved field and must not be set")
-		}
-		if r.Selector == nil {
-			return fmt.Errorf("no selector provided for robots %d", i)
-		}
-		// Reject if a selector has neither a matcher nor `any` set.
-		// This mostly helps catching missing `matchLabels`.
-		if r.Selector.Any == nil && r.Selector.LabelSelector == nil {
-			return fmt.Errorf("empty selector for robots %d (matchLabels not specified?)", i)
-		}
-	}
-	return nil
 }

--- a/src/go/pkg/controller/approllout/controller_test.go
+++ b/src/go/pkg/controller/approllout/controller_test.go
@@ -15,25 +15,20 @@
 package approllout
 
 import (
-	"encoding/json"
-	"net/http"
 	"strings"
 	"testing"
 
 	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
 	registry "github.com/googlecloudrobotics/core/src/go/pkg/apis/registry/v1alpha1"
-	admissionv1 "k8s.io/api/admission/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/helm/pkg/chartutil"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/yaml"
 )
 
@@ -673,201 +668,6 @@ status:
 	}
 }
 
-func TestValidateAppRollout(t *testing.T) {
-	cases := []struct {
-		name       string
-		cur        string
-		shouldFail bool
-	}{
-		{
-			name: "valid-all",
-			cur: `
-spec:
-  appName: myapp
-  cloud:
-    values:
-      a: 2
-      b: {c: 3}
-  robots:
-  - selector:
-      any: true
-    values:
-      c: d
-  - selector:
-      matchLabels:
-        abc: def
-        foo: bar
-  - selector:
-      matchExpressions:
-      - {key: foo, Op: DoesExist}
-	`,
-		},
-		{
-			name: "valid-app-name-only",
-			cur: `
-spec:
-  appName: my-app.123
-	`,
-		},
-		{
-			name:       "missing-app-name",
-			cur:        `spec: {}`,
-			shouldFail: true,
-		},
-		{
-			name: "invalid-app-name",
-			cur: `
-spec:
-  appName: my%app
-	`,
-			shouldFail: true,
-		},
-		{
-			name: "missing-robot-selector",
-			cur: `
-spec:
-  appName: myapp
-  robots:
-  - values:
-      a: b
-	`,
-			shouldFail: true,
-		},
-		{
-			name: "wrong-selector",
-			cur: `
-spec:
-  appName: myapp
-  robots:
-  - selector:
-      a: b
-	`,
-			shouldFail: true,
-		},
-		{
-			name: "cloud-values-Robots",
-			cur: `
-spec:
-  appName: myapp
-  cloud:
-    values:
-      robots:
-        c: d
-	`,
-			shouldFail: true,
-		},
-		{
-			name: "robot-values-robot",
-			cur: `
-spec:
-  appName: myapp
-  robots:
-  - selector:
-      any: true
-    values:
-      robot:
-        c: d
-	`,
-			shouldFail: true,
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			var cur apps.AppRollout
-			unmarshalYAML(t, &cur, c.cur)
-
-			err := appRolloutValidate(&cur)
-			if err == nil && c.shouldFail {
-				t.Fatal("expected failure but got none")
-			}
-			if err != nil && !c.shouldFail {
-				t.Fatalf("unexpected error: %s", err)
-			}
-		})
-	}
-}
-
-// TestValidateApp tests all the labels and mechanism for the apps
-func TestValidateApp(t *testing.T) {
-	cases := []struct {
-		name       string
-		cur        string
-		shouldFail bool
-	}{
-		{
-			name: "valid",
-			cur: `
-metadata:
-  name: app
-	`,
-		},
-		{
-			name: "valid-app-label-only",
-			cur: `
-metadata:
-  name: app
-  labels:
-    cloudrobotics.com/app-name: app
-	`,
-		},
-		{
-			name: "valid-both-labels",
-			cur: `
-metadata:
-  name: app.v17
-  labels:
-    cloudrobotics.com/app-name: app
-    cloudrobotics.com/app-version: 17
-	`,
-		},
-		{
-			name: "valid-both-labels-lower",
-			cur: `
-metadata:
-  name: app.v17rc00
-  labels:
-    cloudrobotics.com/app-name: app
-    cloudrobotics.com/app-version: 17RC00
-	`,
-		},
-		{
-			name:       "invalid-app-label-only",
-			shouldFail: true,
-			cur: `
-metadata:
-  name: app2
-  labels:
-    cloudrobotics.com/app-name: app
-	`,
-		},
-		{
-			name:       "invalid-both-labels",
-			shouldFail: true,
-			cur: `
-metadata:
-  name: app.v17rc10
-  labels:
-    cloudrobotics.com/app-name: app
-    cloudrobotics.com/app-version: 17RC00
-	`,
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			var cur apps.App
-			unmarshalYAML(t, &cur, c.cur)
-
-			err := appValidate(&cur)
-			if err == nil && c.shouldFail {
-				t.Fatal("expected failure but got none")
-			}
-			if err != nil && !c.shouldFail {
-				t.Fatalf("unexpected error: %s", err)
-			}
-		})
-	}
-}
-
 func TestReconciler_Reconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	apps.AddToScheme(scheme)
@@ -1074,149 +874,6 @@ func TestReconciler_Reconcile(t *testing.T) {
 	}
 }
 
-func TestAppValidator_Handle(t *testing.T) {
-	scheme := runtime.NewScheme()
-	apps.AddToScheme(scheme)
-
-	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
-	v := &appValidator{decoder: decoder}
-
-	tests := []struct {
-		name       string
-		req        admission.Request
-		wantAllow  bool
-		wantStatus int32
-	}{
-		{
-			name: "DecodeError",
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Object: runtime.RawExtension{Raw: []byte("invalid json")},
-				},
-			},
-			wantAllow:  false,
-			wantStatus: http.StatusBadRequest,
-		},
-		{
-			name: "Allowed",
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Object: runtime.RawExtension{
-						Raw: mustMarshal(&apps.App{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "myapp",
-								Labels: map[string]string{
-									labelAppName: "myapp",
-								},
-							},
-						}),
-					},
-				},
-			},
-			wantAllow: true,
-		},
-		{
-			name: "Denied_ValidationFailure",
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Object: runtime.RawExtension{
-						Raw: mustMarshal(&apps.App{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "myapp-invalid-name",
-								Labels: map[string]string{
-									labelAppName: "myapp",
-								},
-							},
-						}),
-					},
-				},
-			},
-			wantAllow: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			resp := v.Handle(t.Context(), tc.req)
-			if resp.Allowed != tc.wantAllow {
-				t.Errorf("Handle() allowed = %v, want %v. Message: %s", resp.Allowed, tc.wantAllow, resp.Result.Message)
-			}
-			if tc.wantStatus != 0 && resp.Result.Code != tc.wantStatus {
-				t.Errorf("Handle() status code = %d, want %d", resp.Result.Code, tc.wantStatus)
-			}
-		})
-	}
-}
-
-func TestAppRolloutValidator_Handle(t *testing.T) {
-	scheme := runtime.NewScheme()
-	apps.AddToScheme(scheme)
-
-	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
-	v := &appRolloutValidator{decoder: decoder}
-
-	tests := []struct {
-		name      string
-		req       admission.Request
-		wantAllow bool
-	}{
-		{
-			name: "DecodeError",
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Object: runtime.RawExtension{Raw: []byte("invalid json")},
-				},
-			},
-			wantAllow: false,
-		},
-		{
-			name: "Allowed",
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Object: runtime.RawExtension{
-						Raw: mustMarshal(&apps.AppRollout{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-rollout",
-							},
-							Spec: apps.AppRolloutSpec{
-								AppName: "my-app",
-							},
-						}),
-					},
-				},
-			},
-			wantAllow: true,
-		},
-		{
-			name: "Denied_ValidationFailure",
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Object: runtime.RawExtension{
-						Raw: mustMarshal(&apps.AppRollout{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-rollout",
-							},
-							Spec: apps.AppRolloutSpec{
-								AppName: "", // Missing app name
-							},
-						}),
-					},
-				},
-			},
-			wantAllow: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			resp := v.Handle(t.Context(), tc.req)
-			if resp.Allowed != tc.wantAllow {
-				t.Errorf("Handle() allowed = %v, want %v. Message: %s", resp.Allowed, tc.wantAllow, resp.Result.Message)
-			}
-		})
-	}
-}
-
 func TestReconciler_EnqueueHelpers(t *testing.T) {
 	scheme := runtime.NewScheme()
 	apps.AddToScheme(scheme)
@@ -1284,12 +941,4 @@ func TestReconciler_EnqueueHelpers(t *testing.T) {
 		t.Errorf("Expected enqueued rollout 'owner-rollout', got %q", req2.Name)
 	}
 	q2.Done(req2)
-}
-
-func mustMarshal(v interface{}) []byte {
-	b, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return b
 }

--- a/src/go/pkg/controller/approllout/validator.go
+++ b/src/go/pkg/controller/approllout/validator.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The Cloud Robotics Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approllout
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// canonical name of an app
+	labelAppName = "cloudrobotics.com/app-name"
+	// version of that app. Note, the default version of the app has
+	// a version label of ""
+	labelAppVersion = "cloudrobotics.com/app-version"
+)
+
+// NewAppValidationWebhook returns a new webhook that validates Apps.
+//
+// This pertains to multiple versions of the same app, so that the labels
+// defined above are in sync with the name of the App.
+// The policy is
+// - an unversioned app defines
+//   - cloudrobotics.com/app-name
+//   - (optionally): cloudrobotics.com/app-version with a "" value
+//     this must match the name of the object
+//
+// - a versioned app defines
+//   - cloudrobotics.com/app-name
+//   - cloudrobotics.com/app-version
+//     the name of the App object must match LOWERCASE([app-name].v[app-version])
+func NewAppValidationWebhook(mgr manager.Manager) *admission.Webhook {
+	return &admission.Webhook{Handler: newAppValidator(mgr.GetScheme())}
+}
+
+// appValidator implements a validation webhook.
+type appValidator struct {
+	decoder runtime.Decoder
+}
+
+func newAppValidator(sc *runtime.Scheme) *appValidator {
+	return &appValidator{
+		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
+	}
+}
+
+func (v *appValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	cur := &apps.App{}
+	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if err := appValidate(cur); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+func appValidate(cur *apps.App) error {
+	name := cur.Name
+	appName, anok := cur.Labels[labelAppName]
+	appVersion, avok := cur.Labels[labelAppVersion]
+	if anok {
+		if avok && appVersion != "" {
+			// both name and version are defined
+			ename := strings.ToLower(fmt.Sprintf("%s.v%s", appName, appVersion))
+			if ename != name {
+				return fmt.Errorf("%q=%q, %q=%q: expected object name %q, got %q", labelAppName, appName, labelAppVersion, appVersion, ename, name)
+			}
+		} else {
+			// only name is defined
+			if appName != name {
+				return fmt.Errorf("%q=%q, undefined %q: expected object name %q, got %q", labelAppName, appName, labelAppVersion, appName, name)
+			}
+		}
+	}
+	// neither is defined, we're dealing with a legacy app
+	return nil
+}
+
+// NewAppRolloutValidationWebhook returns a new webhook that validates AppRollouts.
+func NewAppRolloutValidationWebhook(mgr manager.Manager) *admission.Webhook {
+	return &admission.Webhook{Handler: newAppRolloutValidator(mgr.GetScheme())}
+}
+
+// appRolloutValidator implements a validation webhook.
+type appRolloutValidator struct {
+	decoder runtime.Decoder
+}
+
+func newAppRolloutValidator(sc *runtime.Scheme) *appRolloutValidator {
+	return &appRolloutValidator{
+		decoder: serializer.NewCodecFactory(sc).UniversalDeserializer(),
+	}
+}
+
+func (v *appRolloutValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	cur := &apps.AppRollout{}
+
+	if err := runtime.DecodeInto(v.decoder, req.AdmissionRequest.Object.Raw, cur); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if err := appRolloutValidate(cur); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+func appRolloutValidate(cur *apps.AppRollout) error {
+	if cur.Spec.AppName == "" {
+		return fmt.Errorf("spec.appName is missing for AppRollout %q", cur.Name)
+	}
+	errs := validation.NameIsDNSSubdomain(cur.Spec.AppName, false)
+	if len(errs) > 0 {
+		return fmt.Errorf("validate app name: %s", strings.Join(errs, ", "))
+	}
+	if _, ok := cur.Spec.Cloud.Values["robots"]; ok {
+		return fmt.Errorf(".spec.cloud.values.robots is a reserved field and must not be set")
+	}
+	for i, r := range cur.Spec.Robots {
+		if _, ok := r.Values["robot"]; ok {
+			return fmt.Errorf(".spec.robots[].values.robot is a reserved field and must not be set")
+		}
+		if r.Selector == nil {
+			return fmt.Errorf("no selector provided for robots %d", i)
+		}
+		// Reject if a selector has neither a matcher nor `any` set.
+		// This mostly helps catching missing `matchLabels`.
+		if r.Selector.Any == nil && r.Selector.LabelSelector == nil {
+			return fmt.Errorf("empty selector for robots %d (matchLabels not specified?)", i)
+		}
+	}
+	return nil
+}

--- a/src/go/pkg/controller/approllout/validator_test.go
+++ b/src/go/pkg/controller/approllout/validator_test.go
@@ -1,0 +1,373 @@
+// Copyright 2026 The Cloud Robotics Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approllout
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apps "github.com/googlecloudrobotics/core/src/go/pkg/apis/apps/v1alpha1"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestValidateAppRollout(t *testing.T) {
+	cases := []struct {
+		name       string
+		cur        string
+		shouldFail bool
+	}{
+		{
+			name: "valid-all",
+			cur: `
+spec:
+  appName: myapp
+  cloud:
+    values:
+      a: 2
+      b: {c: 3}
+  robots:
+  - selector:
+      any: true
+    values:
+      c: d
+  - selector:
+      matchLabels:
+        abc: def
+        foo: bar
+  - selector:
+      matchExpressions:
+      - {key: foo, Op: DoesExist}
+	`,
+		},
+		{
+			name: "valid-app-name-only",
+			cur: `
+spec:
+  appName: my-app.123
+	`,
+		},
+		{
+			name:       "missing-app-name",
+			cur:        `spec: {}`,
+			shouldFail: true,
+		},
+		{
+			name: "invalid-app-name",
+			cur: `
+spec:
+  appName: my%app
+	`,
+			shouldFail: true,
+		},
+		{
+			name: "missing-robot-selector",
+			cur: `
+spec:
+  appName: myapp
+  robots:
+  - values:
+      a: b
+	`,
+			shouldFail: true,
+		},
+		{
+			name: "wrong-selector",
+			cur: `
+spec:
+  appName: myapp
+  robots:
+  - selector:
+      a: b
+	`,
+			shouldFail: true,
+		},
+		{
+			name: "cloud-values-Robots",
+			cur: `
+spec:
+  appName: myapp
+  cloud:
+    values:
+      robots:
+        c: d
+	`,
+			shouldFail: true,
+		},
+		{
+			name: "robot-values-robot",
+			cur: `
+spec:
+  appName: myapp
+  robots:
+  - selector:
+      any: true
+    values:
+      robot:
+        c: d
+	`,
+			shouldFail: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var cur apps.AppRollout
+			unmarshalYAML(t, &cur, c.cur)
+
+			err := appRolloutValidate(&cur)
+			if err == nil && c.shouldFail {
+				t.Fatal("expected failure but got none")
+			}
+			if err != nil && !c.shouldFail {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestValidateApp(t *testing.T) {
+	cases := []struct {
+		name       string
+		cur        string
+		shouldFail bool
+	}{
+		{
+			name: "valid",
+			cur: `
+metadata:
+  name: app
+	`,
+		},
+		{
+			name: "valid-app-label-only",
+			cur: `
+metadata:
+  name: app
+  labels:
+    cloudrobotics.com/app-name: app
+	`,
+		},
+		{
+			name: "valid-both-labels",
+			cur: `
+metadata:
+  name: app.v17
+  labels:
+    cloudrobotics.com/app-name: app
+    cloudrobotics.com/app-version: 17
+	`,
+		},
+		{
+			name: "valid-both-labels-lower",
+			cur: `
+metadata:
+  name: app.v17rc00
+  labels:
+    cloudrobotics.com/app-name: app
+    cloudrobotics.com/app-version: 17RC00
+	`,
+		},
+		{
+			name:       "invalid-app-label-only",
+			shouldFail: true,
+			cur: `
+metadata:
+  name: app2
+  labels:
+    cloudrobotics.com/app-name: app
+	`,
+		},
+		{
+			name:       "invalid-both-labels",
+			shouldFail: true,
+			cur: `
+metadata:
+  name: app.v17rc10
+  labels:
+    cloudrobotics.com/app-name: app
+    cloudrobotics.com/app-version: 17RC00
+	`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var cur apps.App
+			unmarshalYAML(t, &cur, c.cur)
+
+			err := appValidate(&cur)
+			if err == nil && c.shouldFail {
+				t.Fatal("expected failure but got none")
+			}
+			if err != nil && !c.shouldFail {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestAppValidator_Handle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	apps.AddToScheme(scheme)
+
+	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+	v := &appValidator{decoder: decoder}
+
+	tests := []struct {
+		name       string
+		req        admission.Request
+		wantAllow  bool
+		wantStatus int32
+	}{
+		{
+			name: "DecodeError",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{Raw: []byte("invalid json")},
+				},
+			},
+			wantAllow:  false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: mustMarshal(&apps.App{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "myapp",
+								Labels: map[string]string{
+									labelAppName: "myapp",
+								},
+							},
+						}),
+					},
+				},
+			},
+			wantAllow: true,
+		},
+		{
+			name: "Denied_ValidationFailure",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: mustMarshal(&apps.App{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "myapp-invalid-name",
+								Labels: map[string]string{
+									labelAppName: "myapp",
+								},
+							},
+						}),
+					},
+				},
+			},
+			wantAllow: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := v.Handle(t.Context(), tc.req)
+			if resp.Allowed != tc.wantAllow {
+				t.Errorf("Handle() allowed = %v, want %v. Message: %s", resp.Allowed, tc.wantAllow, resp.Result.Message)
+			}
+			if tc.wantStatus != 0 && resp.Result.Code != tc.wantStatus {
+				t.Errorf("Handle() status code = %d, want %d", resp.Result.Code, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAppRolloutValidator_Handle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	apps.AddToScheme(scheme)
+
+	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+	v := &appRolloutValidator{decoder: decoder}
+
+	tests := []struct {
+		name      string
+		req       admission.Request
+		wantAllow bool
+	}{
+		{
+			name: "DecodeError",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{Raw: []byte("invalid json")},
+				},
+			},
+			wantAllow: false,
+		},
+		{
+			name: "Allowed",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: mustMarshal(&apps.AppRollout{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "my-rollout",
+							},
+							Spec: apps.AppRolloutSpec{
+								AppName: "my-app",
+							},
+						}),
+					},
+				},
+			},
+			wantAllow: true,
+		},
+		{
+			name: "Denied_ValidationFailure",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: mustMarshal(&apps.AppRollout{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "my-rollout",
+							},
+							Spec: apps.AppRolloutSpec{
+								AppName: "", // Missing app name
+							},
+						}),
+					},
+				},
+			},
+			wantAllow: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := v.Handle(t.Context(), tc.req)
+			if resp.Allowed != tc.wantAllow {
+				t.Errorf("Handle() allowed = %v, want %v. Message: %s", resp.Allowed, tc.wantAllow, resp.Result.Message)
+			}
+		})
+	}
+}
+
+func mustMarshal(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}


### PR DESCRIPTION
This follows the example from the chart assignment controller.

Also contains gazelle cleanup on previous changes.