### PR TITLE
Upgrade Helm 3 to v3.21.3

### DIFF
--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -38,9 +38,9 @@ def _non_module_deps_impl(ctx):
     http_archive(
         name = "kubernetes_helm3",
         urls = [
-            "https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz",
+            "https://get.helm.sh/helm-v3.21.3-linux-amd64.tar.gz",
         ],
-        sha256 = "1484ffb0c7a608d8069470f48b88d729e88c41a1b6602f145231e8ea7b43b50a",
+        sha256 = "15e041a93a590dce8100f39385cd98c84a765c9e36aeeb9e2dc6ff9e4769e2e0",
         strip_prefix = "linux-amd64",
         build_file = "//third_party/helm3:BUILD.bazel",
     )


### PR DESCRIPTION
Why: VictoriaMetrics' vmagent needs 3.14+ to be able to be upgraded to a version that allows us to inject creds files (for the eventual cross-project cloud ops Mimir write).

# Tested with...

The generated YAML manifests were fully diffed between the two Helm versions. There were zero differences in the output YAML.

Note: A pre-existing warning (warning: cannot overwrite table with non table for kube-prometheus-stack.prometheus.prometheusSpec.nodeSelector) is now emitted on a different line number in the Helm source code (coalesce.go:316 instead of coalesce.go:220). This does not affect the build or templating.

Verification Steps
```
# 1. Build and capture the YAML output using the OLD Helm version (v3.9.0)
git checkout main
bazel build //src/app_charts/...
find bazel-bin/src/app_charts -name "*.yaml" | xargs cat > /tmp/helm_3.9.0_output.yaml

# 2. Build and capture the YAML output using the NEW Helm version (v3.21.3)
git checkout <this-pr-branch>
bazel build //src/app_charts/...
find bazel-bin/src/app_charts -name "*.yaml" | xargs cat > /tmp/helm_3.21.3_output.yaml

# 3. Diff the generated templates
diff /tmp/helm_3.9.0_output.yaml /tmp/helm_3.21.3_output.yaml
```

Expected Result:
The diff command returns empty, proving that the rendered Kubernetes manifests are 100% identical.