### PR TITLE
👷 ci: allow 'Create release' workflow to pick up any passing postsubmit run on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,6 @@ on:
     - cron: "0 5 * * *" # Once a day at 5am.
   # Manual runs through Actions tab in the UI
   workflow_dispatch:
-    inputs:
-      any-postsubmit:
-        description: >-
-          Allow releasing from any successful postsubmit (including manual
-          runs), not just scheduled ones.
-        type: boolean
-        default: false
 
 permissions:
   actions: read
@@ -33,16 +26,11 @@ jobs:
         id: latest-green
         env:
           REPO: ${{ github.repository }}
-          ANY_POSTSUBMIT: ${{ inputs.any-postsubmit }}
         run: |
           set -euo pipefail
-          EVENT_FILTER="&event=schedule"
-          if [[ "${ANY_POSTSUBMIT}" == "true" ]]; then
-            EVENT_FILTER=""
-          fi
           output=$(curl --fail-with-body -sS \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&status=success${EVENT_FILTER}")
+            "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&status=success")
           repo_id=$(jq -r '.workflow_runs[0].head_repository.id' <<< $output)
           if [[ "${repo_id}" != "${{ github.repository_id }}" ]] ; then
             echo >&2 "Unexpected head repository ID: ${repo_id} - check postsubmit.yml configuration"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           EVENT_FILTER="&event=schedule"
-          if [[ "${ANY_POSTSUBMIT}" == "true" || ("${{ github.event_name }}" == "workflow_dispatch" && "${ANY_POSTSUBMIT}" == "") ]] ; then
+          if [[ "${ANY_POSTSUBMIT}" == "true" ]]; then
             EVENT_FILTER=""
           fi
           output=$(curl --fail-with-body -sS \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     - cron: "0 5 * * *" # Once a day at 5am.
   # Manual runs through Actions tab in the UI
   workflow_dispatch:
+    inputs:
+      any-postsubmit:
+        description: >-
+          Allow releasing from any successful postsubmit (including manual
+          runs), not just scheduled ones.
+        type: boolean
+        default: true
 
 permissions:
   actions: read
@@ -26,11 +33,16 @@ jobs:
         id: latest-green
         env:
           REPO: ${{ github.repository }}
+          ANY_POSTSUBMIT: ${{ inputs.any-postsubmit }}
         run: |
           set -euo pipefail
+          EVENT_FILTER="&event=schedule"
+          if [[ "${ANY_POSTSUBMIT}" == "true" || ("${{ github.event_name }}" == "workflow_dispatch" && "${ANY_POSTSUBMIT}" == "") ]] ; then
+            EVENT_FILTER=""
+          fi
           output=$(curl --fail-with-body -sS \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&event=schedule&status=success")
+            "https://api.github.com/repos/$REPO/actions/workflows/postsubmit.yml/runs?per_page=1&branch=main&status=success${EVENT_FILTER}")
           repo_id=$(jq -r '.workflow_runs[0].head_repository.id' <<< $output)
           if [[ "${repo_id}" != "${{ github.repository_id }}" ]] ; then
             echo >&2 "Unexpected head repository ID: ${repo_id} - check postsubmit.yml configuration"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
           Allow releasing from any successful postsubmit (including manual
           runs), not just scheduled ones.
         type: boolean
-        default: true
+        default: false
 
 permissions:
   actions: read


### PR DESCRIPTION
Allow 'Create release' workflow to pick up manual postsubmit runs when dispatched, rather than only scheduled cron runs.

#### Why

Previously, release.yml filtered postsubmit runs strictly on '&event=schedule'. This prevented manually dispatched postsubmits (created with force-binary-release) from being recognized when triggering Create release manually out-of-band.

#### The code changes include:

- Add any-postsubmit boolean input to workflow_dispatch in .github/workflows/release.yml (defaulting to true).
- Conditionally remove the '&event=schedule' filter when triggered manually or when any-postsubmit is true, while preserving scheduled cron behavior.

go/traj/61432784-b795-4e4d-af0b-d60d97c7a0ae