### PR TITLE
synk: prioritize RBAC resources in newGvknn sorting

### DIFF
--- a/src/go/pkg/synk/synk.go
+++ b/src/go/pkg/synk/synk.go
@@ -324,8 +324,58 @@ func (s *Synk) applyAll(
 ) (applyResults, error) {
 	results := applyResults{}
 
-	crds, regulars := separateCRDsFromResources(resources)
+	groups := groupResources(resources, isCustomResourceDefinition, isRBACResource)
+	crds := groups[0]
 
+	if err := s.applyCRDs(ctx, rs, opts, results, crds); err != nil {
+		return results, err
+	}
+
+	for _, group := range groups[1:] {
+		s.applyResources(ctx, rs, opts, results, group)
+	}
+	// The overall error we return is a transient error if all resource errors
+	// are transient. If there's at least one permanent failure, retrying
+	// will never make Apply overall successful.
+	allTransient := true
+	numErrors := 0
+	var firstFailure *applyResult
+	for _, r := range results {
+		if r.err != nil {
+			if !IsTransientErr(r.err) {
+				allTransient = false
+			}
+			if firstFailure == nil {
+				firstFailure = r
+			}
+			numErrors++
+		}
+	}
+	if numErrors == 0 {
+		return results, nil
+	}
+	err := fmt.Errorf("%d/%d resources failed to apply", numErrors, len(results))
+	if numErrors == 1 {
+		err = fmt.Errorf("%s: %s: %s", err, resourceKey(firstFailure.resource), firstFailure.err)
+	} else {
+		err = fmt.Errorf("%s, including %s: %s", err, resourceKey(firstFailure.resource), firstFailure.err)
+	}
+	if allTransient {
+		err = transientErr{err}
+	}
+	return results, err
+}
+
+func (s *Synk) applyCRDs(
+	ctx context.Context,
+	rs *apps.ResourceSet,
+	opts *ApplyOptions,
+	results applyResults,
+	crds []*unstructured.Unstructured,
+) error {
+	if len(crds) == 0 {
+		return nil
+	}
 	// Insert CRDs and wait for them to become available.
 	for _, crd := range crds {
 		// CRDs must never be replaced as deleting them will delete
@@ -353,11 +403,20 @@ func (s *Synk) applyAll(
 		backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 60),
 	)
 	if err != nil {
-		return results, fmt.Errorf("wait for CRDs: %w", err)
+		return fmt.Errorf("wait for CRDs: %w", err)
 	}
 	// Reset all discovery and mapping once again.
 	s.resetMapper()
+	return nil
+}
 
