### PR TITLE
Prefix short SHA with 'g' in BUILD_VERSION for Helm chart

### DIFF
--- a/.github/ci/release_binary.sh
+++ b/.github/ci/release_binary.sh
@@ -43,7 +43,7 @@ release_binary "${GCP_BUCKET}" "crc-${VERSION}/crc-${VERSION}+${SHA}" ${LABELS}
 # - BUILD_VERSION is used by `bazel --stamp`.
 # - HELM_* are used by the push-chart script to auth to GAR.
 echo "Pushing Helm chart to GAR..."
-export BUILD_VERSION="${VERSION}-${SHA}"
+export BUILD_VERSION="${VERSION}-g${SHA}"
 export HELM_REGISTRY_USERNAME="oauth2accesstoken"
 export HELM_REGISTRY_PASSWORD=$(gcloud auth print-access-token)
 bazel_ci run //src/app_charts/chart-assignment-controller:push-chart


### PR DESCRIPTION
SemVer 2.0.0 Section 9 forbids leading zeros in numeric pre-release identifiers. When a commit short SHA consists only of digits and starts with a zero (such as 0156133), Helm fails chart metadata validation ('0.1.0-0156133').

Prefixing the short SHA with 'g' (e.g. 0.1.0-g0156133) follows the git describe convention and ensures the pre-release identifier is always alphanumeric, preventing invalid SemVer errors.

This is a followup for [pr/803](https://github.com/googlecloudrobotics/core/pull/880)