### PR TITLE
Make Grafana a standalone application

### DIFF
--- a/src/app_charts/BUILD.bazel
+++ b/src/app_charts/BUILD.bazel
@@ -7,6 +7,7 @@ APPS = [
     "k8s-relay",
     "mission-crd",
     "prometheus",
+    "grafana",
     "token-vendor",
     "akri",
 ]

--- a/src/app_charts/base/cloud/oauth2-proxy.yaml
+++ b/src/app_charts/base/cloud/oauth2-proxy.yaml
@@ -181,6 +181,9 @@ spec:
   - group: gateway.envoyproxy.io
     kind: SecurityPolicy
     namespace: app-prometheus
+  - group: gateway.envoyproxy.io
+    kind: SecurityPolicy
+    namespace: app-grafana
   to:
   - group: ""
     kind: Service

--- a/src/app_charts/grafana/BUILD.bazel
+++ b/src/app_charts/grafana/BUILD.bazel
@@ -1,0 +1,35 @@
+load("//bazel:app.bzl", "app")
+load("//bazel:app_chart.bzl", "app_chart")
+load("//bazel:build_rules/helm_template.bzl", "helm_template")
+
+helm_template(
+    name = "grafana-operator-chart.cloud",
+    # We use the kube-prometheus-stack chart instead of the standalone grafana chart
+    # because it natively bundles all the default Kubernetes mixin dashboards (like node-exporter,
+    # kubelet, apiserver) as ConfigMaps. We disable the rest of the backend components in the values file.
+    chart = "//third_party/kube-prometheus-stack:kube-prometheus-stack-87.5.1.tgz",
+    helm_version = 3,
+    kube_version = "1.29.0",
+    # The namespace will later be replaced with the actual one.
+    namespace = "HELM-NAMESPACE",
+    # Pick a short release name as it will be used as a prefix for a lot of resources.
+    release_name = "grafana",
+    values = "grafana-cloud.values.yaml",
+)
+
+app_chart(
+    name = "grafana-cloud",
+    # CRITICAL: Do NOT include 00-crds.yaml to prevent ownership collisions with Prometheus
+    extra_values = ["values-cloud.yaml"],
+    files = [
+        ":grafana-operator-chart.cloud",
+    ],
+)
+
+app(
+    name = "grafana",
+    charts = [
+        ":grafana-cloud",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/app_charts/grafana/cloud/app.yaml
+++ b/src/app_charts/grafana/cloud/app.yaml
@@ -1,0 +1,32 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: "grafana"
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: apps
+    kind: Ingress
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  - group: gateway.envoyproxy.io
+    kind: SecurityPolicy
+  descriptor:
+    type: "grafana"
+    version: {{ .Chart.Version }}
+    description: "Grafana provides visualization dashboards"
+    keywords:
+    - "dashboard"
+    - "visualization"
+    links:
+    - description: Grafana Dashboard
+      url: "https://{{ .Values.domain }}/grafana/"

--- a/src/app_charts/grafana/cloud/grafana-datasources.yaml
+++ b/src/app_charts/grafana/cloud/grafana-datasources.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  labels:
+    grafana_datasource: "1"
+    app.kubernetes.io/name: {{ .Chart.Name }}
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    {{- if .Values.datasources }}
+    datasources:
+{{ toYaml .Values.datasources | indent 4 }}
+    {{- else }}
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      uid: prometheus
+      url: http://kube-prometheus.{{ .Values.prometheusNamespace | default "app-prometheus" }}.svc.cluster.local:9090
+      access: proxy
+      isDefault: true
+{{- end }}

--- a/src/app_charts/grafana/cloud/grafana-http-route.yaml
+++ b/src/app_charts/grafana/cloud/grafana-http-route.yaml
@@ -23,7 +23,7 @@ spec:
           type: ReplacePrefixMatch
           replacePrefixMatch: /
     backendRefs:
-    - name: prom-grafana
+    - name: grafana
       port: 80
   - matches:
     - path:
@@ -36,7 +36,7 @@ spec:
           type: ReplaceFullPath
           replaceFullPath: /
     backendRefs:
-    - name: prom-grafana
+    - name: grafana
       port: 80
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1

--- a/src/app_charts/grafana/cloud/grafana-ingress.yaml
+++ b/src/app_charts/grafana/cloud/grafana-ingress.yaml
@@ -23,6 +23,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: prom-grafana
+            name: grafana
             port:
               number: 80

--- a/src/app_charts/grafana/cloud/grafana-operator.yaml
+++ b/src/app_charts/grafana/cloud/grafana-operator.yaml
@@ -1,0 +1,25 @@
+# This includes all resources expanded from the grafana-operator chart using
+# the values in ../grafana-cloud.values.yaml.
+# Some pseudo-variables that were inserted there are replaced with actual runtime values.
+# NOTE: The order here is important. The domain and project might be part of other values and
+#       need to be replaced last.
+{{- $data := .Files.Get "files/grafana-operator-chart.cloud.yaml" -}}
+# Pre-process variables
+{{- $data = $data | replace "${CR_GF_INGRESS_AUTH_URL}" .Values.gf_ingress_auth_url -}}
+{{- $data = $data | replace "${CR_GF_INGRESS_AUTH_SIGNIN}" .Values.gf_ingress_auth_signin -}}
+{{- $data = $data | replace "${CR_GF_INGRESS_ERROR_PAGE_403}" .Values.gf_ingress_error_page_403 -}}
+{{- $data = $data | replace "${CR_GF_SERVER_DOMAIN}" .Values.gf_server_domain -}}
+{{- $data = $data | replace "${CR_GF_SERVER_ROOT_URL}" .Values.gf_server_root_url -}}
+{{- $data = $data | replace "${CR_GF_CSRF_TRUSTED_ORIGINS}" .Values.gf_csrf_trusted_origins -}}
+{{- $data = $data | replace "${CR_GF_SMTP_ENABLED}" .Values.gf_smtp_enabled -}}
+{{- $data = $data | replace "${CR_GF_SMTP_HOST}" .Values.gf_smtp_host -}}
+{{- $data = $data | replace "${CR_GF_SMTP_USER}" .Values.gf_smtp_user -}}
+{{- $data = $data | replace "${CR_GF_SMTP_PASSWORD}" .Values.gf_smtp_password -}}
+{{- $data = $data | replace "${CR_GF_SMTP_FROM_ADDRESS}" .Values.gf_smtp_from_address -}}
+{{- $data = $data | replace "${CR_GF_SMTP_FROM_NAME}" .Values.gf_smtp_from_name -}}
+{{- $data = $data | replace "${CR_GF_SMTP_SKIP_VERIFY}" .Values.gf_smtp_skip_verify -}}
+{{- $data = $data | replace "HELM-NAMESPACE" .Release.Namespace -}}
+{{- $data = $data | replace "${CLOUD_ROBOTICS_DOMAIN}" .Values.domain -}}
+{{- $data = $data | replace "${GCP_PROJECT_ID}" .Values.project -}}
+
+{{ $data }}

--- a/src/app_charts/grafana/grafana-cloud.values.yaml
+++ b/src/app_charts/grafana/grafana-cloud.values.yaml
@@ -1,0 +1,69 @@
+nameOverride: kube
+fullnameOverride: kube
+
+kubeTargetVersionOverride: "1.23.8"
+
+# We use the kube-prometheus-stack chart instead of the standalone grafana chart
+# because the stack chart natively bundles and updates a large collection of standard
+# kubernetes monitoring dashboards (via kubernetes-mixin, node-exporter-mixin, etc.) 
+# as ConfigMaps. By disabling the rest of the backend components and keeping only Grafana 
+# enabled, we get a fully configured standalone Grafana with all the rich Kubernetes 
+# observability dashboards maintained for us out of the box.
+grafana:
+  # default password used by old releases, deployed behind auth-proxy so this
+  # is not a secret.
+  # we could also use "auth proxy authentication" but the second login defends
+  # against unintentional edits to dashboards.
+  adminPassword: "prom-operator"
+  testFramework:
+    enabled: false
+  env:
+    GF_SERVER_DOMAIN: "${CR_GF_SERVER_DOMAIN}"
+    GF_SERVER_ROOT_URL: "${CR_GF_SERVER_ROOT_URL}"
+    GF_AUTH_ANONYMOUS_ENABLED: "true"
+  # Load dashboards from configmaps with a given label across all namespaces.
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana # Label our own legacy grafana-operator uses.
+      searchNamespace: ALL
+      multicluster:
+        global:
+          enabled: true
+        etcd:
+          enabled: true
+  grafana.ini:
+    analytics:
+      check_for_updates: false
+    security:
+      csrf_trusted_origins: "${CR_GF_CSRF_TRUSTED_ORIGINS}"
+    smtp:
+      enabled: "${CR_GF_SMTP_ENABLED}"
+      host: "${CR_GF_SMTP_HOST}"
+      user: "${CR_GF_SMTP_USER}"
+      password: "${CR_GF_SMTP_PASSWORD}"
+      from_address: "${CR_GF_SMTP_FROM_ADDRESS}"
+      from_name: "${CR_GF_SMTP_FROM_NAME}"
+      skip_verify: "${CR_GF_SMTP_SKIP_VERIFY}"
+  serviceMonitor:
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      targetLabel: instance
+
+gf_ingress_auth_url: "${CR_GF_INGRESS_AUTH_URL}"
+gf_ingress_auth_signin: "${CR_GF_INGRESS_AUTH_SIGNIN}"
+gf_ingress_error_page_403: "${CR_GF_INGRESS_ERROR_PAGE_403}"
+
+# Disable all non-Grafana components
+defaultRules:
+  create: false
+alertmanager:
+  enabled: false
+prometheus:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+prometheusOperator:
+  enabled: false

--- a/src/app_charts/grafana/values-cloud.yaml
+++ b/src/app_charts/grafana/values-cloud.yaml
@@ -1,0 +1,43 @@
+# Enable toggle for the standalone app components
+grafana:
+  enabled: true
+
+# Grafana HTTP configuration
+gf_server_domain: "${CLOUD_ROBOTICS_DOMAIN}"
+gf_server_root_url: "https://${CLOUD_ROBOTICS_DOMAIN}/grafana"
+gf_csrf_trusted_origins: ""
+# Grafana Ingress configuration. Does not use the same replace as the values above.
+gf_ingress_auth_url: "http://oauth2-proxy.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify"
+# Header modification for Istio/HTTPRoutes support.
+gf_ingress_auth_url_header: ""
+gf_ingress_auth_url_headervalue: ""
+gf_ingress_auth_signin: "https://{{ .Values.domain }}/oauth2/start?rd=$escaped_request_uri"
+gf_ingress_error_page_403: "https://{{ .Values.domain }}/oauth2/start?rd=$escaped_request_uri"
+gf_auth_backend:
+  protocol: "http"
+  service: "oauth2-proxy"
+  namespace: "default"
+  port: 80
+  path: "/oauth2/auth"
+  contextExtensions: {}
+authProxy:
+  authHeaders:
+  - authorization
+  - cookie
+  - x-forwarded-access-token
+  - x-forwarded-host
+  - apikey-token
+  - x-server-name
+
+# Grafana SMTP configuration
+# Notes: these need to be all string, since we apply them using the template funtion "replace"
+gf_smtp_enabled: "false"
+gf_smtp_host: "smtp-host"
+gf_smtp_user: "smtp-user"
+gf_smtp_password: "smtp-api-key"
+gf_smtp_from_address: "from-address@example.com"
+gf_smtp_from_name: "from-name"
+gf_smtp_skip_verify: "true"
+
+# Fallback prometheus datasource namespace
+prometheusNamespace: "app-prometheus"

--- a/src/app_charts/prometheus/cloud/app.yaml
+++ b/src/app_charts/prometheus/cloud/app.yaml
@@ -21,6 +21,10 @@ spec:
     kind: Ingress
   - group: apps
     kind: StatefulSet
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  - group: gateway.envoyproxy.io
+    kind: SecurityPolicy
   descriptor:
     type: "prometheus"
     version: {{ .Chart.Version }}
@@ -31,5 +35,3 @@ spec:
     links:
     - description: Prometheus
       url: "https://{{ .Values.domain }}/prometheus/"
-    - description: Grafana Dashboard
-      url: "https://{{ .Values.domain }}/grafana/"

--- a/src/app_charts/prometheus/cloud/prometheus-operator.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-operator.yaml
@@ -7,7 +7,18 @@
 #       need to be replaced last.
 {{- $data := .Files.Get "files/prometheus-operator-chart.cloud.yaml" -}}
 # Pre-process variables
-{{- $data = $data | replace "${CR_GF_SERVER_DOMAIN}" .Values.gf_server_domain | replace "${CR_GF_SERVER_ROOT_URL}" .Values.gf_server_root_url | replace "${CR_GF_CSRF_TRUSTED_ORIGINS}" .Values.gf_csrf_trusted_origins | replace "${CR_GF_SMTP_ENABLED}" .Values.gf_smtp_enabled | replace "${CR_GF_SMTP_HOST}" .Values.gf_smtp_host | replace "${CR_GF_SMTP_USER}" .Values.gf_smtp_user | replace "${CR_GF_SMTP_PASSWORD}" .Values.gf_smtp_password | replace "${CR_GF_SMTP_FROM_ADDRESS}" .Values.gf_smtp_from_address | replace "${CR_GF_SMTP_FROM_NAME}" .Values.gf_smtp_from_name | replace "${CR_GF_SMTP_SKIP_VERIFY}" .Values.gf_smtp_skip_verify | replace "${CR_GF_INGRESS_AUTH_URL}" .Values.gf_ingress_auth_url | replace "${CR_GF_INGRESS_AUTH_SIGNIN}" .Values.gf_ingress_auth_signin | replace "${CR_GF_INGRESS_ERROR_PAGE_403}" .Values.gf_ingress_error_page_403 | replace "${CR_PROM_INGRESS_AUTH_URL}" .Values.prom_ingress_auth_url | replace "${CR_PROM_INGRESS_AUTH_SIGNIN}" .Values.prom_ingress_auth_signin | replace "${CR_PROM_INGRESS_ERROR_PAGE_403}" .Values.prom_ingress_error_page_403 | replace "HELM-NAMESPACE" .Release.Namespace | replace "${LIMITS_MEMORY}" .Values.limits.memory | replace "${LIMITS_CPU}" .Values.limits.cpu | replace "${REQUESTS_STORAGE}" .Values.requests.storage | replace "${RETENTION_TIME}" .Values.retention.time | replace "${RETENTION_SIZE}" .Values.retention.size | replace "${EXTERNAL_URL}" .Values.prom_external_url | replace "${CLOUD_ROBOTICS_DOMAIN}" .Values.domain | replace "${GCP_PROJECT_ID}" .Values.project -}}
+{{- $data = $data | replace "${CR_PROM_INGRESS_AUTH_URL}" .Values.prom_ingress_auth_url -}}
+{{- $data = $data | replace "${CR_PROM_INGRESS_AUTH_SIGNIN}" .Values.prom_ingress_auth_signin -}}
+{{- $data = $data | replace "${CR_PROM_INGRESS_ERROR_PAGE_403}" .Values.prom_ingress_error_page_403 -}}
+{{- $data = $data | replace "HELM-NAMESPACE" .Release.Namespace -}}
+{{- $data = $data | replace "${LIMITS_MEMORY}" .Values.limits.memory -}}
+{{- $data = $data | replace "${LIMITS_CPU}" .Values.limits.cpu -}}
+{{- $data = $data | replace "${REQUESTS_STORAGE}" .Values.requests.storage -}}
+{{- $data = $data | replace "${RETENTION_TIME}" .Values.retention.time -}}
+{{- $data = $data | replace "${RETENTION_SIZE}" .Values.retention.size -}}
+{{- $data = $data | replace "${EXTERNAL_URL}" .Values.prom_external_url -}}
+{{- $data = $data | replace "${CLOUD_ROBOTICS_DOMAIN}" .Values.domain -}}
+{{- $data = $data | replace "${GCP_PROJECT_ID}" .Values.project -}}
 
 # Inject the nodeSelector as a pre-formatted YAML block to allow users to define multiple selectors in a dict within values-cloud.yaml while maintaining valid indentation in the output.
 {{- $prometheusNodeSelectorMap := .Values.prometheus.prometheusSpec.nodeSelector -}}

--- a/src/app_charts/prometheus/prometheus-cloud.values.yaml
+++ b/src/app_charts/prometheus/prometheus-cloud.values.yaml
@@ -182,49 +182,7 @@ nodeExporter:
       targetLabel: instance
 
 grafana:
-  # default password used by old releases, deployed behind auth-proxy so this
-  # is not a secret.
-  # we could also use "auth proxy authentication" but the second login defends
-  # against unintentional edits to dashboards.
-  adminPassword: "prom-operator"
-  testFramework:
-    enabled: false
-  env:
-    GF_SERVER_DOMAIN: "${CR_GF_SERVER_DOMAIN}"
-    GF_SERVER_ROOT_URL: "${CR_GF_SERVER_ROOT_URL}"
-    GF_AUTH_ANONYMOUS_ENABLED: "true"
-  # Load dashboards from configmaps with a given label across all namespaces.
-  sidecar:
-    dashboards:
-      enabled: true
-      label: grafana # Label our own legacy grafana-operator uses.
-      searchNamespace: ALL
-      multicluster:
-        global:
-          enabled: true
-        etcd:
-          enabled: true
-  grafana.ini:
-    analytics:
-      check_for_updates: false
-    security:
-      csrf_trusted_origins: "${CR_GF_CSRF_TRUSTED_ORIGINS}"
-    smtp:
-      enabled: "${CR_GF_SMTP_ENABLED}"
-      host: "${CR_GF_SMTP_HOST}"
-      user: "${CR_GF_SMTP_USER}"
-      password: "${CR_GF_SMTP_PASSWORD}"
-      from_address: "${CR_GF_SMTP_FROM_ADDRESS}"
-      from_name: "${CR_GF_SMTP_FROM_NAME}"
-      skip_verify: "${CR_GF_SMTP_SKIP_VERIFY}"
-  serviceMonitor:
-    relabelings:
-    - sourceLabels: [__meta_kubernetes_pod_node_name]
-      targetLabel: instance
-
-gf_ingress_auth_url: "${CR_GF_INGRESS_AUTH_URL}"
-gf_ingress_auth_signin: "${CR_GF_INGRESS_AUTH_SIGNIN}"
-gf_ingress_error_page_403: "${CR_GF_INGRESS_ERROR_PAGE_403}"
+  enabled: false
 
 prom_ingress_auth_url: "${CR_PROM_INGRESS_AUTH_URL}"
 prom_ingress_auth_signin: "${CR_PROM_INGRESS_AUTH_SIGNIN}"

--- a/src/app_charts/prometheus/values-cloud.yaml
+++ b/src/app_charts/prometheus/values-cloud.yaml
@@ -35,24 +35,6 @@ prometheus:
   serviceMonitor:
     metricRelabelings: []
 
-# Grafana HTTP configuration
-gf_server_domain: "${CLOUD_ROBOTICS_DOMAIN}"
-gf_server_root_url: "https://${CLOUD_ROBOTICS_DOMAIN}/grafana"
-gf_csrf_trusted_origins: ""
-# Grafana Ingress configuration. Does not use the same replace as the values above.
-gf_ingress_auth_url: "http://oauth2-proxy.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify"
-# Header modification for Envoy Gateway/HTTPRoutes support.
-gf_ingress_auth_url_header: ""
-gf_ingress_auth_url_headervalue: ""
-gf_ingress_auth_signin: "https://{{ .Values.domain }}/oauth2/start?rd=$escaped_request_uri"
-gf_ingress_error_page_403: "https://{{ .Values.domain }}/oauth2/start?rd=$escaped_request_uri"
-gf_auth_backend:
-  protocol: "http"
-  service: "oauth2-proxy"
-  namespace: "default"
-  port: 80
-  path: "/oauth2/auth"
-  contextExtensions: {}
 # Prometheus
 prom_ingress_auth_url: "http://oauth2-proxy.default.svc.cluster.local/apis/core.token-vendor/v1/token.verify"
 # Header modification for Envoy Gateway/HTTPRoutes support.
@@ -77,12 +59,3 @@ authProxy:
   - x-server-name
 # Prometheus: Using ${} replacement
 prom_external_url: "https://${CLOUD_ROBOTICS_DOMAIN}/prometheus/"
-# Grafana SMTP configuration
-# Notes: these need to be all string, since we apply them using the template funtion "replace"
-gf_smtp_enabled: "false"
-gf_smtp_host: "smtp-host"
-gf_smtp_user: "smtp-user"
-gf_smtp_password: "smtp-api-key"
-gf_smtp_from_address: "from-address@example.com"
-gf_smtp_from_name: "from-name"
-gf_smtp_skip_verify: "true"


### PR DESCRIPTION
Extract Grafana from the Prometheus application, enabling it to be deployed and managed independently.

!!! Merge AFTER ([context](https://chat.google.com/room/AAAA-ATNShc/WHZHvxyCf00)):
- https://github.com/intrinsic-ai/insrc/pull/51993

#### Why

So Grafana becomes a cross cutting concern, used by Prometheus and (soon to be) VictoriaMetrics

Previously, Grafana was deployed as a component of the Prometheus operator chart, which tightly coupled its lifecycle and configuration to Prometheus. This change decouples Grafana, allowing for:

-   **Independent Management:** Grafana can now be configured, deployed,
    and updated separately from Prometheus.
-   **Clearer Ownership:** Grafana resources are now owned by its own
    dedicated application definition.
-   **Reduced Conflicts:** Explicitly disables Grafana within the
    Prometheus chart and ensures CRD ownership is handled correctly,
    preventing resource conflicts.

#### The code changes include:

-   Adding a new `grafana` application definition under `src/app_charts`.
-   Moving Grafana's HTTPRoute and Ingress configurations to the new app.
-   Configuring the standalone Grafana to use the `kube-prometheus-stack`
    Helm chart, but with only Grafana components enabled.
-   Disabling Grafana within the `prometheus` application's chart.