+func (s *Synk) applyResources(
+	ctx context.Context,
+	rs *apps.ResourceSet,
+	opts *ApplyOptions,
+	results applyResults,
+	resources []*unstructured.Unstructured,
+) {
 	// Try applying until the errors stay the same between iterations. Put in
 	// an upper bound just in case of flapping errors.
 	prevFailures := 0
@@ -365,7 +424,7 @@ func (s *Synk) applyAll(
 	for i := 0; i < 10; i++ {
 		curFailures := 0
 
-		for _, r := range regulars {
+		for _, r := range resources {
 			// Don't retry resources that were applied successfully
 			// in the first iteration.
 			if i > 0 && !results.failed(r) {
@@ -388,36 +447,6 @@ func (s *Synk) applyAll(
 		}
 		prevFailures = curFailures
 	}
-	// The overall error we return is a transient error if all resource errors
-	// are transient. If there's at least one permanent failure, retrying
-	// will never make Apply overall successful.
-	allTransient := true
-	numErrors := 0
-	var firstFailure *applyResult
-	for _, r := range results {
-		if r.err != nil {
-			if !IsTransientErr(r.err) {
-				allTransient = false
-			}
-			if firstFailure == nil {
-				firstFailure = r
-			}
-			numErrors++
-		}
-	}
-	if numErrors == 0 {
-		return results, nil
-	}
-	err = fmt.Errorf("%d/%d resources failed to apply", numErrors, len(results))
-	if numErrors == 1 {
-		err = fmt.Errorf("%s: %s: %s", err, resourceKey(firstFailure.resource), firstFailure.err)
-	} else {
-		err = fmt.Errorf("%s, including %s: %s", err, resourceKey(firstFailure.resource), firstFailure.err)
-	}
-	if allTransient {
-		err = transientErr{err}
-	}
-	return results, err
 }
 
 func validateNamespace(r *unstructured.Unstructured, optsNs string) error {
@@ -1104,15 +1133,34 @@ func isCustomResourceDefinition(r *unstructured.Unstructured) bool {
 	return strings.HasPrefix(r.GetAPIVersion(), "apiextensions.k8s.io/") && r.GetKind() == "CustomResourceDefinition"
 }
 
-func separateCRDsFromResources(resources []*unstructured.Unstructured) (crds []*unstructured.Unstructured, regulars []*unstructured.Unstructured) {
+func isRBACResource(r *unstructured.Unstructured) bool {
+	gvk := r.GroupVersionKind()
+	return gvk.Group == "rbac.authorization.k8s.io" || (gvk.Group == "" && gvk.Kind == "ServiceAccount")
+}
+
+// groupResources partitions resources into groups according to matching predicates.
+// Resources that don't match any predicate are placed into the final group.
+func groupResources(resources []*unstructured.Unstructured, predicates ...func(*unstructured.Unstructured) bool) [][]*unstructured.Unstructured {
+	groups := make([][]*unstructured.Unstructured, len(predicates)+1)
 	for _, r := range resources {
-		if isCustomResourceDefinition(r) {
-			crds = append(crds, r)
-		} else {
-			regulars = append(regulars, r)
+		matched := false
+		for i, p := range predicates {
+			if p(r) {
+				groups[i] = append(groups[i], r)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			groups[len(predicates)] = append(groups[len(predicates)], r)
 		}
 	}
-	return crds, regulars
+	return groups
+}
+
+func separateCRDsFromResources(resources []*unstructured.Unstructured) (crds []*unstructured.Unstructured, regulars []*unstructured.Unstructured) {
+	groups := groupResources(resources, isCustomResourceDefinition)
+	return groups[0], groups[1]
 }
 
 func filter(in []*unstructured.Unstructured, f func(*unstructured.Unstructured) bool) (out []*unstructured.Unstructured) {

--- a/src/go/pkg/synk/synk_test.go
+++ b/src/go/pkg/synk/synk_test.go
@@ -1027,3 +1027,108 @@ func Test_decodeResourceSetName(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupResources(t *testing.T) {
+	crd := newUnstructured("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", "crd1")
+	role := newUnstructured("rbac.authorization.k8s.io/v1", "Role", "ns1", "role1")
+	roleBinding := newUnstructured("rbac.authorization.k8s.io/v1", "RoleBinding", "ns1", "rb1")
+	clusterRole := newUnstructured("rbac.authorization.k8s.io/v1", "ClusterRole", "", "cr1")
+	clusterRoleBinding := newUnstructured("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "", "crb1")
+	sa := newUnstructured("v1", "ServiceAccount", "ns1", "sa1")
+	deploy := newUnstructured("apps/v1", "Deployment", "ns1", "deploy1")
+	cm := newUnstructured("v1", "ConfigMap", "ns1", "cm1")
+	secret := newUnstructured("v1", "Secret", "ns1", "secret1")
+
+	resources := []*unstructured.Unstructured{deploy, crd, role, cm, sa, clusterRole, secret, roleBinding, clusterRoleBinding}
+
+	groups := groupResources(resources, isCustomResourceDefinition, isRBACResource)
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+
+	wantCRDs := []*unstructured.Unstructured{crd}
+	if !reflect.DeepEqual(groups[0], wantCRDs) {
+		t.Errorf("group 0 (CRDs) mismatch: got %v, want %v", groups[0], wantCRDs)
+	}
+
+	wantRBAC := []*unstructured.Unstructured{role, sa, clusterRole, roleBinding, clusterRoleBinding}
+	if !reflect.DeepEqual(groups[1], wantRBAC) {
+		t.Errorf("group 1 (RBAC) mismatch: got %v, want %v", groups[1], wantRBAC)
+	}
+
+	wantRemaining := []*unstructured.Unstructured{deploy, cm, secret}
+	if !reflect.DeepEqual(groups[2], wantRemaining) {
+		t.Errorf("group 2 (Remaining) mismatch: got %v, want %v", groups[2], wantRemaining)
+	}
+}
+
+func TestIsRBACResource(t *testing.T) {
+	tests := []struct {
+		res  *unstructured.Unstructured
+		want bool
+	}{
+		{newUnstructured("rbac.authorization.k8s.io/v1", "Role", "ns", "r"), true},
+		{newUnstructured("rbac.authorization.k8s.io/v1", "RoleBinding", "ns", "rb"), true},
+		{newUnstructured("rbac.authorization.k8s.io/v1", "ClusterRole", "", "cr"), true},
+		{newUnstructured("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "", "crb"), true},
+		{newUnstructured("rbac.authorization.k8s.io/v1beta1", "Role", "ns", "r"), true},
+		{newUnstructured("v1", "ServiceAccount", "ns", "sa"), true},
+		{newUnstructured("v1", "Pod", "ns", "p"), false},
+		{newUnstructured("v1", "Secret", "ns", "s"), false},
+		{newUnstructured("v1", "ConfigMap", "ns", "cm"), false},
+		{newUnstructured("apps/v1", "Deployment", "ns", "d"), false},
+		{newUnstructured("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", "crd"), false},
+	}
+	for _, tc := range tests {
+		if got := isRBACResource(tc.res); got != tc.want {
+			t.Errorf("isRBACResource(%s/%s) = %v, want %v", tc.res.GetAPIVersion(), tc.res.GetKind(), got, tc.want)
+		}
+	}
+}
+
+func TestSynk_applyAllGroupOrder(t *testing.T) {
+	f := newFixture(t)
+
+	deploy := newUnstructured("apps/v1", "Deployment", "foo", "dp1")
+	role := newUnstructured("rbac.authorization.k8s.io/v1", "Role", "foo", "role1")
+	sa := newUnstructured("v1", "ServiceAccount", "foo", "sa1")
+
+	set := &apps.ResourceSet{}
+	set.Name = "test.v1"
+	set.UID = "deadbeef"
+
+	// Pass deploy first; applyAll should still apply RBAC resources (role, sa) before remaining (deploy).
+	results, err := f.newSynk().applyAll(t.Context(), set, &ApplyOptions{name: "test"},
+		deploy.DeepCopy(),
+		role.DeepCopy(),
+		sa.DeepCopy(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         "apps.cloudrobotics.com/v1alpha1",
+		Kind:               "ResourceSet",
+		Name:               set.Name,
+		UID:                set.UID,
+		BlockOwnerDeletion: new(true),
+	}
+	for _, res := range []*unstructured.Unstructured{role, sa, deploy} {
+		res.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+		setAppliedAnnotation(res)
+	}
+
+	roleGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+	saGVR := schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}
+
+	f.expectActions(
+		k8stest.NewCreateAction(roleGVR, "foo", role),
+		k8stest.NewCreateAction(saGVR, "foo", sa),
+		k8stest.NewCreateAction(gvrs["deployments"], "foo", deploy),
+	)
+	f.verifyWriteActions()
+}


### PR DESCRIPTION
Assign higher sort priorities to ClusterRole, Role, ClusterRoleBinding,
and RoleBinding in newGvknn so that RBAC rules are applied after
Namespaces, ServiceAccounts, and Secrets, and before remaining
workloads

TAG=agy
CONV=d1d5e845-2765-44b2-ab59-1fa15cb5878d