### PR TITLE
Use the config.sh stored in the project itself.

### DIFF
--- a/.github/ci/deploy_navtest.sh
+++ b/.github/ci/deploy_navtest.sh
@@ -2,9 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${DIR}/common.sh"
-
-PROJECT_DIR="${DIR}/deployments/robco-navtest"
-source "${PROJECT_DIR}/config.sh"
+source <(gcloud storage cat "gs://GCP_PROJECT_ID-cloud-robotics-config/config.sh")
 
 # TODO(skopecki) These variables should be declared in the run-install.sh and removed from this script.
 export BUCKET_URI="https://storage.googleapis.com/robco-ci-binary-builds"

--- a/.github/ci/integration_test.sh
+++ b/.github/ci/integration_test.sh
@@ -3,13 +3,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${DIR}/common.sh"
 source "./scripts/common.sh"
+source <(gcloud storage cat "gs://robco-integration-test-cloud-robotics-config/config.sh")
 
 # Because the format from common.sh is not recognized by Cloud Build.
 export 'PS4='
 
-# Need to source the project config from here
-PROJECT_DIR="${DIR}/deployments/robco-integration-test"
-source "${PROJECT_DIR}/config.sh"
 gcloud config set project ${GCP_PROJECT_ID}
 gke_get_credentials "${GCP_PROJECT_ID}" "cloud-robotics" "${GCP_REGION}" "${GCP_ZONE}"
 


### PR DESCRIPTION
This is a preparation to eliminate the checked-in variant. This will avoid config drift. I did compare then, and the only diff is an obsolete comment in the config.sh files we're going to remove.