### PR TITLE
Export service accounts

### DIFF
--- a/src/bootstrap/cloud/terraform/output.tf
+++ b/src/bootstrap/cloud/terraform/output.tf
@@ -11,3 +11,10 @@ output "ingress-ip-ar" {
 output "cluster-location" {
   value = google_container_cluster.cloud-robotics.location
 }
+
+output "service-accounts" {
+  value = {
+    human         = google_service_account.human-acl
+    robot-service = google_service_account.robot-service
+  }
+}


### PR DESCRIPTION
Export service accounts so downstream can reference them without querying GCP or remote state.