### PR TITLE
Add volume mount config to prometheus

### DIFF
--- a/src/app_charts/prometheus/cloud/prometheus-operator.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-operator.yaml
@@ -86,6 +86,22 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+# Inject volumeMounts
+{{- $prometheusVolumeMountsList := dict -}}
+{{- if .Values.prometheus }}
+  {{- if .Values.prometheus.prometheusSpec }}
+    {{- if .Values.prometheus.prometheusSpec.volumeMounts }}
+      {{- $prometheusVolumeMountsList = .Values.prometheus.prometheusSpec.volumeMounts -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if $prometheusVolumeMountsList }}
+  {{- $formattedVolumeMountsObject := toYaml $prometheusVolumeMountsList | nindent 4 -}}
+  {{- $data = $data | replace "- name: ${CR_PROMETHEUS_VOLUME_MOUNTS_OBJECT}" $formattedVolumeMountsObject -}}
+{{- else }}
+  {{- $data = $data | replace "  volumeMounts:\n    - name: ${CR_PROMETHEUS_VOLUME_MOUNTS_OBJECT}" "" -}}
+{{- end }}
 {{- if $prometheusVolumesList }}
   {{- $formattedVolumesObject := toYaml $prometheusVolumesList | nindent 4 -}}
   {{- $data = $data | replace "- name: ${CR_PROMETHEUS_VOLUMES_OBJECT}" $formattedVolumesObject -}}

--- a/src/app_charts/prometheus/prometheus-cloud.values.yaml
+++ b/src/app_charts/prometheus/prometheus-cloud.values.yaml
@@ -106,6 +106,8 @@ prometheus:
     - url: "${CR_PROMETHEUS_REMOTE_WRITE_OBJECT}"
     volumes:
     - name: "${CR_PROMETHEUS_VOLUMES_OBJECT}"
+    volumeMounts:
+    - name: "${CR_PROMETHEUS_VOLUME_MOUNTS_OBJECT}"
   serviceAccount:
     annotations:
       "${CR_PROMETHEUS_SA_ANNOTATIONS}": ""

--- a/src/app_charts/prometheus/prometheus-robot.values.yaml
+++ b/src/app_charts/prometheus/prometheus-robot.values.yaml
@@ -83,6 +83,8 @@ prometheus:
     - url: "${CR_PROMETHEUS_REMOTE_WRITE_OBJECT}"
     volumes:
     - name: "${CR_PROMETHEUS_VOLUMES_OBJECT}"
+    volumeMounts:
+    - name: "${CR_PROMETHEUS_VOLUME_MOUNTS_OBJECT}"
     storageSpec:
       emptyDir:
         medium: Memory

--- a/src/app_charts/prometheus/robot/prometheus-operator.yaml
+++ b/src/app_charts/prometheus/robot/prometheus-operator.yaml
@@ -58,6 +58,22 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+# Inject volumeMounts
+{{- $prometheusVolumeMountsList := dict -}}
+{{- if .Values.prometheus }}
+  {{- if .Values.prometheus.prometheusSpec }}
+    {{- if .Values.prometheus.prometheusSpec.volumeMounts }}
+      {{- $prometheusVolumeMountsList = .Values.prometheus.prometheusSpec.volumeMounts -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if $prometheusVolumeMountsList }}
+  {{- $formattedVolumeMountsObject := toYaml $prometheusVolumeMountsList | nindent 4 -}}
+  {{- $data = $data | replace "- name: ${CR_PROMETHEUS_VOLUME_MOUNTS_OBJECT}" $formattedVolumeMountsObject -}}
+{{- else }}
+  {{- $data = $data | replace "  volumeMounts:\n    - name: ${CR_PROMETHEUS_VOLUME_MOUNTS_OBJECT}" "" -}}
+{{- end }}
 {{- if $prometheusVolumesList }}
   {{- $formattedVolumesObject := toYaml $prometheusVolumesList | nindent 4 -}}
   {{- $data = $data | replace "- name: ${CR_PROMETHEUS_VOLUMES_OBJECT}" $formattedVolumesObject -}}


### PR DESCRIPTION
This PR introduces additional extensibility to the Prometheus Helm chart templates for both cloud and robot deployments. It enables custom injection of `volumeMounts` configurations directly into the `prometheusSpec`.
    
Specifically, this addresses an oversight in a previous change by adding the missing `volumeMounts` injection logic, ensuring that any custom volumes added to the Prometheus pod can actually be mounted and accessed.