### PR TITLE
Remove old workaround causing slower than needed build times.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,6 @@
 # Enable Bzlmod for every Bazel command
 common --enable_bzlmod
 
-# Work around go issue with LLVM 15+: https://github.com/bazelbuild/rules_go/issues/3691#issuecomment-2263999685
-build --@io_bazel_rules_go//go/config:linkmode=pie
-
 # Enforce stricter environment rules, which eliminates some non-hermetic
 # behavior and therefore improves both the remote_cache cache hit rate and the
 # correctness and repeatability of the build.


### PR DESCRIPTION
The original issue (https://github.com/bazelbuild/rules_go/issues/3691) was caused by older rules_go releases interacting with LLVM 15+ toolchains when linking with - Wl,-z,relro / position-independent code. With the upgraded toolchains in use (rules_go 0.59.0, toolchains_llvm 1.7.0 / LLVM 18.1.4, and Go 1.26.1), rules_go manages default linking without requiring forced linkmode=pie.