### PR TITLE
🛂 (token-vendor): support endpoint and robot context extensions for gRPC ext_authz

### DIFF
--- a/src/go/cmd/token-vendor/api/v1/authz.go
+++ b/src/go/cmd/token-vendor/api/v1/authz.go
@@ -58,10 +58,8 @@ func (s *ExtAuthzServer) Check(ctx context.Context, req *authv3.CheckRequest) (*
 	}
 
 	var endpoint string
-	var extPath string
 	if ext := req.GetAttributes().GetContextExtensions(); ext != nil {
 		endpoint = strings.TrimSpace(ext["endpoint"])
-		extPath = strings.TrimSpace(ext["path"])
 	}
 
 	// Extract token from request headers or query parameter
@@ -79,36 +77,21 @@ func (s *ExtAuthzServer) Check(ctx context.Context, req *authv3.CheckRequest) (*
 			token = u.Query().Get("token")
 		}
 	}
-	if token == "" && extPath != "" && strings.Contains(extPath, "?") {
-		if u, err := url.Parse(extPath); err == nil {
-			token = u.Query().Get("token")
-		}
-	}
 
 	if token == "" {
 		return deniedResponse(typev3.StatusCode_Unauthorized, codes.Unauthenticated, "missing authorization credentials"), nil
 	}
 
-	if strings.HasPrefix(endpoint, "token.verify") || hasPathSuffix(extPath, "/token.verify") || hasPathSuffix(reqPath, "/token.verify") {
+	switch endpoint {
+	case "token.verify":
 		return s.verifyOAuthToken(ctx, token, isRobotReq)
-	}
-
-	if strings.HasPrefix(endpoint, "jwt.verify") || hasPathSuffix(extPath, "/jwt.verify") || hasPathSuffix(reqPath, "/jwt.verify") {
+	case "jwt.verify":
 		return s.verifyJWT(ctx, token)
+	case "", "default", "validate":
+		return s.validateCredentials(ctx, token, isRobotReq)
+	default:
+		return deniedResponse(typev3.StatusCode_BadRequest, codes.InvalidArgument, "unrecognized endpoint: "+endpoint), nil
 	}
-
-	return s.validateCredentials(ctx, token, isRobotReq)
-}
-
-func hasPathSuffix(rawURL, suffix string) bool {
-	if rawURL == "" {
-		return false
-	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return strings.HasSuffix(rawURL, suffix)
-	}
-	return strings.HasSuffix(u.Path, suffix) || u.Path == strings.TrimPrefix(suffix, "/")
 }
 
 func (s *ExtAuthzServer) verifyOAuthTokenInternal(ctx context.Context, token string, isRobot bool) (*authv3.CheckResponse, error) {
@@ -193,22 +176,12 @@ func isRobot(req *authv3.CheckRequest) bool {
 				return b
 			}
 		}
