### PR TITLE
Port more tests to use synctest.

### DIFF
--- a/src/go/cmd/cr-syncer/syncer.go
+++ b/src/go/cmd/cr-syncer/syncer.go
@@ -407,6 +407,9 @@ func (s *crSyncer) run() {
 func (s *crSyncer) stop() {
 	slog.Info("Stopping syncer", slog.String("CRD", s.crd.GetName()))
 	close(s.done)
+	s.stopInformers()
+	s.upstreamQueue.ShutDown()
+	s.downstreamQueue.ShutDown()
 }
 
 // syncDownstream reconciles state after receiving change events from the

--- a/src/go/cmd/cr-syncer/syncer_test.go
+++ b/src/go/cmd/cr-syncer/syncer_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -428,128 +429,131 @@ func TestSyncDownstream_statusSubtree(t *testing.T) {
 }
 
 func TestSyncDownstream_downstreamNotFound(t *testing.T) {
-	crd := testCRD(crdtypes.NamespaceScoped)
-	f := newFixture(t)
+	synctest.Test(t, func(t *testing.T) {
+		crd := testCRD(crdtypes.NamespaceScoped)
+		f := newFixture(t)
 
-	// If the downstream resource is not present when synced, the upstream
-	// resource should be added to the upstream queue, so that syncUpstream
-	// can recreate the downstream resource.  This tests the case where the
-	// upstream resource was deleted and immediately recreated.
-	var (
-		tcrRemote = newTestCR("resource1", "spec1", "status1")
-	)
+		// If the downstream resource is not present when synced, the upstream
+		// resource should be added to the upstream queue, so that syncUpstream
+		// can recreate the downstream resource.  This tests the case where the
+		// upstream resource was deleted and immediately recreated.
+		var (
+			tcrRemote = newTestCR("resource1", "spec1", "status1")
+		)
 
-	f.addRemoteObjects(tcrRemote)
+		f.addRemoteObjects(tcrRemote)
 
-	crs, _ := f.newCRSyncer(crd, "cluster1")
-	defer crs.stop()
+		crs, _ := f.newCRSyncer(crd, "cluster1")
+		defer crs.stop()
 
-	crs.startInformers()
-	// startInformers adds the initial state to the upstream queue.  Ignore
-	// it, so that we can check that the same resource is requeued.
-	upstreamChannel := channelFromQueue(t, crs.upstreamQueue, crs.upstreamInf)
-	select {
-	case <-upstreamChannel:
-		// Ignore.
-	case <-time.After(5 * time.Second):
-		t.Errorf("upstream resource was not queued by informer; want %v", tcrRemote)
-	}
-
-	if err := crs.syncDownstream("default/resource1"); err != nil {
-		t.Fatal(err)
-	}
-
-	// syncDownstream should have requeued the upstream resource.
-	select {
-	case got := <-upstreamChannel:
-		if !reflect.DeepEqual(got, tcrRemote) {
-			t.Errorf("upstream queue got %v; want %v", got, tcrRemote)
+		crs.startInformers()
+		// startInformers adds the initial state to the upstream queue.  Ignore
+		// it, so that we can check that the same resource is requeued.
+		upstreamChannel := channelFromQueue(t, crs.upstreamQueue, crs.upstreamInf)
+		select {
+		case <-upstreamChannel:
+			// Ignore.
+		case <-time.After(5 * time.Second):
+			t.Errorf("upstream resource was not queued by informer; want %v", tcrRemote)
 		}
-	case <-time.After(5 * time.Second):
-		t.Errorf("upstream resource was not requeued to %p; want %v", crs.upstreamQueue, tcrRemote)
-	}
 
-	// We don't need to call syncUpstream here, as this is tested by
-	// TestSyncUpstream_createSpec.
+		if err := crs.syncDownstream("default/resource1"); err != nil {
+			t.Fatal(err)
+		}
+
+		// syncDownstream should have requeued the upstream resource.
+		select {
+		case got := <-upstreamChannel:
+			if !reflect.DeepEqual(got, tcrRemote) {
+				t.Errorf("upstream queue got %v; want %v", got, tcrRemote)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("upstream resource was not requeued to %p; want %v", crs.upstreamQueue, tcrRemote)
+		}
+	})
 }
 
 func TestCRSyncer_populateWorkqueue(t *testing.T) {
-	crd := testCRD(crdtypes.NamespaceScoped)
-	f := newFixture(t)
+	synctest.Test(t, func(t *testing.T) {
+		crd := testCRD(crdtypes.NamespaceScoped)
+		f := newFixture(t)
 
-	cr1 := newTestCR("cr1", "spec1", "status1")
-	f.addRemoteObjects(cr1)
+		cr1 := newTestCR("cr1", "spec1", "status1")
+		f.addRemoteObjects(cr1)
 
-	crs, _ := f.newCRSyncer(crd, "")
-	defer crs.stop()
-	crs.startInformers()
+		crs, _ := f.newCRSyncer(crd, "")
+		defer crs.stop()
+		crs.startInformers()
 
-	// Workqueue exposes no interface to select{} over, so we call Get()
-	// in a goroutine to surface deadlocks properly.
-	channel := make(chan interface{}, 1)
-	go func() {
-		key, quit := crs.upstreamQueue.Get()
-		if quit {
-			t.Errorf("unexpected quit")
-			return
-		}
-		item, exists, err := crs.upstreamInf.GetIndexer().GetByKey(key.(string))
-		if err != nil {
-			t.Errorf("unexpected lookup error for key %s: %s", key, err)
-		}
-		if !exists {
-			t.Errorf("item for key %s does not exist", key)
-		} else {
-			channel <- item
-		}
-	}()
+		// Workqueue exposes no interface to select{} over, so we call Get()
+		// in a goroutine to surface deadlocks properly.
+		channel := make(chan interface{}, 1)
+		go func() {
+			key, quit := crs.upstreamQueue.Get()
+			if quit {
+				t.Errorf("unexpected quit")
+				return
+			}
+			item, exists, err := crs.upstreamInf.GetIndexer().GetByKey(key.(string))
+			if err != nil {
+				t.Errorf("unexpected lookup error for key %s: %s", key, err)
+			}
+			if !exists {
+				t.Errorf("item for key %s does not exist", key)
+			} else {
+				channel <- item
+			}
+		}()
 
-	select {
-	case obj := <-channel:
-		if got := obj.(*unstructured.Unstructured); !reflect.DeepEqual(got, cr1) {
-			t.Errorf("unexpected object; want %v; got %v", cr1, got)
+		select {
+		case obj := <-channel:
+			if got := obj.(*unstructured.Unstructured); !reflect.DeepEqual(got, cr1) {
+				t.Errorf("unexpected object; want %v; got %v", cr1, got)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("Received no watch event; wanted %v", cr1)
 		}
-	case <-time.After(5 * time.Second):
-		t.Errorf("Received no watch event; wanted %v", cr1)
-	}
+	})
 }
 
 func TestCRSyncer_populateWorkqueueWithFilter(t *testing.T) {
-	crd := testCRD(crdtypes.NamespaceScoped)
-	crd.ObjectMeta.Annotations[annotationFilterByRobotName] = "true"
+	synctest.Test(t, func(t *testing.T) {
+		crd := testCRD(crdtypes.NamespaceScoped)
+		crd.ObjectMeta.Annotations[annotationFilterByRobotName] = "true"
 
-	f := newFixture(t)
+		f := newFixture(t)
 
-	// Create three CRs of which only one matches the robot the CR syncer
-	// is running on.
-	crCorrectRobot := newTestCR("cr1", "spec1", "status1")
-	crWrongRobot := newTestCR("cr2", "spec2", "status2")
-	crNoRobot := newTestCR("cr3", "spec3", "status3")
+		// Create three CRs of which only one matches the robot the CR syncer
+		// is running on.
+		crCorrectRobot := newTestCR("cr1", "spec1", "status1")
+		crWrongRobot := newTestCR("cr2", "spec2", "status2")
+		crNoRobot := newTestCR("cr3", "spec3", "status3")
 
-	crCorrectRobot.SetLabels(map[string]string{labelRobotName: "robot-1"})
-	crWrongRobot.SetLabels(map[string]string{labelRobotName: "robot-2"})
+		crCorrectRobot.SetLabels(map[string]string{labelRobotName: "robot-1"})
+		crWrongRobot.SetLabels(map[string]string{labelRobotName: "robot-2"})
 
-	f.addRemoteObjects(crCorrectRobot, crWrongRobot, crNoRobot)
+		f.addRemoteObjects(crCorrectRobot, crWrongRobot, crNoRobot)
 
-	crs, _ := f.newCRSyncer(crd, "robot-1")
-	defer crs.stop()
-	crs.startInformers()
+		crs, _ := f.newCRSyncer(crd, "robot-1")
+		defer crs.stop()
+		crs.startInformers()
 
-	channel := channelFromQueue(t, crs.upstreamQueue, crs.upstreamInf)
-	select {
-	case got := <-channel:
-		if !reflect.DeepEqual(got, crCorrectRobot) {
-			t.Errorf("unexpected object; want %v; got %v", crCorrectRobot, got)
+		channel := channelFromQueue(t, crs.upstreamQueue, crs.upstreamInf)
+		select {
+		case got := <-channel:
+			if !reflect.DeepEqual(got, crCorrectRobot) {
+				t.Errorf("unexpected object; want %v; got %v", crCorrectRobot, got)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("Received no watch event; wanted %v", crCorrectRobot)
 		}
-	case <-time.After(5 * time.Second):
-		t.Errorf("Received no watch event; wanted %v", crCorrectRobot)
-	}
-	// No other items should come through.
-	select {
-	case item := <-channel:
-		t.Errorf("Unexpected update: %v", item)
-	case <-time.After(3 * time.Second):
-	}
+		// No other items should come through.
+		select {
+		case item := <-channel:
+			t.Errorf("Unexpected update: %v", item)
+		case <-time.After(3 * time.Second):
+		}
+	})
 }
 
 func channelFromQueue(t *testing.T, queue workqueue.Interface, inf cache.SharedIndexInformer) <-chan *unstructured.Unstructured {
@@ -560,7 +564,6 @@ func channelFromQueue(t *testing.T, queue workqueue.Interface, inf cache.SharedI
 		for {
 			key, quit := queue.Get()
 			if quit {
-				t.Errorf("unexpected quit")
 				return
 			}
 			item, exists, err := inf.GetIndexer().GetByKey(key.(string))

--- a/src/go/cmd/http-relay-client/client/client_test.go
+++ b/src/go/cmd/http-relay-client/client/client_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"net/http"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	pb "github.com/googlecloudrobotics/core/src/proto/http-relay"
@@ -40,175 +41,185 @@ func assertMocksDoneWithin(t *testing.T, d time.Duration) {
 }
 
 func TestAssertMocksDoneWithin_SucceedsWhenMocksAreDone(t *testing.T) {
-	assertMocksDoneWithin(t, time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		assertMocksDoneWithin(t, time.Millisecond)
+	})
 }
 
 func TestAssertMocksDoneWithin_FailsWhenMocksNotDone(t *testing.T) {
-	defer gock.Off()
-	gock.New("https://localhost:8081")
-	faket := &testing.T{}
-	assertMocksDoneWithin(faket, time.Millisecond)
-	if !faket.Failed() {
-		t.Errorf("assertMocksDoneWithin didn't trigger an error despite outstanding mocks")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		defer gock.Off()
+		gock.New("https://localhost:8081")
+		faket := &testing.T{}
+		assertMocksDoneWithin(faket, time.Millisecond)
+		if !faket.Failed() {
+			t.Errorf("assertMocksDoneWithin didn't trigger an error despite outstanding mocks")
+		}
+	})
 }
 
 func TestLocalProxy(t *testing.T) {
-	// Hot patch: gock refuses to match bodies with unknown content-types by default.
-	gock.BodyTypes = append(gock.BodyTypes, "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse")
-	defer gock.Off()
+	synctest.Test(t, func(t *testing.T) {
+		// Hot patch: gock refuses to match bodies with unknown content-types by default.
+		gock.BodyTypes = append(gock.BodyTypes, "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse")
+		defer gock.Off()
 
-	// We expect the response below to always contain 0 milliseconds.
-	timeSince = func(t time.Time) time.Duration { return 0 * time.Millisecond }
+		// We expect the response below to always contain 0 milliseconds.
+		timeSince = func(t time.Time) time.Duration { return 0 * time.Millisecond }
 
-	req, _ := proto.Marshal(&pb.HttpRequest{
-		Id:     proto.String("15"),
-		Method: proto.String("GET"),
-		Url:    proto.String("http://invalid/foo/bar?a=b"),
-		Header: []*pb.HttpHeader{{
-			Name:  proto.String("X-GFE"),
-			Value: proto.String("google.com")}},
-		Body: []byte("thebody"),
-	})
-	resp, _ := proto.Marshal(&pb.HttpResponse{
-		Id:         proto.String("15"),
-		StatusCode: proto.Int32(201),
-		Header: []*pb.HttpHeader{
-			{
-				Name:  proto.String("Priority"),
-				Value: proto.String("High"),
+		req, _ := proto.Marshal(&pb.HttpRequest{
+			Id:     proto.String("15"),
+			Method: proto.String("GET"),
+			Url:    proto.String("http://invalid/foo/bar?a=b"),
+			Header: []*pb.HttpHeader{{
+				Name:  proto.String("X-GFE"),
+				Value: proto.String("google.com")}},
+			Body: []byte("thebody"),
+		})
+		resp, _ := proto.Marshal(&pb.HttpResponse{
+			Id:         proto.String("15"),
+			StatusCode: proto.Int32(201),
+			Header: []*pb.HttpHeader{
+				{
+					Name:  proto.String("Priority"),
+					Value: proto.String("High"),
+				},
 			},
-		},
-		Body:              []byte("theresponsebody"),
-		Eof:               proto.Bool(true),
-		BackendDurationMs: proto.Int64(0),
-	})
-	gock.New("https://localhost:8081").
-		Get("/server/request").
-		MatchParam("server", "foo").
-		Reply(200).
-		BodyString(string(req))
-	gock.New("https://localhost:8080").
-		Get("/foo/bar").
-		MatchParam("a", "b").
-		MatchHeader("X-GFE", "google.com").
-		BodyString("thebody").
-		Reply(201).
-		SetHeader("Priority", "High").
-		BodyString("theresponsebody")
-	gock.New("https://localhost:8081").
-		Post("/server/response").
-		Body(bytes.NewReader(resp)).
-		Reply(200)
+			Body:              []byte("theresponsebody"),
+			Eof:               proto.Bool(true),
+			BackendDurationMs: proto.Int64(0),
+		})
+		gock.New("https://localhost:8081").
+			Get("/server/request").
+			MatchParam("server", "foo").
+			Reply(200).
+			BodyString(string(req))
+		gock.New("https://localhost:8080").
+			Get("/foo/bar").
+			MatchParam("a", "b").
+			MatchHeader("X-GFE", "google.com").
+			BodyString("thebody").
+			Reply(201).
+			SetHeader("Priority", "High").
+			BodyString("theresponsebody")
+		gock.New("https://localhost:8081").
+			Post("/server/response").
+			Body(bytes.NewReader(resp)).
+			Reply(200)
 
-	config := DefaultClientConfig()
-	config.ServerName = "foo"
-	client := NewClient(config)
-	err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	assertMocksDoneWithin(t, 10*time.Second)
+		config := DefaultClientConfig()
+		config.ServerName = "foo"
+		client := NewClient(config)
+		err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		assertMocksDoneWithin(t, 10*time.Second)
+	})
 }
 
 func TestBackendError(t *testing.T) {
-	// Hot patch: gock refuses to match bodies with unknown content-types by default.
-	gock.BodyTypes = append(gock.BodyTypes, "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse")
-	defer gock.Off()
+	synctest.Test(t, func(t *testing.T) {
+		// Hot patch: gock refuses to match bodies with unknown content-types by default.
+		gock.BodyTypes = append(gock.BodyTypes, "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse")
+		defer gock.Off()
 
-	// We expect the response below to always contain 0 milliseconds.
-	timeSince = func(t time.Time) time.Duration { return 0 * time.Millisecond }
+		// We expect the response below to always contain 0 milliseconds.
+		timeSince = func(t time.Time) time.Duration { return 0 * time.Millisecond }
 
-	// The pending request on the relay-server side.
-	req, _ := proto.Marshal(&pb.HttpRequest{
-		Id:     proto.String("15"),
-		Method: proto.String("GET"),
-		Url:    proto.String("http://invalid/foo/bar?a=b"),
-		Header: []*pb.HttpHeader{{
-			Name:  proto.String("X-GFE"),
-			Value: proto.String("google.com")}},
-		Body: []byte("thebody"),
+		// The pending request on the relay-server side.
+		req, _ := proto.Marshal(&pb.HttpRequest{
+			Id:     proto.String("15"),
+			Method: proto.String("GET"),
+			Url:    proto.String("http://invalid/foo/bar?a=b"),
+			Header: []*pb.HttpHeader{{
+				Name:  proto.String("X-GFE"),
+				Value: proto.String("google.com")}},
+			Body: []byte("thebody"),
+		})
+
+		resp, _ := proto.Marshal(&pb.HttpResponse{
+			Id:                proto.String("15"),
+			StatusCode:        proto.Int32(400),
+			Body:              []byte("theresponsebody"),
+			Eof:               proto.Bool(true),
+			BackendDurationMs: proto.Int64(0),
+		})
+
+		relayServerAddress := "https://localhost:8081"
+		backendServerAddress := "https://localhost:8080"
+
+		// Mocks the response from the relay server from which we are getting
+		// the initial data.
+		gock.New(relayServerAddress).
+			Get("/server/request").
+			MatchParam("server", "foo").
+			Reply(200).
+			BodyString(string(req))
+
+		// Mocks the response from the backend server to which we relayed data.
+		gock.New(backendServerAddress).
+			Get("/foo/bar").
+			MatchParam("a", "b").
+			MatchHeader("X-GFE", "google.com").
+			BodyString("thebody").
+			Reply(400).
+			BodyString("theresponsebody")
+
+		// Mocks the response from the realy-server after having received the
+		// actual backend response.
+		gock.New(relayServerAddress).
+			Post("/server/response").
+			Body(bytes.NewReader(resp)).
+			Reply(200)
+
+		config := DefaultClientConfig()
+		config.ServerName = "foo"
+		client := NewClient(config)
+
+		// localProxy ...
+		// 1. pulls a request from the realy-server (/server/request)
+		// 2. send that request to the backend server (here localhost:8080/foo/bar?a=b)
+		// 3. retrieves the response from the backend and sends it to the relay-server
+		err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		assertMocksDoneWithin(t, 10*time.Second)
 	})
-
-	resp, _ := proto.Marshal(&pb.HttpResponse{
-		Id:                proto.String("15"),
-		StatusCode:        proto.Int32(400),
-		Body:              []byte("theresponsebody"),
-		Eof:               proto.Bool(true),
-		BackendDurationMs: proto.Int64(0),
-	})
-
-	relayServerAddress := "https://localhost:8081"
-	backendServerAddress := "https://localhost:8080"
-
-	// Mocks the response from the relay server from which we are getting
-	// the initial data.
-	gock.New(relayServerAddress).
-		Get("/server/request").
-		MatchParam("server", "foo").
-		Reply(200).
-		BodyString(string(req))
-
-	// Mocks the response from the backend server to which we relayed data.
-	gock.New(backendServerAddress).
-		Get("/foo/bar").
-		MatchParam("a", "b").
-		MatchHeader("X-GFE", "google.com").
-		BodyString("thebody").
-		Reply(400).
-		BodyString("theresponsebody")
-
-	// Mocks the response from the realy-server after having received the
-	// actual backend response.
-	gock.New(relayServerAddress).
-		Post("/server/response").
-		Body(bytes.NewReader(resp)).
-		Reply(200)
-
-	config := DefaultClientConfig()
-	config.ServerName = "foo"
-	client := NewClient(config)
-
-	// localProxy ...
-	// 1. pulls a request from the realy-server (/server/request)
-	// 2. send that request to the backend server (here localhost:8080/foo/bar?a=b)
-	// 3. retrieves the response from the backend and sends it to the relay-server
-	err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	assertMocksDoneWithin(t, 10*time.Second)
 }
 
 func TestServerTimeout(t *testing.T) {
-	// Hot patch: gock refuses to match bodies with application/octet-data
-	// by default.
-	gock.BodyTypes = append(gock.BodyTypes, "application/octet-data")
-	defer gock.Off()
+	synctest.Test(t, func(t *testing.T) {
+		// Hot patch: gock refuses to match bodies with application/octet-data
+		// by default.
+		gock.BodyTypes = append(gock.BodyTypes, "application/octet-data")
+		defer gock.Off()
 
-	req, _ := proto.Marshal(&pb.HttpRequest{
-		Id:     proto.String("15"),
-		Method: proto.String("GET"),
-		Url:    proto.String("http://invalid/foo/bar?a=b"),
-		Header: []*pb.HttpHeader{{
-			Name:  proto.String("X-GFE"),
-			Value: proto.String("google.com")}},
-		Body: []byte("thebody"),
+		req, _ := proto.Marshal(&pb.HttpRequest{
+			Id:     proto.String("15"),
+			Method: proto.String("GET"),
+			Url:    proto.String("http://invalid/foo/bar?a=b"),
+			Header: []*pb.HttpHeader{{
+				Name:  proto.String("X-GFE"),
+				Value: proto.String("google.com")}},
+			Body: []byte("thebody"),
+		})
+		gock.New("https://localhost:8081").
+			Get("/server/request").
+			MatchParam("server", "foo").
+			Reply(408).
+			BodyString(string(req))
+
+		config := DefaultClientConfig()
+		config.ServerName = "foo"
+		client := NewClient(config)
+		err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
+		if err != ErrTimeout {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		assertMocksDoneWithin(t, 10*time.Second)
 	})
-	gock.New("https://localhost:8081").
-		Get("/server/request").
-		MatchParam("server", "foo").
-		Reply(408).
-		BodyString(string(req))
-
-	config := DefaultClientConfig()
-	config.ServerName = "foo"
-	client := NewClient(config)
-	err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
-	if err != ErrTimeout {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	assertMocksDoneWithin(t, 10*time.Second)
 }
 
 func TestBuildResponsesTimesOut(t *testing.T) {


### PR DESCRIPTION
This will make the time controlled and the test faster. For cr-syncer we had to fix the cleanup to explicitly stop informers and shut down workqueues. Previously, if `Run()` wasn't executed (which is common in unit tests that only call `startInformers()`), the informers and queue worker goroutines would leak. synctest detects these leaks as deadlocks and panics.