### PR TITLE
Eliminate klog v1 dependency.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,7 +77,6 @@ use_repo(
     "io_k8s_cli_runtime",
     "io_k8s_client_go",
     "io_k8s_helm",
-    "io_k8s_klog",
     "io_k8s_klog_v2",
     "io_k8s_sigs_controller_runtime",
     "io_k8s_sigs_kind",

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	k8s.io/cli-runtime v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/helm v2.17.0+incompatible
-	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/kind v0.32.0
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -172,7 +172,6 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -865,8 +864,6 @@ k8s.io/client-go v0.36.2 h1:bfgxmFKc9CgqsgX4xKLAAdmTQlWee7Ob/HlDOrJ5TBI=
 k8s.io/client-go v0.36.2/go.mod h1:1vgO4OAlfPnoLcb+Rze2GF5rAr14w8qjrYMoyXJzQj0=
 k8s.io/helm v2.17.0+incompatible h1:Bpn6o1wKLYqKM3+Osh8e+1/K2g/GsQJ4F4yNF2+deao=
 k8s.io/helm v2.17.0+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hkbPJgdATINPMAxaynU2Ovg=

--- a/src/go/cmd/cr-syncer/BUILD.bazel
+++ b/src/go/cmd/cr-syncer/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_k8s_client_go//util/workqueue:go_default_library",
-        "@io_k8s_klog//:go_default_library",
+        "@io_k8s_klog_v2//:go_default_library",
         "@io_opencensus_go//plugin/ochttp:go_default_library",
         "@io_opencensus_go//stats:go_default_library",
         "@io_opencensus_go//stats/view:go_default_library",

--- a/src/go/cmd/cr-syncer/main.go
+++ b/src/go/cmd/cr-syncer/main.go
@@ -74,7 +74,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -238,6 +238,7 @@ func streamCrds(done <-chan struct{}, clientset crdclientset.Interface, crds cha
 }
 
 func main() {
+	// Initialize klog flags (e.g. -v) to allow configuring client-go's internal logging verbosity.
 	klog.InitFlags(nil)
 	flag.Parse()
 

--- a/src/go/tests/BUILD.bazel
+++ b/src/go/tests/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
         "@io_k8s_apimachinery//pkg/util/yaml:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//util/jsonpath:go_default_library",
-        "@io_k8s_klog_v2//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
         "@org_golang_x_oauth2//google:go_default_library",
     ],

--- a/src/go/tests/k8s_integration_test_auth_helper.go
+++ b/src/go/tests/k8s_integration_test_auth_helper.go
@@ -35,18 +35,21 @@ import (
 	"sync"
 	"time"
 
+	"log/slog"
+	"os"
+
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/jsonpath"
-	"k8s.io/klog/v2"
 )
 
 func init() {
 	if err := restclient.RegisterAuthProviderPlugin("gcp", newGCPAuthProvider); err != nil {
-		klog.Fatalf("Failed to register gcp auth plugin: %v", err)
+		slog.Error("Failed to register gcp auth plugin", slog.Any("error", err))
+		os.Exit(1)
 	}
 }
 
@@ -124,7 +127,7 @@ var warnOnce sync.Once
 
 func newGCPAuthProvider(_ string, gcpConfig map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
 	warnOnce.Do(func() {
-		klog.Warningf(`WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.26+; use gcloud instead.
+		slog.Warn(`WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.26+; use gcloud instead.
 To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke`)
 	})
 
@@ -237,7 +240,7 @@ func (t *cachedTokenSource) Token() (*oauth2.Token, error) {
 	cache := t.update(tok)
 	if t.persister != nil {
 		if err := t.persister.Persist(cache); err != nil {
-			klog.V(4).Infof("Failed to persist token: %v", err)
+			slog.Debug("Failed to persist token", slog.Any("error", err))
 		}
 	}
 	return tok, nil
@@ -343,7 +346,7 @@ func (c *commandTokenSource) parseTokenCmdOutput(output []byte) (*oauth2.Token, 
 	}
 	var expiry time.Time
 	if t, err := time.Parse(c.timeFmt, expiryStr); err != nil {
-		klog.V(4).Infof("Failed to parse token expiry from %s (fmt=%s): %v", expiryStr, c.timeFmt, err)
+		slog.Debug("Failed to parse token expiry", slog.String("expiry", expiryStr), slog.String("format", c.timeFmt), slog.Any("error", err))
 	} else {
 		expiry = t
 	}
@@ -387,7 +390,7 @@ func (t *conditionalTransport) RoundTrip(req *http.Request) (*http.Response, err
 	}
 
 	if res.StatusCode == 401 {
-		klog.V(4).Infof("The credentials that were supplied are invalid for the target cluster")
+		slog.Debug("The credentials that were supplied are invalid for the target cluster")
 		t.persister.Persist(t.resetCache)
 	}
 


### PR DESCRIPTION
* Switch last use to klog/v2.
* Switch test to use slong, rather than klog.
* Add a comment why we added klog in cr-syncer/main.go