-		if p, ok := ext["path"]; ok && p != "" && (strings.Contains(p, "robot") || strings.Contains(p, "robots")) {
-			if b, ok := getRobotFromQuery(p); ok {
-				return b
-			}
-		}
 	}
 
 	httpReq := req.GetAttributes().GetRequest().GetHttp()
 	if httpReq != nil {
 		if val := getHeader(httpReq.GetHeaders(), headerRobots); val != "" {
 			if b, ok := parseBoolValue(val); ok {
-				return b
-			}
-		}
-		if reqPath := httpReq.GetPath(); reqPath != "" && (strings.Contains(reqPath, "robot") || strings.Contains(reqPath, "robots")) {
-			if b, ok := getRobotFromQuery(reqPath); ok {
 				return b
 			}
 		}
@@ -219,26 +192,6 @@ func isRobot(req *authv3.CheckRequest) bool {
 func parseBoolValue(val string) (b, ok bool) {
 	parsed, err := strconv.ParseBool(strings.TrimSpace(val))
 	return parsed, err == nil
-}
-
-func getRobotFromQuery(rawURL string) (val, ok bool) {
-	if rawURL == "" || !strings.Contains(rawURL, "?") {
-		return false, false
-	}
-	if u, err := url.Parse(rawURL); err == nil {
-		q := u.Query()
-		if param := q.Get("robots"); param != "" {
-			if b, ok := parseBoolValue(param); ok {
-				return b, true
-			}
-		}
-		if param := q.Get("robot"); param != "" {
-			if b, ok := parseBoolValue(param); ok {
-				return b, true
-			}
-		}
-	}
-	return false, false
 }
 
 func getHeader(headers map[string]string, key string) string {

--- a/src/go/cmd/token-vendor/api/v1/authz_test.go
+++ b/src/go/cmd/token-vendor/api/v1/authz_test.go
@@ -170,8 +170,10 @@ func TestExtAuthzCheck_RobotJWT(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "valid robot jwt with path query robots=true",
-			path: "/test?robots=true",
+			name: "valid robot jwt with contextExtension robots=true",
+			contextExt: map[string]string{
+				"robots": "true",
+			},
 			headers: map[string]string{
 				"authorization": "Bearer " + jwtCorrect,
 			},
@@ -356,25 +358,9 @@ func TestExtAuthzCheck_EndpointDifferentiated(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "path /apis/core.token-vendor/v1/token.verify?robots=true with valid oauth token",
-			path: "/apis/core.token-vendor/v1/token.verify?robots=true",
-			headers: map[string]string{
-				"authorization": "Bearer " + validOAuthToken,
-			},
-			wantOK: true,
-		},
-		{
-			name: "path /apis/core.token-vendor/v1/jwt.verify with valid jwt",
-			path: "/apis/core.token-vendor/v1/jwt.verify",
-			headers: map[string]string{
-				"authorization": "Bearer " + jwtCorrect,
-			},
-			wantOK: true,
-		},
-		{
-			name: "contextExtensions path /apis/core.token-vendor/v1/token.verify?robots=true",
+			name: "empty endpoint defaults to validateCredentials",
 			contextExt: map[string]string{
-				"path": "/apis/core.token-vendor/v1/token.verify?robots=true",
+				"endpoint": "",
 			},
 			headers: map[string]string{
 				"authorization": "Bearer " + validOAuthToken,
@@ -382,14 +368,36 @@ func TestExtAuthzCheck_EndpointDifferentiated(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "contextExtensions path /apis/core.token-vendor/v1/jwt.verify",
+			name: "endpoint validate delegates to validateCredentials",
 			contextExt: map[string]string{
-				"path": "/apis/core.token-vendor/v1/jwt.verify",
+				"endpoint": "validate",
 			},
 			headers: map[string]string{
-				"authorization": "Bearer " + jwtCorrect,
+				"authorization": "Bearer " + validOAuthToken,
 			},
 			wantOK: true,
+		},
+		{
+			name: "endpoint default delegates to validateCredentials",
+			contextExt: map[string]string{
+				"endpoint": "default",
+			},
+			headers: map[string]string{
+				"authorization": "Bearer " + validOAuthToken,
+			},
+			wantOK: true,
+		},
+		{
+			name: "unrecognized endpoint returns 400 Bad Request",
+			contextExt: map[string]string{
+				"endpoint": "unknown.endpoint",
+			},
+			headers: map[string]string{
+				"authorization": "Bearer " + validOAuthToken,
+			},
+			wantOK:       false,
+			wantHTTPCode: typev3.StatusCode_BadRequest,
+			wantRPCCode:  codes.InvalidArgument,
 		},
 		{
 			name: "endpoint token.verify rejects non-oauth format token",


### PR DESCRIPTION
Align token-vendor's Envoy ext_authz gRPC server with Gateway API SecurityPolicy context extensions and remove legacy path/query fallback.

#### Why

Envoy gRPC ext_authz requests do not evaluate HTTP subrequest URI paths. Gateway API SecurityPolicy resources pass configuration via explicit context extensions (`endpoint`, `robot`, `scopes`). Removing legacy pseudo-path and query parsing simplifies the auth dispatch logic and prevents unintended fallback behavior.

#### The code changes include:

- Route gRPC Check requests based strictly on the `endpoint` context extension (`token.verify`, `jwt.verify`, or default).
- Evaluate robot vs. human ACLs via `robot` / `robots` context extensions and `x-crc-tv-robots` header.
- Remove legacy `hasPathSuffix` and URL query string parsing on request paths.
- Update unit tests to cover context extension dispatch and invalid endpoint rejection.