### PR TITLE
Some minor optimization to NGINX shield to handle connection bursts

### DIFF
--- a/src/app_charts/base/cloud/nginx-ingress-controller-shield-configmap.yaml
+++ b/src/app_charts/base/cloud/nginx-ingress-controller-shield-configmap.yaml
@@ -175,7 +175,7 @@ data:
 
       # Set the maximum number of simultaneous connections
       # that can be opened by a worker process
-      worker_connections 4096;
+      worker_connections 8192;
     }
 
     http {
@@ -268,19 +268,19 @@ data:
       # Upstream pool for standard HTTP/HTTPS traffic
       upstream backend_http {
           server nginx-ingress-controller-internal:443;
-          keepalive 64;
+          keepalive 256;
       }
 
       # Upstream pool for gRPC traffic
       upstream backend_grpc {
           server nginx-ingress-controller-internal:443;
-          keepalive 64;
+          keepalive 256;
       }
 
       # Listen on port 80 for non-secure HTTP requests
       # Redirect all HTTP traffic to HTTPS (port 443) using a 301 Permanent Redirect.
       server {
-          listen 80;
+          listen 80 backlog=4096;
           server_name _;
           return 301 https://$host$request_uri;
       }
@@ -289,7 +289,7 @@ data:
       server {
 
         # Listen on port 443 for all secure HTTPS requests.
-        listen 443 ssl default_server;
+        listen 443 ssl default_server backlog=4096;
 
         # Enable HTTP/2
         http2 on;
@@ -427,7 +427,7 @@ data:
     pid /tmp/nginx.pid;
 
     events {
-      worker_connections 4096;
+      worker_connections 8192;
     }
 
     http {
@@ -445,12 +445,12 @@ data:
 
       upstream backend_http_bootstrap {
           server nginx-ingress-controller-internal:80;
-          keepalive 64;
+          keepalive 256;
       }
 
       # Bootstrap configuration for HTTP-01 challenges
       server {
-          listen 80;
+          listen 80 backlog=4096;
           server_name _;
 
           # Verify that responses come from CRC NGINX Shield


### PR DESCRIPTION
Some minor optimization to NGINX shield to handle connection bursts
- increase worker_connections
- increase upstream keepalive
- increase listen backlog