### PR TITLE
Reduce prom retention yet again

### DIFF
--- a/src/app_charts/prometheus/prometheus-robot.values.yaml
+++ b/src/app_charts/prometheus/prometheus-robot.values.yaml
@@ -62,11 +62,11 @@ prometheus:
     # `retentionSize`. WAL+maxChunkSize also counted toward retentionSize,
     # but Prometheus puts no limit on WAL size, so it's up to us to make
     # sure we don't have too many metrics and the WAL doesn't grow too big.
-    retention: "3h"
+    retention: "1h"
     # If you increase retentionSize, increase sizeLimit below as well, but
     # remember that this is RAM, not disk. We don't know how much headroom
     # is needed, but if set equal you can still run out of disk space.
-    retentionSize: 448MB
+    retentionSize: 200MB
     # Reduce the max chunk size (default=512MB) to reduce the headroom required
     # for the in-progress chunk.
     # This chunk size correlates with the current retention size. Larger


### PR DESCRIPTION
Reduce prom retention yet again

On the robot we see a lot of metric growth causing 3h retention be too much.