### PR TITLE
Add a test covering the chunked transfer

### DIFF
--- a/src/go/cmd/http-relay-server/README.md
+++ b/src/go/cmd/http-relay-server/README.md
@@ -96,13 +96,10 @@ It has been tested with the following traffic:
 
 - HTTP 1.1 & 2 from web browsers (including bidirectional streaming with websockets)
 - HTTP 1.1 from kubectl, including streaming response bodies for `kubectl logs`
+- HTTP 1.1 chunked request bodies (`Transfer-Encoding: chunked` in the request header, buffered before relaying)
 - SPDY from kubectl (via HTTP 101 Switching Protocols) for `kubectl exec`
 - Unidirectional gRPC (HTTP2 cleartext and HTTP trailers)
 - Streaming gRPC (server, client, and bi-directional)
-
-The following has not been tested:
-
-- HTTP 1.1 streaming request body (`Transfer-Encoding: chunked` in the request header)
 
 ## Flags
 

--- a/src/go/cmd/http-relay-server/server/server_test.go
+++ b/src/go/cmd/http-relay-server/server/server_test.go
@@ -190,6 +190,49 @@ func TestClientHandlerWithChunkedResponse(t *testing.T) {
 	}
 }
 
+func TestClientHandlerWithChunkedRequest(t *testing.T) {
+	pr, pw := io.Pipe()
+	req := httptest.NewRequest("POST", "/client/foo/upload", pr)
+	respRecorder := httptest.NewRecorder()
+	server := NewServer(Config{})
+	server.b.req["foo"] = &backendState{reqChan: make(chan *pb.HttpRequest), lastActivity: time.Now()}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		server.userClientRequest(respRecorder, req)
+	}()
+
+	// Concurrently write chunks into the pipe
+	go func() {
+		pw.Write([]byte("chunk1-"))
+		pw.Write([]byte("chunk2-"))
+		pw.Write([]byte("chunk3"))
+		pw.Close()
+	}()
+
+	relayRequest, err := server.b.GetRequest(t.Context(), "foo", "/")
+	if err != nil {
+		t.Fatalf("Error when getting request: %v", err)
+	}
+
+	if got, want := string(relayRequest.Body), "chunk1-chunk2-chunk3"; got != want {
+		t.Errorf("Wrong request body; got %q; want %q", got, want)
+	}
+
+	server.b.SendResponse(&pb.HttpResponse{
+		Id:         relayRequest.Id,
+		StatusCode: proto.Int32(200),
+		Body:       []byte("ok"),
+		Eof:        proto.Bool(true),
+	})
+
+	wg.Wait()
+	resp := respRecorder.Result()
+	checkResponse(t, resp, 200, "ok")
+}
+
 func TestHeaderMarshaling(t *testing.T) {
 	h := http.Header{}
 	h.Add("X-Test", "value1")

--- a/src/go/tests/relay/http_test.go
+++ b/src/go/tests/relay/http_test.go
@@ -130,3 +130,67 @@ func TestHttpErrorPropagation(t *testing.T) {
 		})
 	}
 }
+
+func TestHttpChunkedRequestBody(t *testing.T) {
+	expectedRequestBody := []byte("chunk1-chunk2-chunk3")
+	expectedResponseBody := []byte("received: chunk1-chunk2-chunk3")
+
+	env := setupRelay(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "expected POST method", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if !bytes.Equal(body, expectedRequestBody) {
+			http.Error(w, fmt.Sprintf("unexpected body: got %q, want %q", body, expectedRequestBody), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(append([]byte("received: "), body...))
+	}))
+	defer env.Close()
+
+	// Use an io.Pipe to stream chunks in the request body (Transfer-Encoding: chunked).
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		chunks := [][]byte{[]byte("chunk1-"), []byte("chunk2-"), []byte("chunk3")}
+		for _, chunk := range chunks {
+			if _, err := pw.Write(chunk); err != nil {
+				t.Errorf("failed to write chunk to pipe: %v", err)
+				return
+			}
+		}
+	}()
+
+	relayAddress := fmt.Sprint("http://127.0.0.1:", env.RelayPort, "/client/server_name/upload")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, relayAddress, pr)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.ContentLength = -1 // Force Transfer-Encoding: chunked
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request through relay failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(res.Body)
+		t.Fatalf("unexpected status code %d: %s", res.StatusCode, respBody)
+	}
+
+	observedResponse, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if !bytes.Equal(observedResponse, expectedResponseBody) {
+		t.Errorf("received wrong response.\n\tExpected: %s\n\tObserved: %s", expectedResponseBody, observedResponse)
+	}
+}


### PR DESCRIPTION
Add unit and integration tests covering HTTP/1.1 chunked request bodies
(Transfer-Encoding: chunked) through the relay server:
- Unit test in server_test.go using io.Pipe and sync.WaitGroup to verify
  in-memory chunked request buffering and forwarding.
- End-to-end integration test in http_test.go using io.Pipe.
- Update Tested capabilities section in http-relay-server README.md.