### PR TITLE
✨ bootstrap: forward optional flags in run-install.sh

### DIFF
--- a/src/bootstrap/cloud/run-install.sh
+++ b/src/bootstrap/cloud/run-install.sh
@@ -20,7 +20,9 @@ set -o pipefail -o errexit
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUCKET_URI=${BUCKET_URI:-"https://storage.googleapis.com/cloud-robotics-releases"}
-if [[ $# -lt 1 || -z "$1" || "$1" == -* ]]; then
+GCP_PROJECT_ID="$1"
+
+if [[ -z "${GCP_PROJECT_ID}" || "${GCP_PROJECT_ID}" == -* ]]; then
   echo "Usage: $0 <project id> [<version-file>|<tarball>] [<command>] [deploy-args...]"
   echo "Supported commands:"
   echo "  --set-config    Updates the cloud config interactively."
@@ -31,7 +33,6 @@ if [[ $# -lt 1 || -z "$1" || "$1" == -* ]]; then
   exit 1
 fi
 
-GCP_PROJECT_ID="$1"
 shift
 
 TARGET="latest"

--- a/src/bootstrap/cloud/run-install.sh
+++ b/src/bootstrap/cloud/run-install.sh
@@ -20,25 +20,30 @@ set -o pipefail -o errexit
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUCKET_URI=${BUCKET_URI:-"https://storage.googleapis.com/cloud-robotics-releases"}
-GCP_PROJECT_ID="$1"
-
-if [[ -z "$2" || "$2" = --* ]]; then
-  TARGET="latest"
-  COMMAND="$2"
-else
-  TARGET="$2"
-  COMMAND="$3"
-fi
-
-if [[ -z "${GCP_PROJECT_ID}" || ! "${COMMAND}" =~ ^(|--set-config|--set-oauth|--delete|--terraform)$ ]]; then
-  echo "Usage: $0 <project id> [<version-file>|<tarball>] [<command>]"
+if [[ $# -lt 1 || -z "$1" || "$1" == -* ]]; then
+  echo "Usage: $0 <project id> [<version-file>|<tarball>] [<command>] [deploy-args...]"
   echo "Supported commands:"
   echo "  --set-config    Updates the cloud config interactively."
   echo "  --set-oauth     Enables and configures OAuth interactively."
   echo "  --delete        Deletes Cloud Robotics from the cloud project."
   echo "  --terraform     Apply only terraform changes."
-  echo "  (default)       Install the specifies version."
+  echo "  (default)       Install the specified version."
   exit 1
+fi
+
+GCP_PROJECT_ID="$1"
+shift
+
+TARGET="latest"
+if [[ $# -gt 0 && -n "$1" && "$1" != -* ]]; then
+  TARGET="$1"
+  shift
+fi
+
+COMMAND=""
+if [[ $# -gt 0 && "$1" =~ ^(--set-config|--set-oauth|--delete|--terraform)$ ]]; then
+  COMMAND="$1"
+  shift
 fi
 
 if [[ ! "${TARGET}" = *.tar.gz ]]; then
@@ -58,20 +63,20 @@ if [[ $SHELLOPTS =~ xtrace ]] ; then
 fi
 
 if [[ "${COMMAND}" = "--set-config" ]]; then
-  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}"
+  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" "$@"
 elif [[ "${COMMAND}" = "--set-oauth" ]]; then
-  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --edit-oauth
+  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --edit-oauth "$@"
 elif [[ "${COMMAND}" = "--delete" ]]; then
-  $BASH ./deploy.sh delete "${GCP_PROJECT_ID}"
+  $BASH ./deploy.sh delete "${GCP_PROJECT_ID}" "$@"
 else
   # We tag the setup-robot files with this information to be able to check if
   # cloud and robot-installations are in sync
   export TARGET
   $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --ensure-config
   if [[ "${COMMAND}" = "--terraform" ]]; then
-    $BASH ./deploy.sh update_infra "${GCP_PROJECT_ID}"
+    $BASH ./deploy.sh update_infra "${GCP_PROJECT_ID}" "$@"
   else
-    $BASH ./deploy.sh create "${GCP_PROJECT_ID}"
+    $BASH ./deploy.sh create "${GCP_PROJECT_ID}" "$@"
   fi
 fi
 


### PR DESCRIPTION
Refactor argument parsing in `run-install.sh` to support forwarding optional deploy flags (such as `-f` / `--values`) to `deploy.sh` and `set-config.sh`.

#### Why

Allow callers of `run-install.sh` to pass additional flags (e.g. Helm values files like `-f values-envoyExtAuthzHttp.yaml`) through to `deploy.sh create`, where they are passed to `helm template`.

#### The code changes include:

- Use `shift` in `run-install.sh` to parse `<project_id>`, optional `<version>`, and optional `<command>` while retaining any trailing deploy flags in `"$@"`
- Forward `"$@"` to `deploy.sh` (`create`, `update_infra`, `delete`) and `set-config.sh`