### PR TITLE
📊 (gateway): package dashboards in base chart and add prometheus monitors

### DIFF
--- a/src/app_charts/base/BUILD.bazel
+++ b/src/app_charts/base/BUILD.bazel
@@ -115,6 +115,7 @@ app_chart(
         "relay-dashboard.json",
         ":cert-manager-chart.cloud",
         ":chart-assignment-controller-chart.cloud",
+        "//third_party/envoy-gateway:envoy-gateway-dashboards",
         "@ingress-nginx//:ingress-nginx-dashboards",
     ],
     images = {

--- a/src/app_charts/base/cloud/gateway.yaml
+++ b/src/app_charts/base/cloud/gateway.yaml
@@ -126,6 +126,55 @@ spec:
   timeout:
     http:
       requestTimeout: 0s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-proxy-metrics
+  namespace: envoy-gateway-system
+  labels:
+    prometheus: kube-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: envoy
+      app.kubernetes.io/component: proxy
+  podMetricsEndpoints:
+    - port: metrics
+      path: /stats/prometheus
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: instance
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-gateway-metrics
+  namespace: envoy-gateway-system
+  labels:
+    prometheus: kube-prometheus
+spec:
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway
+  endpoints:
+    - port: metrics
+      path: /metrics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-dashboards-json
+  namespace: envoy-gateway-system
+  labels:
+    grafana: "1"
+data:
+  envoy-proxy-global.json: |-
+{{ .Files.Get "files/envoy-proxy-global.json" | indent 4 }}
+  envoy-gateway-global.json: |-
+{{ .Files.Get "files/envoy-gateway-global.json" | indent 4 }}
+  envoy-clusters.json: |-
+{{ .Files.Get "files/envoy-clusters.json" | indent 4 }}
 {{- end }}
 
 


### PR DESCRIPTION
Package Envoy Gateway dashboards in the base-cloud Helm chart and configure Prometheus scraping and Grafana dashboard provisioning in gateway.yaml.

#### Why

To provide out-of-the-box observability for Envoy Gateway in Cloud Robotics Core, the base chart needs to package the vendored dashboard JSONs, deploy Prometheus PodMonitor and ServiceMonitor resources to scrape Envoy data and control plane metrics, and deploy a ConfigMap for Grafana auto-discovery.

#### The code changes include:

- Add //third_party/envoy-gateway:envoy-gateway-dashboards to files in src/app_charts/base/BUILD.bazel.
- Deploy PodMonitor (envoy-proxy-metrics) in src/app_charts/base/cloud/gateway.yaml to scrape Envoy Proxy metrics on port 19001 at /stats/prometheus.
- Deploy ServiceMonitor (envoy-gateway-metrics) in src/app_charts/base/cloud/gateway.yaml to scrape Envoy Gateway metrics on port 19001 at /metrics.
- Deploy ConfigMap (envoy-dashboards-json) in src/app_charts/base/cloud/gateway.yaml with label grafana: "1" embedding the vendored dashboards.

TESTED=UNITTESTS
RELNOTES=NONE
TAG=agy
CONV=58e945b5-1256-4805-88e8-1509d9fe10c7