### PR TITLE
Support fast_push in run-install

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -340,7 +340,10 @@ function helm_region_shared {
 
 function helm_main_region {
   local INGRESS_IP
-  INGRESS_IP=$(terraform_exec output ingress-ip | tr -d '"')
+  INGRESS_IP=$(gcloud compute addresses describe cloud-robotics \
+    --region="${GCP_REGION}" \
+    --project="${GCP_PROJECT_ID}" \
+    --format='value(address)')
 
   helm_region_shared \
     "${CLOUD_ROBOTICS_CTX}" \
@@ -369,7 +372,10 @@ function helm_additional_region {
   CLUSTER_NAME="${AR_NAME}-ar-cloud-robotics"
 
   local INGRESS_IP
-  INGRESS_IP=$(terraform_exec output -json ingress-ip-ar | jq -r ."\"${CLUSTER_NAME}\"")
+  INGRESS_IP=$(gcloud compute addresses describe "${CLUSTER_NAME}" \
+    --region="${AR_REGION}" \
+    --project="${GCP_PROJECT_ID}" \
+    --format='value(address)')
 
   helm_region_shared \
     $(gke_context_name "${GCP_PROJECT_ID}" "${CLUSTER_NAME}" "${AR_REGION}" "${AR_ZONE}") \
@@ -420,7 +426,7 @@ function update {
   create "$@"
 }
 
-# This is a shortcut for skipping Terraform config checks if you know the config has not changed.
+# This is a shortcut for skipping Terraform config checks if you know the config has not changed, or if the config is managed by terraform module.
 function fast_push {
   include_config_and_defaults $1
   shift
@@ -430,7 +436,7 @@ function fast_push {
   helm_charts "$@"
 }
 
-# This is a shortcut for skipping building and applying Terraform configs if you know the build has not changed.
+# This is a shortcut for skipping building and only applying Terraform configs (if you know the build has not changed).
 function update_infra {
   include_config_and_defaults $1
   terraform_apply

--- a/deploy.sh
+++ b/deploy.sh
@@ -341,6 +341,9 @@ function helm_region_shared {
 function helm_main_region {
   local INGRESS_IP="${CLOUD_ROBOTICS_INGRESS_IP:-}"
   if [[ -z "${INGRESS_IP}" ]]; then
+    if [[ "${CONFIG_MANAGED_BY_TERRAFORM:-}" == "true" ]]; then
+      die "CLOUD_ROBOTICS_INGRESS_IP is missing in Terraform-managed configuration, please update your terraform module to a supported version."
+    fi
     INGRESS_IP=$(terraform_exec output ingress-ip | tr -d '"')
   fi
 
@@ -373,6 +376,9 @@ function helm_additional_region {
   local INGRESS_IP
   INGRESS_IP=$(jq -r '.ingress_ip // ""' <<<"${ar_description}")
   if [[ -z "${INGRESS_IP}" ]]; then
+    if [[ "${CONFIG_MANAGED_BY_TERRAFORM:-}" == "true" ]]; then
+      die "ingress_ip for ${AR_NAME} is missing in Terraform-managed configuration, please update your terraform module to a supported version."
+    fi
     INGRESS_IP=$(terraform_exec output -json ingress-ip-ar | jq -r ."\"${CLUSTER_NAME}\"")
   fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -339,11 +339,10 @@ function helm_region_shared {
 }
 
 function helm_main_region {
-  local INGRESS_IP
-  INGRESS_IP=$(gcloud compute addresses describe cloud-robotics \
-    --region="${GCP_REGION}" \
-    --project="${GCP_PROJECT_ID}" \
-    --format='value(address)')
+  local INGRESS_IP="${CLOUD_ROBOTICS_INGRESS_IP:-}"
+  if [[ -z "${INGRESS_IP}" ]]; then
+    INGRESS_IP=$(terraform_exec output ingress-ip | tr -d '"')
+  fi
 
   helm_region_shared \
     "${CLOUD_ROBOTICS_CTX}" \
@@ -372,10 +371,10 @@ function helm_additional_region {
   CLUSTER_NAME="${AR_NAME}-ar-cloud-robotics"
 
   local INGRESS_IP
-  INGRESS_IP=$(gcloud compute addresses describe "${CLUSTER_NAME}" \
-    --region="${AR_REGION}" \
-    --project="${GCP_PROJECT_ID}" \
-    --format='value(address)')
+  INGRESS_IP=$(jq -r '.ingress_ip // ""' <<<"${ar_description}")
+  if [[ -z "${INGRESS_IP}" ]]; then
+    INGRESS_IP=$(terraform_exec output -json ingress-ip-ar | jq -r ."\"${CLUSTER_NAME}\"")
+  fi
 
   helm_region_shared \
     $(gke_context_name "${GCP_PROJECT_ID}" "${CLUSTER_NAME}" "${AR_REGION}" "${AR_ZONE}") \

--- a/src/bootstrap/cloud/run-install.sh
+++ b/src/bootstrap/cloud/run-install.sh
@@ -29,6 +29,7 @@ if [[ -z "${GCP_PROJECT_ID}" || "${GCP_PROJECT_ID}" == -* ]]; then
   echo "  --set-oauth     Enables and configures OAuth interactively."
   echo "  --delete        Deletes Cloud Robotics from the cloud project."
   echo "  --terraform     Apply only terraform changes."
+  echo "  --fast-push     Only deploy charts, skip terraform."
   echo "  (default)       Install the specified version."
   exit 1
 fi
@@ -42,7 +43,7 @@ if [[ $# -gt 0 && -n "$1" && "$1" != -* ]]; then
 fi
 
 COMMAND=""
-if [[ $# -gt 0 && "$1" =~ ^(--set-config|--set-oauth|--delete|--terraform)$ ]]; then
+if [[ $# -gt 0 && "$1" =~ ^(--set-config|--set-oauth|--delete|--terraform|--fast-push)$ ]]; then
   COMMAND="$1"
   shift
 fi
@@ -63,11 +64,13 @@ if [[ $SHELLOPTS =~ xtrace ]] ; then
   BASH="bash -o xtrace"
 fi
 
-if [[ "${COMMAND}" = "--set-config" ]]; then
+if [[ "${COMMAND}" == "--set-config" ]]; then
   $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" "$@"
-elif [[ "${COMMAND}" = "--set-oauth" ]]; then
+elif [[ "${COMMAND}" == "--fast-push" ]]; then
+  $BASH ./deploy.sh fast_push "${GCP_PROJECT_ID}" "$@"
+elif [[ "${COMMAND}" == "--set-oauth" ]]; then
   $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --edit-oauth "$@"
-elif [[ "${COMMAND}" = "--delete" ]]; then
+elif [[ "${COMMAND}" == "--delete" ]]; then
   $BASH ./deploy.sh delete "${GCP_PROJECT_ID}" "$@"
 else
   # We tag the setup-robot files with this information to be able to check if

--- a/src/bootstrap/cloud/run-install.sh
+++ b/src/bootstrap/cloud/run-install.sh
@@ -64,25 +64,31 @@ if [[ $SHELLOPTS =~ xtrace ]] ; then
   BASH="bash -o xtrace"
 fi
 
-if [[ "${COMMAND}" == "--set-config" ]]; then
-  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" "$@"
-elif [[ "${COMMAND}" == "--fast-push" ]]; then
-  $BASH ./deploy.sh fast_push "${GCP_PROJECT_ID}" "$@"
-elif [[ "${COMMAND}" == "--set-oauth" ]]; then
-  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --edit-oauth "$@"
-elif [[ "${COMMAND}" == "--delete" ]]; then
-  $BASH ./deploy.sh delete "${GCP_PROJECT_ID}" "$@"
-else
-  # We tag the setup-robot files with this information to be able to check if
-  # cloud and robot-installations are in sync
-  export TARGET
-  $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --ensure-config
-  if [[ "${COMMAND}" = "--terraform" ]]; then
-    $BASH ./deploy.sh update_infra "${GCP_PROJECT_ID}" "$@"
-  else
-    $BASH ./deploy.sh create "${GCP_PROJECT_ID}" "$@"
-  fi
-fi
+case "${COMMAND}" in
+  --set-config)
+    $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" "$@"
+    ;;
+  --set-oauth)
+    $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --edit-oauth "$@"
+    ;;
+  --fast-push)
+    $BASH ./deploy.sh fast_push "${GCP_PROJECT_ID}" "$@"
+    ;;
+  --delete)
+    $BASH ./deploy.sh delete "${GCP_PROJECT_ID}" "$@"
+    ;;
+  *)
+    # We tag the setup-robot files with this information to be able to check if
+    # cloud and robot-installations are in sync
+    export TARGET
+    $BASH scripts/set-config.sh "${GCP_PROJECT_ID}" --ensure-config
+    if [[ "${COMMAND}" = "--terraform" ]]; then
+      $BASH ./deploy.sh update_infra "${GCP_PROJECT_ID}" "$@"
+    else
+      $BASH ./deploy.sh create "${GCP_PROJECT_ID}" "$@"
+    fi
+    ;;
+esac
 
 cd ${DIR}
 rm -rf ${TMPDIR}

--- a/src/bootstrap/cloud/terraform/gcs.tf
+++ b/src/bootstrap/cloud/terraform/gcs.tf
@@ -82,6 +82,8 @@ CLOUD_ROBOTICS_COOKIE_SECRET='${random_id.cloud_robotics_cookie_secret[0].b64_ur
 CLOUD_ROBOTICS_OAUTH2_CLIENT_ID='${var.oauth2_client_id}'
 CLOUD_ROBOTICS_OAUTH2_CLIENT_SECRET='${var.oauth2_secret}'
 CLOUD_ROBOTICS_DOMAIN='${var.domain}'
+CLOUD_ROBOTICS_INGRESS_IP='${google_compute_address.cloud_robotics.address}'
+ADDITIONAL_REGIONS=(%{ for key, value in var.additional_regions ~}'${jsonencode({ name = key, region = value.region, zone = value.zone, ingress_ip = google_compute_address.cloud_robotics_ar[key].address })}' %{ endfor ~})
 GCP_NODE_VM_TYPE='${var.node_machine_type}'
 GKE_MIN_NODES='${var.min_node_count}'
 GKE_MAX_NODES='${var.max_node_count}'


### PR DESCRIPTION
- Support `fast_push` in `run-install.sh`.
- Remove use of terraform in `fast_push`.

This is to allow projects that provision CRC directly via terraform module to update CRC charts using the deploy script.