### PR TITLE
Replace gock usage with a mock-transport.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -71,7 +71,6 @@ use_repo(
     "com_github_spf13_pflag",
     "com_google_cloud_go_compute_metadata",
     "com_google_cloud_go_storage",
-    "in_gopkg_h2non_gock_v1",
     "io_k8s_api",
     "io_k8s_apiextensions_apiserver",
     "io_k8s_apimachinery",

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	google.golang.org/api v0.286.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
-	gopkg.in/h2non/gock.v1 v1.1.2
 	// WatchList feature in client-go 0.35+ causes timeouts with fake clients.
 	// See https://github.com/kubernetes/kubernetes/issues/125501
 	// Keep at 0.34.4 until fakes support bookmark events for initial events stream.
@@ -140,7 +139,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
-	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	// TODO: remove this indirect dependency once sigs.k8s.io/controller-runtime is updated to v0.24.1 or higher
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,6 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/googlecloudrobotics/ilog v0.0.0-20240112131211-2efd642f756e h1:lfnmC6SUHV/5QrqXElmZ0WgojfIccKVNtxDry4T3AS8=
 github.com/googlecloudrobotics/ilog v0.0.0-20240112131211-2efd642f756e/go.mod h1:t9Up/i5bPfkBc7lEE+p0+lcD0NDw2zTTr19x19D7720=
-github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
-github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
@@ -367,8 +365,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
-github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/onsi/ginkgo/v2 v2.27.4 h1:fcEcQW/A++6aZAZQNUmNjvA9PSOzefMJBerHJ4t8v8Y=
 github.com/onsi/ginkgo/v2 v2.27.4/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.0 h1:y2ROC3hKFmQZJNFeGAMeHZKkjBL65mIZcvrLQBF9k6Q=
@@ -835,8 +831,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
-gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
-gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/src/go/cmd/http-relay-client/client/BUILD.bazel
+++ b/src/go/cmd/http-relay-client/client/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/proto/http-relay:go_default_library",
-        "@in_gopkg_h2non_gock_v1//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/src/go/cmd/http-relay-client/client/client_test.go
+++ b/src/go/cmd/http-relay-client/client/client_test.go
@@ -16,7 +16,10 @@ package client
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -24,50 +27,22 @@ import (
 	pb "github.com/googlecloudrobotics/core/src/proto/http-relay"
 
 	"google.golang.org/protobuf/proto"
-	"gopkg.in/h2non/gock.v1"
 )
 
-func assertMocksDoneWithin(t *testing.T, d time.Duration) {
-	t.Helper()
-	for start := time.Now(); time.Since(start) < d; {
-		if gock.IsDone() {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	for _, m := range gock.Pending() {
-		t.Errorf("mock still pending after %s: %v", d, m.Request().URLStruct)
-	}
+type mockTransport struct {
+	roundTrip func(*http.Request) (*http.Response, error)
 }
 
-func TestAssertMocksDoneWithin_SucceedsWhenMocksAreDone(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		assertMocksDoneWithin(t, time.Millisecond)
-	})
-}
-
-func TestAssertMocksDoneWithin_FailsWhenMocksNotDone(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		defer gock.Off()
-		gock.New("https://localhost:8081")
-		faket := &testing.T{}
-		assertMocksDoneWithin(faket, time.Millisecond)
-		if !faket.Failed() {
-			t.Errorf("assertMocksDoneWithin didn't trigger an error despite outstanding mocks")
-		}
-	})
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTrip(req)
 }
 
 func TestLocalProxy(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		// Hot patch: gock refuses to match bodies with unknown content-types by default.
-		gock.BodyTypes = append(gock.BodyTypes, "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse")
-		defer gock.Off()
-
 		// We expect the response below to always contain 0 milliseconds.
 		timeSince = func(t time.Time) time.Duration { return 0 * time.Millisecond }
 
-		req, _ := proto.Marshal(&pb.HttpRequest{
+		reqPayload, _ := proto.Marshal(&pb.HttpRequest{
 			Id:     proto.String("15"),
 			Method: proto.String("GET"),
 			Url:    proto.String("http://invalid/foo/bar?a=b"),
@@ -76,7 +51,7 @@ func TestLocalProxy(t *testing.T) {
 				Value: proto.String("google.com")}},
 			Body: []byte("thebody"),
 		})
-		resp, _ := proto.Marshal(&pb.HttpResponse{
+		respPayload, _ := proto.Marshal(&pb.HttpResponse{
 			Id:         proto.String("15"),
 			StatusCode: proto.Int32(201),
 			Header: []*pb.HttpHeader{
@@ -89,46 +64,96 @@ func TestLocalProxy(t *testing.T) {
 			Eof:               proto.Bool(true),
 			BackendDurationMs: proto.Int64(0),
 		})
-		gock.New("https://localhost:8081").
-			Get("/server/request").
-			MatchParam("server", "foo").
-			Reply(200).
-			BodyString(string(req))
-		gock.New("https://localhost:8080").
-			Get("/foo/bar").
-			MatchParam("a", "b").
-			MatchHeader("X-GFE", "google.com").
-			BodyString("thebody").
-			Reply(201).
-			SetHeader("Priority", "High").
-			BodyString("theresponsebody")
-		gock.New("https://localhost:8081").
-			Post("/server/response").
-			Body(bytes.NewReader(resp)).
-			Reply(200)
+
+		relayRequests := 0
+		relayTransport := &mockTransport{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				relayRequests++
+				switch relayRequests {
+				case 1:
+					if req.Method != "GET" || req.URL.Path != "/server/request" {
+						t.Errorf("Relay Req 1: expected GET /server/request, got %s %s", req.Method, req.URL.Path)
+					}
+					if req.URL.Query().Get("server") != "foo" {
+						t.Errorf("Relay Req 1: expected query server=foo, got %q", req.URL.RawQuery)
+					}
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader(reqPayload)),
+					}, nil
+				case 2:
+					if req.Method != "POST" || req.URL.Path != "/server/response" {
+						t.Errorf("Relay Req 2: expected POST /server/response, got %s %s", req.Method, req.URL.Path)
+					}
+					body, _ := io.ReadAll(req.Body)
+					if !bytes.Equal(body, respPayload) {
+						t.Errorf("Relay Req 2: body mismatch")
+					}
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				default:
+					t.Errorf("Unexpected extra request to relay: %s %s", req.Method, req.URL.Path)
+					return nil, fmt.Errorf("unexpected request")
+				}
+			},
+		}
+
+		backendRequests := 0
+		backendTransport := &mockTransport{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				backendRequests++
+				if req.Method != "GET" || req.URL.Path != "/foo/bar" {
+					t.Errorf("Backend Req: expected GET /foo/bar, got %s %s", req.Method, req.URL.Path)
+				}
+				if req.URL.Query().Get("a") != "b" {
+					t.Errorf("Backend Req: expected query a=b, got %q", req.URL.RawQuery)
+				}
+				if req.Header.Get("X-GFE") != "google.com" {
+					t.Errorf("Backend Req: expected header X-GFE=google.com, got %q", req.Header.Get("X-GFE"))
+				}
+				body, _ := io.ReadAll(req.Body)
+				if !bytes.Equal(body, []byte("thebody")) {
+					t.Errorf("Backend Req: body mismatch, got %q", body)
+				}
+				return &http.Response{
+					StatusCode: 201,
+					Header:     http.Header{"Priority": []string{"High"}},
+					Body:       io.NopCloser(bytes.NewReader([]byte("theresponsebody"))),
+				}, nil
+			},
+		}
 
 		config := DefaultClientConfig()
 		config.ServerName = "foo"
 		client := NewClient(config)
-		err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
+
+		relayClient := &http.Client{Transport: relayTransport}
+		backendClient := &http.Client{Transport: backendTransport}
+
+		err := client.localProxy(t.Context(), relayClient, backendClient)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		assertMocksDoneWithin(t, 10*time.Second)
+
+		synctest.Wait()
+
+		if relayRequests != 2 {
+			t.Errorf("Expected 2 requests to relay, got %d", relayRequests)
+		}
+		if backendRequests != 1 {
+			t.Errorf("Expected 1 request to backend, got %d", backendRequests)
+		}
 	})
 }
 
 func TestBackendError(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		// Hot patch: gock refuses to match bodies with unknown content-types by default.
-		gock.BodyTypes = append(gock.BodyTypes, "application/vnd.google.protobuf;proto=cloudrobotics.http_relay.v1alpha1.HttpResponse")
-		defer gock.Off()
-
 		// We expect the response below to always contain 0 milliseconds.
 		timeSince = func(t time.Time) time.Duration { return 0 * time.Millisecond }
 
-		// The pending request on the relay-server side.
-		req, _ := proto.Marshal(&pb.HttpRequest{
+		reqPayload, _ := proto.Marshal(&pb.HttpRequest{
 			Id:     proto.String("15"),
 			Method: proto.String("GET"),
 			Url:    proto.String("http://invalid/foo/bar?a=b"),
@@ -138,7 +163,7 @@ func TestBackendError(t *testing.T) {
 			Body: []byte("thebody"),
 		})
 
-		resp, _ := proto.Marshal(&pb.HttpResponse{
+		respPayload, _ := proto.Marshal(&pb.HttpResponse{
 			Id:                proto.String("15"),
 			StatusCode:        proto.Int32(400),
 			Body:              []byte("theresponsebody"),
@@ -146,79 +171,108 @@ func TestBackendError(t *testing.T) {
 			BackendDurationMs: proto.Int64(0),
 		})
 
-		relayServerAddress := "https://localhost:8081"
-		backendServerAddress := "https://localhost:8080"
+		relayRequests := 0
+		relayTransport := &mockTransport{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				relayRequests++
+				switch relayRequests {
+				case 1:
+					if req.Method != "GET" || req.URL.Path != "/server/request" {
+						t.Errorf("Relay Req 1: expected GET /server/request, got %s %s", req.Method, req.URL.Path)
+					}
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader(reqPayload)),
+					}, nil
+				case 2:
+					if req.Method != "POST" || req.URL.Path != "/server/response" {
+						t.Errorf("Relay Req 2: expected POST /server/response, got %s %s", req.Method, req.URL.Path)
+					}
+					body, _ := io.ReadAll(req.Body)
+					if !bytes.Equal(body, respPayload) {
+						t.Errorf("Relay Req 2: body mismatch")
+					}
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				default:
+					t.Errorf("Unexpected extra request to relay: %s %s", req.Method, req.URL.Path)
+					return nil, fmt.Errorf("unexpected request")
+				}
+			},
+		}
 
-		// Mocks the response from the relay server from which we are getting
-		// the initial data.
-		gock.New(relayServerAddress).
-			Get("/server/request").
-			MatchParam("server", "foo").
-			Reply(200).
-			BodyString(string(req))
-
-		// Mocks the response from the backend server to which we relayed data.
-		gock.New(backendServerAddress).
-			Get("/foo/bar").
-			MatchParam("a", "b").
-			MatchHeader("X-GFE", "google.com").
-			BodyString("thebody").
-			Reply(400).
-			BodyString("theresponsebody")
-
-		// Mocks the response from the realy-server after having received the
-		// actual backend response.
-		gock.New(relayServerAddress).
-			Post("/server/response").
-			Body(bytes.NewReader(resp)).
-			Reply(200)
+		backendRequests := 0
+		backendTransport := &mockTransport{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				backendRequests++
+				if req.Method != "GET" || req.URL.Path != "/foo/bar" {
+					t.Errorf("Backend Req: expected GET /foo/bar, got %s %s", req.Method, req.URL.Path)
+				}
+				return &http.Response{
+					StatusCode: 400,
+					Body:       io.NopCloser(bytes.NewReader([]byte("theresponsebody"))),
+				}, nil
+			},
+		}
 
 		config := DefaultClientConfig()
 		config.ServerName = "foo"
 		client := NewClient(config)
 
-		// localProxy ...
-		// 1. pulls a request from the realy-server (/server/request)
-		// 2. send that request to the backend server (here localhost:8080/foo/bar?a=b)
-		// 3. retrieves the response from the backend and sends it to the relay-server
-		err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
+		relayClient := &http.Client{Transport: relayTransport}
+		backendClient := &http.Client{Transport: backendTransport}
+
+		err := client.localProxy(t.Context(), relayClient, backendClient)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		assertMocksDoneWithin(t, 10*time.Second)
+
+		synctest.Wait()
+
+		if relayRequests != 2 {
+			t.Errorf("Expected 2 requests to relay, got %d", relayRequests)
+		}
+		if backendRequests != 1 {
+			t.Errorf("Expected 1 request to backend, got %d", backendRequests)
+		}
 	})
 }
 
 func TestServerTimeout(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		// Hot patch: gock refuses to match bodies with application/octet-data
-		// by default.
-		gock.BodyTypes = append(gock.BodyTypes, "application/octet-data")
-		defer gock.Off()
-
-		req, _ := proto.Marshal(&pb.HttpRequest{
-			Id:     proto.String("15"),
-			Method: proto.String("GET"),
-			Url:    proto.String("http://invalid/foo/bar?a=b"),
-			Header: []*pb.HttpHeader{{
-				Name:  proto.String("X-GFE"),
-				Value: proto.String("google.com")}},
-			Body: []byte("thebody"),
-		})
-		gock.New("https://localhost:8081").
-			Get("/server/request").
-			MatchParam("server", "foo").
-			Reply(408).
-			BodyString(string(req))
+		relayRequests := 0
+		relayTransport := &mockTransport{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				relayRequests++
+				if req.Method != "GET" || req.URL.Path != "/server/request" {
+					t.Errorf("Relay Req: expected GET /server/request, got %s %s", req.Method, req.URL.Path)
+				}
+				return &http.Response{
+					StatusCode: 408,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			},
+		}
 
 		config := DefaultClientConfig()
 		config.ServerName = "foo"
 		client := NewClient(config)
-		err := client.localProxy(t.Context(), &http.Client{}, &http.Client{})
+
+		relayClient := &http.Client{Transport: relayTransport}
+		backendClient := &http.Client{} // not used
+
+		err := client.localProxy(t.Context(), relayClient, backendClient)
 		if err != ErrTimeout {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		assertMocksDoneWithin(t, 10*time.Second)
+
+		synctest.Wait()
+
+		if relayRequests != 1 {
+			t.Errorf("Expected 1 request to relay, got %d", relayRequests)
+		}
 	})
 }
 


### PR DESCRIPTION
This lets us drop the gock dependency (only used in this test). Using a mocktransport is also a more common way in go to address such testing needs.