### PR TITLE
Use token-vender from its own namessapce.

### DIFF
--- a/docs/how-to/deploying-grpc-service.md
+++ b/docs/how-to/deploying-grpc-service.md
@@ -150,7 +150,7 @@ metadata:
   name: greeter-server-ingress
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
   rules:

--- a/docs/how-to/deploying-service.md
+++ b/docs/how-to/deploying-service.md
@@ -167,7 +167,7 @@ kind: Ingress
 metadata:
   name: hello-server-ingress
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
   rules:

--- a/docs/how-to/examples/greeter-service/greeter-server.yaml.tmpl
+++ b/docs/how-to/examples/greeter-service/greeter-server.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: greeter-server-ingress
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
   rules:

--- a/docs/how-to/examples/hello-service/server/hello-server.yaml
+++ b/docs/how-to/examples/hello-service/server/hello-server.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: hello-server-ingress
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
   rules:

--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -19,7 +19,7 @@ spec:
         - --provider=oidc
         - --oidc-issuer-url=https://accounts.google.com
         - --email-domain=*
-        - --upstream=http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/
+        - --upstream=http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/
         - --upstream=https://{{ .Values.domain }}/
         - --http-address=0.0.0.0:8080
         - --pass-access-token

--- a/src/app_charts/k8s-relay/cloud/ingress.yaml
+++ b/src/app_charts/k8s-relay/cloud/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: kubernetes-relay-client
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify"
     nginx.ingress.kubernetes.io/client-body-buffer-size: "50m"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     # proxy-read-timeout sets how long nginx will allow a request to be idle
@@ -33,7 +33,7 @@ metadata:
     nginx.ingress.kubernetes.io/client-body-buffer-size: "50m"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/rewrite-target: /server/$2
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
   rules:

--- a/src/app_charts/prometheus/cloud/prometheus-relay.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-relay.yaml
@@ -74,7 +74,7 @@ metadata:
     nginx.ingress.kubernetes.io/client-body-buffer-size: "50m"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/rewrite-target: /server/$2
-    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
+    nginx.ingress.kubernetes.io/auth-url: "http://token-vendor.app-token-vendor.svc.cluster.local/apis/core.token-vendor/v1/token.verify?robots=true"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Update some of the legacy urls. This avoids an extra service hop.