### PR TITLE
default disk type to null; add deploy.sh plan

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -39,6 +39,7 @@ fi
 
 TERRAFORM_DIR="${DIR}/src/bootstrap/cloud/terraform"
 TERRAFORM_APPLY_FLAGS=${TERRAFORM_APPLY_FLAGS:- -auto-approve}
+TERRAFORM_PLAN_FLAGS=${TERRAFORM_PLAN_FLAGS:-}
 # utility functions
 
 function include_config_and_defaults {
@@ -214,6 +215,13 @@ function terraform_apply {
   terraform_exec apply ${TERRAFORM_APPLY_FLAGS} \
     || die "terraform apply failed"
   terraform_post
+}
+
+function terraform_plan {
+  terraform_init
+
+  terraform_exec plan ${TERRAFORM_PLAN_FLAGS} \
+    || die "terraform plan failed"
 }
 
 function terraform_post {
@@ -409,9 +417,14 @@ function update_infra {
   terraform_apply
 }
 
+function plan {
+  include_config_and_defaults $1
+  terraform_plan
+}
+
 # main
-if [[ "$#" -lt 2 ]] || [[ ! "$1" =~ ^(set_config|create|delete|update|fast_push|update_infra)$ ]]; then
-  die "Usage: $0 {set_config|create|delete|update|fast_push|update_infra} <project id>"
+if [[ "$#" -lt 2 ]] || [[ ! "$1" =~ ^(set_config|create|delete|update|fast_push|update_infra|plan)$ ]]; then
+  die "Usage: $0 {set_config|create|delete|update|fast_push|update_infra|plan} <project id>"
 fi
 
 # log and call arguments verbatim:

--- a/src/bootstrap/cloud/terraform/cluster.tf
+++ b/src/bootstrap/cloud/terraform/cluster.tf
@@ -5,7 +5,8 @@
 # workloads: see workload-identity.tf for those service accounts.
 
 locals {
-  node_disk_type = var.node_disk_type != null ? var.node_disk_type : (startswith(var.node_machine_type, "n4") ? "hyperdisk-balanced" : "pd-balanced")
+  # 4th gen machines (n4, c4, n4d etc) only supports hyperdisk
+  node_disk_type = var.node_disk_type != null ? var.node_disk_type : substr(var.node_machine_type, 1, 1) == "4" ? "hyperdisk-balanced" : null
 }
 
 resource "google_container_cluster" "cloud-robotics" {


### PR DESCRIPTION
- Defaults disk type to `null` to avoid changing existing clusters that uses `pd-standard`.
- Add `deploy.sh plan` to see the terraform changes before applying.