### PR TITLE
Add readiness probes to Deployments lacking them.

### DIFF
--- a/src/app_charts/base/cloud/app-management.yaml
+++ b/src/app_charts/base/cloud/app-management.yaml
@@ -33,11 +33,17 @@ spec:
         - name: GOOGLE_CLOUD_PROJECT
           value: {{ .Values.project }}
         livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 10
           httpGet:
             port: 8080
             path: /healthz
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 5
+          failureThreshold: 2
         ports:
         - name: webhook
           containerPort: 9876

--- a/src/app_charts/base/robot/cr-syncer.yaml
+++ b/src/app_charts/base/robot/cr-syncer.yaml
@@ -33,6 +33,12 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 120
           timeoutSeconds: 60
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 5
+          failureThreshold: 2
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/src/app_charts/chart-assignment-controller/templates/deployment.yaml
+++ b/src/app_charts/chart-assignment-controller/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 2
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/src/app_charts/k8s-relay/cloud/kubernetes-relay-server.yaml
+++ b/src/app_charts/k8s-relay/cloud/kubernetes-relay-server.yaml
@@ -28,6 +28,12 @@ spec:
             port: 8080
           initialDelaySeconds: 15
           timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 5
+          failureThreshold: 2
         ports:
         - name: http
           containerPort: 8080

--- a/src/app_charts/prometheus/cloud/prometheus-relay.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-relay.yaml
@@ -25,6 +25,12 @@ spec:
             path: /healthz
             port: 8080
           initialDelaySeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 5
+          failureThreshold: 2
         ports:
         - name: http
           containerPort: 8080

--- a/src/app_charts/token-vendor/cloud/token-vendor.yaml
+++ b/src/app_charts/token-vendor/cloud/token-vendor.yaml
@@ -47,6 +47,12 @@ spec:
             path: /healthz
             port: 9090
           initialDelaySeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          periodSeconds: 5
+          failureThreshold: 2
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Insert readiness probes for Deployments that have liveness probes but no readiness probes, targeting the same endpoint. This ensures that pods do not receive traffic until they are actually ready, improving update safety. The probes use a periodSeconds of 5 and failureThreshold of 2 to balance quick readiness detection with reasonable probing frequency.