### PR TITLE
Fix Helm map coercion warnings for Prometheus charts

### DIFF
--- a/src/app_charts/prometheus/cloud/prometheus-operator.yaml
+++ b/src/app_charts/prometheus/cloud/prometheus-operator.yaml
@@ -14,9 +14,9 @@
 {{- if $prometheusNodeSelectorMap }}
   {{- $prometheusNodeSelectorRawYaml := toYaml $prometheusNodeSelectorMap -}}
   {{- $formattedPrometheusNodeSelectorObject := $prometheusNodeSelectorRawYaml | nindent 6 -}}
-  {{- $data = $data | replace "${CR_PROMETHEUS_NODE_SELECTOR_OBJECT}" $formattedPrometheusNodeSelectorObject -}}
+  {{- $data = $data | replace "$CR_PROMETHEUS_NODE_SELECTOR_OBJECT: REMOVE_ME" $formattedPrometheusNodeSelectorObject -}}
 {{- else }}
-  {{- $data = $data | replace "${CR_PROMETHEUS_NODE_SELECTOR_OBJECT}" " {}" -}}
+  {{- $data = $data | replace "$CR_PROMETHEUS_NODE_SELECTOR_OBJECT: REMOVE_ME" "{}" -}}
 {{- end }}
 
 # Inject the tolerations as a pre-formatted YAML block to support multiple key-value pairs in a list within values-cloud.yaml
@@ -39,9 +39,9 @@
 {{- end -}}
 {{- if $prometheusExternalLabelsMap }}
   {{- $formattedExternalLabels := toYaml $prometheusExternalLabelsMap | nindent 6 -}}
-  {{- $data = $data | replace "${PROMETHEUS_EXTERNAL_LABELS}" $formattedExternalLabels -}}
+  {{- $data = $data | replace "$PROMETHEUS_EXTERNAL_LABELS: REMOVE_ME" $formattedExternalLabels -}}
 {{- else }}
-  {{- $data = $data | replace "${PROMETHEUS_EXTERNAL_LABELS}" " {}" -}}
+  {{- $data = $data | replace "$PROMETHEUS_EXTERNAL_LABELS: REMOVE_ME" "{}" -}}
 {{- end }}
 
 # Inject remoteWrite

--- a/src/app_charts/prometheus/prometheus-cloud.values.yaml
+++ b/src/app_charts/prometheus/prometheus-cloud.values.yaml
@@ -60,11 +60,13 @@ prometheus:
         operator: "DoesNotExist"
 
     externalUrl: "${EXTERNAL_URL}"
-    externalLabels: "${PROMETHEUS_EXTERNAL_LABELS}"
+    externalLabels:
+      $PROMETHEUS_EXTERNAL_LABELS: REMOVE_ME
     retention: "${RETENTION_TIME}"
     retentionSize: "${RETENTION_SIZE}"
     walCompression: true
-    nodeSelector: "${CR_PROMETHEUS_NODE_SELECTOR_OBJECT}"
+    nodeSelector:
+      $CR_PROMETHEUS_NODE_SELECTOR_OBJECT: REMOVE_ME
     tolerations: "${CR_PROMETHEUS_TOLERATIONS_OBJECT}"
     resources:
       requests:

--- a/src/app_charts/prometheus/prometheus-robot.values.yaml
+++ b/src/app_charts/prometheus/prometheus-robot.values.yaml
@@ -21,7 +21,8 @@ defaultRules:
 
 prometheus:
   prometheusSpec:
-    externalLabels: "${PROMETHEUS_EXTERNAL_LABELS}"
+    externalLabels:
+      $PROMETHEUS_EXTERNAL_LABELS: REMOVE_ME
     # Pick up all service monitors across all namespaces.
     serviceMonitorNamespaceSelector:
       # Inverse selector selects everything

--- a/src/app_charts/prometheus/robot/prometheus-operator.yaml
+++ b/src/app_charts/prometheus/robot/prometheus-operator.yaml
@@ -12,9 +12,9 @@
 {{- end -}}
 {{- if $prometheusExternalLabelsMap }}
   {{- $formattedExternalLabels := toYaml $prometheusExternalLabelsMap | nindent 6 -}}
-  {{- $data = $data | replace "${PROMETHEUS_EXTERNAL_LABELS}" $formattedExternalLabels -}}
+  {{- $data = $data | replace "$PROMETHEUS_EXTERNAL_LABELS: REMOVE_ME" $formattedExternalLabels -}}
 {{- else }}
-  {{- $data = $data | replace "${PROMETHEUS_EXTERNAL_LABELS}" " {}" -}}
+  {{- $data = $data | replace "$PROMETHEUS_EXTERNAL_LABELS: REMOVE_ME" "{}" -}}
 {{- end }}
 
 # Inject remoteWrite


### PR DESCRIPTION
**Context**
This resolves the `coalesce.go:316: warning: cannot overwrite table with non table` warnings that were appearing in the presubmit. 
    
Previously, `externalLabels` and `nodeSelector` properties in our Helm values files were being overridden with string templates (e.g. `"${PROMETHEUS_EXTERNAL_LABELS}"`). As the upstream `kube-prometheus-stack` chart expects these to be maps, Helm produced warnings during coalescence. 
    
This change replaces the string template definitions in the values yaml files with dummy maps (e.g., `$PROMETHEUS_EXTERNAL_LABELS : REMOVE_ME`). The `replace` template rules in `prometheus-operator.yaml` have been updated to target these dummy keys to inject the processed configurations as before. This successfully aligns the data types to prevent Helm warnings from surfacing in `stderr` while keeping our template injection logic intact.

**Tests Run** 
This change has been helm-templated out with the following test values.yaml
```yaml 
prometheus:
  prometheusSpec:
    externalLabels:
      environment: test
      region: us-central1
```

and verified to render 
```yaml 
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  name: kube-prometheus
  namespace: default
  labels:
    app: kube-prometheus
    
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: prom
    app.kubernetes.io/version: "87.5.1"
    app.kubernetes.io/part-of: kube
    chart: kube-prometheus-stack-87.5.1
    release: "prom"
    heritage: "Helm"
spec:
  automountServiceAccountToken: true
  image: "quay.io/prometheus/prometheus:v3.13.0-distroless"
  imagePullPolicy: "IfNotPresent"
  version: "v3.13.0-distroless"
  externalLabels:
    
      environment: test <-- successfully rendered
      region: us-central1 <-- successfully rendered
```