### PR TITLE
Fix wrong health endpoint cr-syncer.yaml

### DIFF
--- a/src/app_charts/base/robot/cr-syncer.yaml
+++ b/src/app_charts/base/robot/cr-syncer.yaml
@@ -35,7 +35,7 @@ spec:
           timeoutSeconds: 60
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /health
             port: 8080
           periodSeconds: 5
           failureThreshold: 2


### PR DESCRIPTION
cr-syncer uses health and not healthz