### PR TITLE
Replace deprecated go module.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -87,10 +87,10 @@ use_repo(
     "org_golang_google_api",
     "org_golang_google_grpc",
     "org_golang_google_protobuf",
-    "org_golang_x_crypto",
     "org_golang_x_net",
     "org_golang_x_oauth2",
     "org_golang_x_sync",
+    "org_golang_x_term",
 )
 
 #######

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.opencensus.io v0.24.0
-	golang.org/x/crypto v0.54.0
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
@@ -139,7 +139,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
-	// TODO: remove this indirect dependency once sigs.k8s.io/controller-runtime is updated to v0.24.1 or higher
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jaypipes/pcidb v1.1.1
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -160,7 +159,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
-	golang.org/x/term v0.45.0 // indirect
+	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/src/go/pkg/setup/BUILD.bazel
+++ b/src/go/pkg/setup/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_client_go//dynamic:go_default_library",
-        "@org_golang_x_crypto//ssh/terminal:go_default_library",
+        "@org_golang_x_term//:go_default_library",
     ],
 )
 

--- a/src/go/pkg/setup/setupcommon.go
+++ b/src/go/pkg/setup/setupcommon.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/googlecloudrobotics/core/src/go/pkg/robotauth"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -71,7 +71,7 @@ func GetRobotName(ctx context.Context, r io.Reader, client dynamic.ResourceInter
 // exitIfNotRunningInTerminal checks if stdin is connected to a terminal. If
 // not, it prints the given message and exits.
 func exitIfNotRunningInTerminal(message ...interface{}) {
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		fmt.Fprintln(os.Stderr, message...)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Migrated the deprecated `golang.org/x/crypto/ssh/terminal` package to `golang.org/x/term` in src/go/pkg/setup/setupcommon.go.

(Also remove old stale TODO comment in go.mod).