### PR TITLE
🐛 (k8s-relay): fix inverted auth providers in relay AuthorizationPolicies

### DIFF
--- a/src/app_charts/k8s-relay/cloud/http-route.yaml
+++ b/src/app_charts/k8s-relay/cloud/http-route.yaml
@@ -63,7 +63,7 @@ spec:
     name: kubernetes-relay-client
   action: CUSTOM
   provider:
-    name: auth-provider-tv-robots-false
+    name: auth-provider-tv-robots-true
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
@@ -76,4 +76,4 @@ spec:
     name: kubernetes-relay-server
   action: CUSTOM
   provider:
-    name: auth-provider-tv-robots-true
+    name: auth-provider-tv-robots-false


### PR DESCRIPTION
Fix swapped `auth-provider-tv-robots-true` and `auth-provider-tv-robots-false` providers on `kubernetes-relay-client-auth` and `kubernetes-relay-server-auth` AuthorizationPolicies.

#### Why

The robot relay client uses robot token authentication when connecting to `/apis/core.kubernetes-relay/client`. Assigning `auth-provider-tv-robots-false` caused authentication failures on the relay client route, breaking the Cloud-to-Robot relay connection and causing `TestCloudClusterAppStatus` in `//src/go/tests:go_default_test` to time out after 7 minutes.

#### The code changes include:

- Assign `auth-provider-tv-robots-true` to `kubernetes-relay-client-auth` AuthorizationPolicy
- Assign `auth-provider-tv-robots-false` to `kubernetes-relay-server-auth` AuthorizationPolicy

go/traj/9725df8e-fd47-489e-b7c2-487e27e381c1
TESTED=UNITTESTS
RELNOTES=NONE
TAG=agy
CONV=9725df8e-fd47-489e-b7c2-487e27e381c1